### PR TITLE
fix Aldabra index.theme

### DIFF
--- a/desktop-themes/Aldabra/index.theme.in
+++ b/desktop-themes/Aldabra/index.theme.in
@@ -4,24 +4,6 @@ Type=X-GNOME-Metatheme
 Encoding=UTF-8
 GtkTheme=Aldabra
 MetacityTheme=Aldabra
-CursorTheme=mate
-CursorSize=24
-NotificationTheme=slider
-ApplicationFont=Cantarell 11
-DocumentFont=Sans 11
-DesktopFont=Cantarell 11
-WindowTitleFont=Cantarell Bold 11
-FixedWidthFont=Monospace 9
-
-[Desktop Entry]
-Name=Aldabra
-Type=X-MATE-Metatheme
-Comment=
-
-[X-MATE-Metatheme]
-Name=Aldabra
-GtkTheme=Aldabra
-MarcoTheme=Aldabra
 IconTheme=mate
 CursorTheme=mate
 CursorSize=24
@@ -32,3 +14,9 @@ DesktopFont=Cantarell 11
 WindowTitleFont=Cantarell Bold 11
 FixedWidthFont=Monospace 9
 BackgroundImage=@BACKGROUND_DIR@/stripes.jpg
+
+[Desktop Entry]
+Name=Aldabra
+Type=X-MATE-Metatheme
+Comment=gtk2/3 adwaita theme
+


### PR DESCRIPTION
this wiil display the Aldabra theme in the main mate-appearance-properties window
