### PR TITLE
a liitle caja improvment in gtkrc files and remove of some deprecations in gtk-3 themes

### DIFF
--- a/desktop-themes/Aldabra/gtk-2.0/gtkrc
+++ b/desktop-themes/Aldabra/gtk-2.0/gtkrc
@@ -941,3 +941,11 @@ widget "vim-main-window.*Scrollbar*"	style "vim-scrollbar"
 
 # For Eclipse (swt) toolbars.
 widget "*swt*toolbar*"			style "default"
+
+# caja improvement
+style "aldabra-caja-location"
+{
+	bg[NORMAL]  = mix (0.60, shade (1.05, @bg_color), @bg_color)
+}
+
+widget "*.caja-extra-view-widget" style : highest "aldabra-caja-location"

--- a/desktop-themes/Aldabra/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/Aldabra/gtk-3.0/gtk-widgets.css
@@ -1,6 +1,6 @@
 * {
     engine: adwaita;
-    padding: 1;
+    padding: 1px;
 
     /* Style properties */
     -GtkToolButton-icon-spacing: 4;
@@ -43,7 +43,7 @@
     /* Style */
     background-color: @theme_bg_color;
     color: @theme_fg_color;
-    border-radius: 3;
+    border-radius: 3px;
 
     -GtkWidget-focus-padding: 2;
     -GtkWidget-focus-line-width: 1;
@@ -88,7 +88,7 @@
 }
 
 .tooltip {
-    padding: 4 4;
+    padding: 4px 4px;
     border-style: none;
     background-color: @theme_tooltip_bg_color;
     color: @theme_tooltip_fg_color;
@@ -117,15 +117,15 @@
     background-color: @theme_base_color;
     background-image: none;
 
-    border-radius: 2;
-    border-width: 1;
+    border-radius: 2px;
+    border-width: 1px;
     border-style: solid;
     -adwaita-border-gradient: -gtk-gradient (linear,
                                              left top, left bottom,
                                              from (shade (@internal_element_color, 1.14)),
                                              to (shade (@internal_element_color, 1.37)));
 
-    padding: 3;
+    padding: 3px;
 }
 
 .entry:focused {
@@ -144,8 +144,8 @@
     background-color: @theme_selected_bg_color;
     color: @theme_selected_fg_color;
 
-    border-width: 1;
-    border-radius: 1;
+    border-width: 1px;
+    border-radius: 1px;
     border-color: @progressbar_border;
 }
 
@@ -158,12 +158,12 @@
 .spinbutton.button:active {
     background-image: none;
     background-color: @theme_base_color;
-    border-width: 1;
+    border-width: 1px;
     border-style: none;
 }
 
 .spinbutton {
-    padding: 3 2;
+    padding: 3px 2px;
 }
 
 /****************
@@ -175,7 +175,7 @@ GtkProgressBar.progressbar {
                                      from (@progressbar_background_a),
                                      to (@progressbar_background_b));
 
-    border-radius: 3;
+    border-radius: 3px;
     border-style: solid;
     border-color: @progressbar_border;
 }
@@ -186,9 +186,9 @@ GtkProgressBar.trough {
                                      from (@trough_bg_color_a),
                                      to (@trough_bg_color_b));
 
-    border-width: 1;
+    border-width: 1px;
     border-style: solid;
-    border-radius: 3;
+    border-radius: 3px;
     border-color: shade (@inactive_frame_color, 0.925);
 }
 
@@ -202,8 +202,8 @@ GtkScale {
 }
 
 GtkScale.slider {
-    border-width: 1;
-    border-radius: 3;
+    border-width: 1px;
+    border-radius: 3px;
 
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
@@ -250,8 +250,8 @@ GtkScale.scale-has-marks-above.slider.vertical {
 }
 
 GtkScale.trough {
-    border-width: 1;
-    border-radius: 2;
+    border-width: 1px;
+    border-radius: 2px;
     border-style: solid;
     border-color: @internal_element_color;
 }
@@ -282,8 +282,8 @@ GtkScale.progressbar {
                                      to (@scale_fill_b));
 
     border-color: #1864b2;
-    border-width: 1;
-    border-radius: 3;
+    border-width: 1px;
+    border-radius: 3px;
     border-style: solid;
 }
 
@@ -293,7 +293,7 @@ GtkScale.mark {
 
 GtkFrame,
 GtkCalendar {
-    padding: 2;
+    padding: 2px;
 }
 
 .frame {
@@ -307,11 +307,11 @@ GtkCalendar {
  * tabs          *
  *****************/
 .notebook {
-    padding: 2;
+    padding: 2px;
 
     border-color: @notebook_border;
     border-style: solid;
-    border-width: 1;
+    border-width: 1px;
     border-radius: 0;
 
     background-color: @theme_base_color;
@@ -321,7 +321,7 @@ GtkCalendar {
 }
 
 .notebook tab {
-    padding: 3 8 0;
+    padding: 3px 8px 0px;
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (@notebook_tab_gradient_a),
@@ -331,7 +331,7 @@ GtkCalendar {
 }
 
 .notebook tab:active {
-    border-width: 1;
+    border-width: 1px;
 
     -adwaita-border-gradient: -gtk-gradient (linear,
                                              left top, left bottom,
@@ -356,7 +356,7 @@ GtkCalendar {
  **************/
 
 GtkComboBox {
-    padding: 1 2;
+    padding: 1px 2px;
 
     -GtkWidget-focus-padding: 0;
     -GtkWidget-focus-line-width: 0;
@@ -367,7 +367,7 @@ GtkComboBox {
 
 GtkComboBox .button {
     color: @internal_element_color;
-    padding: 1;
+    padding: 1px;
 }
 
 GtkComboBox .button:prelight {
@@ -403,8 +403,8 @@ GtkComboBox .button:prelight {
     background-image: none;
     background-color: @theme_base_color;
     border-color: @button_border;
-    border-radius: 3;
-    border-width: 1;
+    border-radius: 3px;
+    border-width: 1px;
 }
 
 .scrollbar.slider:prelight {
@@ -452,7 +452,7 @@ GtkComboBox .button:prelight {
  * Buttons *
  ***********/
 .button {
-    padding: 1 4;
+    padding: 1px 4px;
 
     -adwaita-focus-fill-color: alpha (@theme_base_color, 0.35);
     -adwaita-focus-border-gradient: -gtk-gradient (linear,
@@ -470,8 +470,8 @@ GtkComboBox .button:prelight {
     -GtkButton-default-border: 0;
     -GtkButton-inner-border: 0;
 
-    border-radius: 2;
-    border-width: 1;
+    border-radius: 2px;
+    border-width: 1px;
     border-color: @button_border;
     border-style: solid;
 
@@ -508,7 +508,7 @@ GtkComboBox .button:prelight {
 }
 
 .button.default {
-    border-width: 2;
+    border-width: 2px;
     border-color: shade (@button_border, 1.10);
 }
 
@@ -525,7 +525,7 @@ GtkComboBox .button:prelight {
 				     to (shade (@theme_bg_color, 0.99)));
     border-width: 0;
     border-style: none;
-    padding: 4;
+    padding: 4px;
     color: @theme_text_color;
 
     -GtkWidget-window-dragging: true;
@@ -539,23 +539,23 @@ GtkComboBox .button:prelight {
     color: @theme_text_color;
 
     border-style: solid;
-    border-radius: 3;
-    border-width: 1;
+    border-radius: 3px;
+    border-width: 1px;
     border-color: @inactive_frame_color;
 }
 
 .menubar.menuitem {
-    border-width: 1;
+    border-width: 1px;
     border-style: none;
 }
 
 .menu {
-    padding: 2;
+    padding: 2px;
 
     background-color: @theme_base_color;
 
     border-style: solid;
-    border-width: 1;
+    border-width: 1px;
     border-radius: 0;
     border-color: @inactive_frame_color;
 
@@ -580,8 +580,8 @@ GtkComboBox .button:prelight {
     background-color: @theme_selected_bg_color;
     color: @theme_selected_fg_color;
     border-style: solid;
-    border-width: 1;
-    border-radius: 1;
+    border-width: 1px;
+    border-radius: 1px;
     border-color: darker (@theme_selected_bg_color);
 }
 
@@ -681,9 +681,9 @@ GtkComboBox .button:prelight {
 .toolbar {
     border-style: solid;
     border-color: darker (@theme_bg_color);
-    border-width: 1;
+    border-width: 1px;
     border-radius: 0;
-    padding: 1;
+    padding: 1px;
 }
 
 .toolbar:insensitive {
@@ -710,7 +710,7 @@ GtkComboBox .button:prelight {
     border-radius: 0;
     border-style: none;
 
-    padding: 2;
+    padding: 2px;
 
     -GtkWidget-window-dragging: true;
     -GtkToolbar-button-relief: normal;
@@ -721,14 +721,14 @@ GtkComboBox .button:prelight {
     background-color: shade (@theme_bg_color, 0.97);
 
     border-style: solid;
-    border-width: 1;
+    border-width: 1px;
     border-color: shade (@theme_bg_color, 0.91);
 }
 
 /* primary toolbar buttons */
 .primary-toolbar.toolbar.button {
     border-style: none;
-    border-width: 1;
+    border-width: 1px;
     background-image: none;
     background-color: alpha (@theme_base_color, 0.0);
 
@@ -758,7 +758,7 @@ GtkComboBox .button:prelight {
 
 .primary-toolbar.toolbar.button:active {
     border-style: solid;
-    border-radius: 4;
+    border-radius: 4px;
     -adwaita-border-gradient: -gtk-gradient (linear,
                                              left top, left bottom,
                                              from (@toolbar_active_button_color),
@@ -774,7 +774,7 @@ GtkComboBox .button:prelight {
 
 .primary-toolbar.toolbar.button:active:prelight {
     border-style: solid;
-    border-radius: 3;
+    border-radius: 3px;
     background-image: -gtk-gradient (linear,
 				     left top, left bottom,
 				     from (alpha (shade (@toolbar_gradient_base, 0.76), 0.7)),
@@ -785,7 +785,7 @@ GtkComboBox .button:prelight {
 
 .primary-toolbar.toolbar.button:active:insensitive {
     border-style: solid;
-    border-radius: 3;
+    border-radius: 3px;
     border-color: @inactive_frame_color;
     -adwaita-border-gradient: none;
 }
@@ -795,15 +795,15 @@ GtkComboBox .button:prelight {
     -GtkWidget-separator-width: 1;
 
     border-style: solid;
-    border-width: 1;
+    border-width: 1px;
     border-color: shade (@theme_bg_color, 0.56);
 }
 
 /* primary toolbar raised buttons */
 .primary-toolbar.toolbar.raised.button,
 .primary-toolbar.toolbar.raised.button:insensitive {
-    border-radius: 2;
-    border-width: 1;
+    border-radius: 2px;
+    border-width: 1px;
     border-color: @button_border;
     border-style: solid;
 
@@ -821,7 +821,7 @@ GtkComboBox .button:prelight {
 				     left top, left bottom,
 				     from (@button_hover_gradient_color_a),
 				     to (@button_hover_gradient_color_b));
-    border-width: 1;
+    border-width: 1px;
     border-style: solid;
 }
 
@@ -834,7 +834,7 @@ GtkComboBox .button:prelight {
     background-color: @theme_base_color;
 
     border-color: @highlighted_border;
-    border-width: 1;
+    border-width: 1px;
     border-style: solid;
 }
 
@@ -847,7 +847,7 @@ GtkComboBox .button:prelight {
                                      to (@trough_bg_color_b));
 
     border-width: 0;
-    border-radius: 2;
+    border-radius: 2px;
     border-color: shade (@inactive_frame_color, 0.925);
 }
 
@@ -856,8 +856,8 @@ GtkComboBox .button:prelight {
  *******************/
 
 .inline-toolbar.toolbar {
-    border-width: 1;
-    border-radius: 3;
+    border-width: 1px;
+    border-radius: 3px;
     border-style: solid;
 
     background-image: -gtk-gradient (linear,
@@ -881,8 +881,8 @@ GtkSwitch {
 
 GtkSwitch.trough {
     color: @internal_element_color;
-    border-radius: 1;
-    border-width: 1;
+    border-radius: 1px;
+    border-width: 1px;
     border-style: solid;
     border-color: shade (@frame_color, 1.22);
     background-image: -gtk-gradient (linear,
@@ -911,11 +911,11 @@ GtkSwitch.trough:insensitive {
 }
 
 GtkSwitch.slider {
-    border-width: 1;
-    border-radius: 1;
+    border-width: 1px;
+    border-radius: 1px;
     border-color: shade (@frame_color, 1.31);
     border-style: solid;
-    padding: 2;
+    padding: 2px;
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (@switch_slider_color),
@@ -939,7 +939,7 @@ GtkSwitch.slider:insensitive {
 }
 
 GtkStatusbar {
-    padding: 5;
+    padding: 5px;
     color: @theme_fg_color;
     -GtkStatusbar-shadow-type: none;
 }
@@ -947,20 +947,20 @@ GtkStatusbar {
 GtkScrolledWindow.frame {
     border-style: solid;
     border-color: darker (@theme_bg_color);
-    border-width: 1;
-    border-radius: 3;
+    border-width: 1px;
+    border-radius: 3px;
 }
 
 GtkViewport,
 GtkIconView {
-    border-radius: 3;
+    border-radius: 3px;
     padding: 0;
 }
 
 GtkIconView.view.cell:selected,
 GtkIconView.view.cell:selected:focused {
     background-color: @theme_selected_bg_color;
-    border-radius: 4;
+    border-radius: 4px;
 
     /* FIXME: this probably needs to be better;
      * see https://bugzilla.gnome.org/show_bug.cgi?id=644157
@@ -974,7 +974,7 @@ GtkIconView.view.cell:selected:focused {
     background-color: @theme_base_color;
     color: @theme_fg_color;
     border-radius: 0;
-    border-width: 3;
+    border-width: 3px;
 }
 
 GtkTreeView {
@@ -992,7 +992,7 @@ GtkTreeView.separator {
 }
 
 column-header {
-    padding: 1 2;
+    padding: 1px 2px;
 }
 
 column-header .button {
@@ -1031,7 +1031,7 @@ row:selected {
 
 .cell {
     color: @theme_text_color;
-    padding: 2;
+    padding: 2px;
     border-width: 0;
 }
 
@@ -1069,10 +1069,10 @@ row:selected {
 
 /* Calendars */
 GtkCalendar.view {
-    border-radius: 3;
+    border-radius: 3px;
     border-style: solid;
-    border-width: 1;
-    padding: 2;
+    border-width: 1px;
+    padding: 2px;
 }
 
 GtkCalendar.header {
@@ -1179,7 +1179,7 @@ PanelApplet GtkToggleButton {
     background-color: @os_chrome_bg_color;
     background-image: none;
     border-color: @os_chrome_bg_color;
-    border-width: 1;
+    border-width: 1px;
     color: @os_chrome_fg_color;
 }
 
@@ -1188,7 +1188,7 @@ PanelApplet GtkToggleButton:active {
     background-color: @os_chrome_selected_bg_color;
     background-image: none;
     border-color: lighter (@os_chrome_selected_bg_color);
-    border-width: 1;
+    border-width: 1px;
     color: @os_chrome_selected_fg_color;
 }
 
@@ -1196,7 +1196,7 @@ PanelApplet GtkToggleButton:prelight {
     background-color: @os_chrome_bg_color;
     background-image: none;
     border-color: @os_chrome_bg_color;
-    border-width: 1;
+    border-width: 1px;
     color: @os_chrome_selected_fg_color;
 }
 

--- a/desktop-themes/Shiny/index.theme.in
+++ b/desktop-themes/Shiny/index.theme.in
@@ -1,7 +1,44 @@
+[Desktop Entry]
+Name=Shiny
+Type=X-MATE-Metatheme
+Comment=The Clearlooks "Shiny" Theme
+
 [X-GNOME-Metatheme]
-_Name=Shiny
+Name=Shiny
+Name[ar]=لامع
+Name[ca]=Brillant
+Name[de]=Glänzend
+Name[eo]=Brila
+Name[es]=Brillante
+Name[eu]=Distiratsua
+Name[fr]=Brillant
+Name[he]=נוצץ
+Name[it]=Shiny
+Name[ms]=Shiny
+Name[nl]=Shiny
+Name[pl]=Lśniący
+Name[pt]=Shiny
+Name[pt_BR]=Brilhante
+Name[ru]=Блестящая
+Name[sl]=Sijoče
+Name[tr]=Parlak
 Type=X-GNOME-Metatheme
-_Comment=A Shiny looking theme
+Comment=A Shiny looking theme
+Comment[ar]=سمة ذات مظهر لامع
+Comment[ca]=Un tema que brilla
+Comment[de]=Ein glänzendes Thema
+Comment[es]=Un tema de apariencia brillante 
+Comment[eu]=Itxura distiratsuko gai bat
+Comment[fr]=Thème avec une apparence brillante
+Comment[he]=ערכת עיצוב נוצצת
+Comment[it]=Un tema dall'aspetto brillante
+Comment[ms]=Tema berkilau
+Comment[nl]=Een glanzend thema
+Comment[pt]=Um tema brilhante
+Comment[pt_BR]=Tema um Brilhante olhar
+Comment[ru]=Блестяще выглядящая тема
+Comment[sl]=Sijoč izgled teme
+Comment[tr]=Parlak görünümlü bir tema
 Encoding=UTF-8
 GtkTheme=Shiny
 MetacityTheme=Shiny

--- a/gtk-themes/AlaDelta/gtkrc
+++ b/gtk-themes/AlaDelta/gtkrc
@@ -169,4 +169,11 @@ widget_class "*<GtkListItem>*" style "glider-fg-is-text-color-workaround"
 # Only match GtkCList and not the parent widgets, because that would also change the headers.
 widget_class "*<GtkCList>" style "glider-fg-is-text-color-workaround"
 
+#caja fix
 
+style "AlaDelta-caja-location"
+{
+	bg[NORMAL]  = mix (0.60, shade (1.05, @bg_color), @bg_color)
+}
+
+widget "*.caja-extra-view-widget" style : highest "AlaDelta-caja-location"

--- a/gtk-themes/Shiny/gtkrc
+++ b/gtk-themes/Shiny/gtkrc
@@ -263,7 +263,7 @@ style "tooltips" {
 
 style "caja_location" {
 
-	bg[NORMAL]        = mix (0.60, shade (1.05, @bg_color), @selected_bg_color)
+	bg[NORMAL]        = mix (0.60, shade (1.05, @bg_color), @bg_color)
 }
 
 # Wrokaroudn style for places where the text color is used instead of the fg color.

--- a/gtk-themes/Simply/gtkrc
+++ b/gtk-themes/Simply/gtkrc
@@ -76,3 +76,11 @@ class "GtkCheckButton" style "togglebuttons"
 class "GtkRadioButton" style "togglebuttons"
 class "GtkProgressBar" style "progressbar"
 class "GtkEntry" style "entry"
+
+# caja improvment
+style "simply-caja-location"
+{
+	bg[NORMAL]  = mix (0.60, shade (1.05, "#e2e2de"), "#e2e2de")
+}
+
+widget "*.caja-extra-view-widget" style : highest "simply-caja-location"

--- a/gtk-themes/TraditionalOkClassic/gtk-2.0/gtkrc
+++ b/gtk-themes/TraditionalOkClassic/gtk-2.0/gtkrc
@@ -400,3 +400,12 @@ widget_class "*<EelEditableLabel>" style "fg_is_text_color_workaround"
 
 # See the documentation of the style.
 widget_class "EShellWindow.GtkVBox.MateComponentDock.MateComponentDockBand.MateComponentDockItem*" style "evo_new_button_workaround"
+
+# caja improvement
+
+style "TraditionalOkClassic-caja-location"
+{
+	bg[NORMAL]  = mix (0.60, shade (1.05, @bg_color), @bg_color)
+}
+
+widget "*.caja-extra-view-widget" style : highest "TraditionalOkClassic-caja-location"

--- a/gtk-themes/TraditionalOkClassic/gtk-3.0/gtk-widgets.css
+++ b/gtk-themes/TraditionalOkClassic/gtk-3.0/gtk-widgets.css
@@ -1,6 +1,6 @@
 * {
     engine: adwaita;
-    padding: 1;
+    padding: 1px;
 
     /* Style properties */
     -GtkToolButton-icon-spacing: 4;
@@ -82,8 +82,8 @@ GtkWindow {
 }
 
 .tooltip {
-    padding: 4 4;
-    border-width: 1;
+    padding: 4px 4px;
+    border-width: 1px;
     border-style: solid;
     border-color: #BABA45;
     background-color: #F5F5B5;
@@ -100,8 +100,8 @@ GtkWindow {
 
     border-color: #7fa5d5;
     border-style: solid;
-    border-width: 1;
-    border-radius: 2;
+    border-width: 1px;
+    border-radius: 2px;
 }
 
 .pane-separator {
@@ -114,7 +114,7 @@ GtkWindow {
 }
 
 GtkStatusbar {
-    padding: 5;
+    padding: 5px;
     color: @theme_fg_color;
     -GtkStatusbar-shadow-type: none;
 }
@@ -126,8 +126,8 @@ GtkStatusbar {
     background-color: @theme_base_color;
 
     border-style: none;
-    border-width: 1;
-    border-radius: 3;
+    border-width: 1px;
+    border-radius: 3px;
 
     /* we use inner-border instead of padding because padding
      * also applies to the progressbar.
@@ -166,8 +166,8 @@ GtkComboBox.combobox-entry .button:prelight,
     background-color: #7fa5d5;
     color: @theme_selected_fg_color;
 
-    border-width: 1;
-    border-radius: 3;
+    border-width: 1px;
+    border-radius: 3px;
     /* border-image defined in -assets variant */
 
     -adwaita-progressbar-pattern: none;
@@ -210,7 +210,7 @@ GtkComboBox.combobox-entry .button:prelight,
 }
 
 .spinbutton.entry {
-    padding: 0 6 0 1;
+    padding: 0 6px 0 1px;
 }
 
 /****************
@@ -231,8 +231,8 @@ GtkComboBox.combobox-entry .button:prelight,
 				     color-stop (0.50, #92B4DF),
 				     to (#84AAD8));
 
-    border-radius: 3;
-    border-width: 1;
+    border-radius: 3px;
+    border-width: 1px;
     border-style: none;
     /* border-image defined in the -assets variant */
 
@@ -278,9 +278,9 @@ GtkProgressBar,
 				     color-stop (0, #CECBC9),
 				     color-stop (0.5, #D6D4D2));
 
-    border-width: 1;
+    border-width: 1px;
     border-style: solid;
-    border-radius: 3;
+    border-radius: 3px;
     border-color: #8C8A87;
 }
 
@@ -321,8 +321,8 @@ GtkScale.slider:insensitive {
 }
 
 GtkScale.trough {
-    border-width: 1;
-    border-radius: 2;
+    border-width: 1px;
+    border-radius: 2px;
     border-style: none;
 
     background-color: @scale_fill;
@@ -342,8 +342,8 @@ GtkScale.trough:insensitive {
 GtkScale.progressbar {
     background-color: @scale_progress_fill;
 
-    border-width: 1;
-    border-radius: 2;
+    border-width: 1px;
+    border-radius: 2px;
     border-style: none;
     /* border-image defined in the -assets variants */
 
@@ -358,7 +358,7 @@ GtkScale.mark {
  * Frames *
  **********/
 .frame {
-    padding: 2;
+    padding: 2px;
     border-width: 0;
 }
 
@@ -366,8 +366,8 @@ GtkScale.mark {
 GtkScrolledWindow.frame {
     border-style: solid;
     border-color: darker (@theme_bg_color);
-    border-width: 1;
-    border-radius: 2;
+    border-width: 1px;
+    border-radius: 2px;
 
     padding: 0;
 }
@@ -376,7 +376,7 @@ GtkScrolledWindow.frame {
  * Buttons *
  ***********/
 .button {
-    padding: 1 4;
+    padding: 1px 4px;
 
     -adwaita-focus-fill-color: alpha (@theme_base_color, 0.35);
     -adwaita-focus-border-gradient: -gtk-gradient (linear,
@@ -394,8 +394,8 @@ GtkScrolledWindow.frame {
     -GtkButton-default-border: 0;
     -GtkButton-inner-border: 0;
 
-    border-radius: 3;
-    border-width: 1;
+    border-radius: 3px;
+    border-width: 1px;
     border-style: none;
     /* border-image in -assets variant */
 
@@ -449,7 +449,7 @@ GtkScrolledWindow.frame {
 }
 
 .button.default {
-    border-width: 1;
+    border-width: 1px;
 }
 
 /*****************
@@ -457,11 +457,11 @@ GtkScrolledWindow.frame {
  * tabs          *
  *****************/
 .notebook {
-    padding: 2;
+    padding: 2px;
 
     border-color: @notebook_border;
     border-style: solid;
-    border-width: 1;
+    border-width: 1px;
 
     background-color: @theme_base_color;
 
@@ -470,7 +470,7 @@ GtkScrolledWindow.frame {
 }
 
 .notebook tab {
-    padding: 2 8;
+    padding: 2px 8px;
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (@notebook_tab_gradient_a),
@@ -480,7 +480,7 @@ GtkScrolledWindow.frame {
 }
 
 .notebook tab:active {
-    border-width: 1;
+    border-width: 1px;
 
     -adwaita-border-gradient: -gtk-gradient (linear,
                                              left top, left bottom,
@@ -519,14 +519,14 @@ GtkComboBox {
 }
 
 GtkComboBox .entry {
-    border-width: 1 0 1 1;
-    border-radius: 3 0 0 3;
+    border-width: 1px 0 1px 1px;
+    border-radius: 3px 0 0 3px;
     border-image-width: 2 0 2 2;
 }
 
 GtkComboBox .button {
     color: @internal_element_color;
-    padding: 2 3 2 6;
+    padding: 2px 3px 2px 6px;
 }
 
 GtkComboBox .button *:prelight {
@@ -535,10 +535,10 @@ GtkComboBox .button *:prelight {
 
 .primary-toolbar GtkComboBox.combobox-entry .button,
 GtkComboBox.combobox-entry .button {
-    border-width: 1 1 1 0;
-    border-radius: 0 3 3 0;
+    border-width: 1px 1px 1px 0;
+    border-radius: 0 3px 3px 0;
 
-    padding: 2 3;
+    padding: 2px 3px;
     -adwaita-focus-fill-color: alpha (@theme_base_color, 0.0);
 }
 
@@ -560,7 +560,7 @@ GtkComboBox.combobox-entry .button:hover:active {
                                     color-stop(0.85, shade(@entry_background_c, 0.95)),
                                     to(shade(@entry_background_d, 0.95)));
 
-    box-shadow: 1 0 inset shade(@frame_color, 1.50);
+    box-shadow: inset 1px 0 shade(@frame_color, 1.50);
 }
 
 /**************
@@ -582,7 +582,7 @@ GtkComboBox.combobox-entry .button:hover:active {
 
 .scrollbar.trough {
     background-color: shade (@theme_bg_color, 0.882);
-    border-width: 1;
+    border-width: 1px;
     border-color: #A19D9A;
     border-radius: 0;
 }
@@ -607,7 +607,7 @@ GtkComboBox.combobox-entry .button:hover:active {
     background-color: @theme_base_color;
     border-color: #5E7EA5;
     border-radius: 0;
-    border-width: 1;
+    border-width: 1px;
 
     border-image: none;
 }
@@ -635,8 +635,8 @@ GtkComboBox.combobox-entry .button:hover:active {
 .scrollbar.button {
     background-color: @theme_base_color;
     border-color: #868482;
-    border-radius: 3;
-    border-width: 1;
+    border-radius: 3px;
+    border-width: 1px;
     color: #000000;
 
     border-image: none;
@@ -773,10 +773,10 @@ GtkTreeMenu.menu.button:insensitive {
 }
 
 GtkTreeMenu .menuitem {
-    padding: 2;
+    padding: 2px;
 
     border-style: solid;
-    border-width: 1 0;
+    border-width: 1px 0;
     border-color: @menu_combobox_border;
 }
 
@@ -796,7 +796,7 @@ GtkTreeMenu .menuitem * {
     border-color: @theme_bg_color;
     border-width: 0;
     border-style: none;
-    padding: 4;
+    padding: 4px;
 
     -GtkWidget-window-dragging: true;
     -GtkMenuBar-internal-padding: 0;
@@ -811,7 +811,7 @@ GtkTreeMenu .menuitem * {
 .menubar .menuitem {
     border-width: 0;
     border-style: none;
-    padding: 3 5;
+    padding: 3px 5px;
 }
 
 /* remove the image from the prelight areas */
@@ -824,7 +824,7 @@ GtkTreeMenu .menuitem * {
 				     color-stop (0.50, #91B3DE),
 				     to (#84AAD8));
 
-    border-radius: 5 5 0 0;
+    border-radius: 5px 5px 0 0;
 }
 
 .menubar .menuitem *:prelight {
@@ -834,7 +834,7 @@ GtkTreeMenu .menuitem * {
 .menuitem {
     -GtkMenuItem-arrow-scaling: 0.4;
     -adwaita-menuitem-arrow-color: @menu_controls_color;
-    padding: 4;
+    padding: 4px;
 }
 
 .menuitem:active,
@@ -849,7 +849,7 @@ GtkTreeMenu .menuitem * {
 				     color-stop (0.50, #91B3DE),
 				     to (#84AAD8));
     border-color: #4B6E99;
-    border-width: 1;
+    border-width: 1px;
     border-style: solid;
     color: @theme_selected_fg_color;
 }
@@ -873,7 +873,7 @@ GtkTreeMenu .menuitem * {
 .menuitem.separator {
     border-color: @menu_separator;
     border-style: solid;
-    border-width: 1;
+    border-width: 1px;
 
     -GtkSeparatorMenuItem-horizontal-padding: 0;
     -GtkWidget-separator-height: 1;
@@ -922,12 +922,12 @@ GtkTreeMenu .menuitem * {
 .toolbar {
     border-style: solid;
     border-color: darker (@theme_bg_color);
-    border-width: 1 0 1 0;
-    padding: 4;
+    border-width: 1px 0 1px 0;
+    padding: 4px;
 }
 
 .toolbar .button {
-    padding: 2;
+    padding: 2px;
 }
 
 .toolbar:insensitive {
@@ -951,7 +951,7 @@ GtkTreeMenu .menuitem * {
 				     color-stop (0.50, @toolbar_gradient_step2),
 				     to (@toolbar_gradient_final));
 
-    border-width: 1 0 1 0;
+    border-width: 1px 0 1px 0;
     border-radius: 0;
     border-style: solid;
     border-top-color: @toolbar_border_top;
@@ -976,7 +976,7 @@ GtkTreeMenu .menuitem * {
 .primary-toolbar.toolbar .button {
     border-style: none;
     border-image: none;
-    border-radius: 4;
+    border-radius: 4px;
 
     background-image: none;
     background-color: alpha (@theme_base_color, 0.0);
@@ -1006,7 +1006,7 @@ GtkTreeMenu .menuitem * {
 .primary-toolbar .toolbar .button:hover,
 .primary-toolbar.toolbar .button:hover {
     border-style: solid;
-    border-width: 1;
+    border-width: 1px;
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (@button_hover_gradient_color_a),
@@ -1018,7 +1018,7 @@ GtkTreeMenu .menuitem * {
 .primary-toolbar .toolbar .button:active,
 .primary-toolbar.toolbar .button:active {
     border-style: solid;
-    border-width: 1;
+    border-width: 1px;
     /* border-image defined in the -assets variant */
 
     background-image: -gtk-gradient (linear,
@@ -1067,7 +1067,7 @@ GtkTreeMenu .menuitem * {
     -GtkWidget-separator-width: 1;
 
     border-style: solid;
-    border-width: 1;
+    border-width: 1px;
     border-color: shade (@theme_bg_color, 0.56);
 }
 
@@ -1076,9 +1076,9 @@ GtkTreeMenu .menuitem * {
 .primary-toolbar.toolbar .raised .button,
 .primary-toolbar .toolbar .raised.button,
 .primary-toolbar.toolbar .raised.button {
-    border-width: 1;
+    border-width: 1px;
     border-style: none;
-    padding: 3;
+    padding: 3px;
 
     background-image: -gtk-gradient (linear,
 				     left top, left bottom,
@@ -1125,7 +1125,7 @@ GtkTreeMenu .menuitem * {
 .primary-toolbar .toolbar .raised.button:insensitive:active,
 .primary-toolbar.toolbar .raised.button:insensitive:active {
     border-style: solid;
-    border-width: 1;
+    border-width: 1px;
 }
 
 /* setup shadows */
@@ -1133,8 +1133,8 @@ GtkTreeMenu .menuitem * {
 .primary-toolbar .toolbar .raised .button,
 .primary-toolbar.toolbar .raised.button,
 .primary-toolbar .toolbar .raised.button {
-    icon-shadow: 0 1 @theme_base_color;
-    text-shadow: 0 1 @theme_base_color;
+    icon-shadow: 0 1px @theme_base_color;
+    text-shadow: 0 1px @theme_base_color;
 }
 
 .primary-toolbar.toolbar .raised .button *:active,
@@ -1154,17 +1154,17 @@ GtkTreeMenu .menuitem * {
 .primary-toolbar.toolbar .raised.linked .button:active,
 .primary-toolbar.toolbar .raised.linked.button,
 .primary-toolbar.toolbar .raised.linked.button:active {
-    border-width: 1 0;
+    border-width: 1px 0;
     border-radius: 0;
 
-    box-shadow: inset 1 0 @button_raised_linked_shadow;
+    box-shadow: inset 1px 0 @button_raised_linked_shadow;
 }
 
 .primary-toolbar.toolbar .raised.linked.button:nth-child(first),
 .primary-toolbar.toolbar .raised.linked.button:active:nth-child(first),
 .primary-toolbar.toolbar .raised.linked:nth-child(first) .button,
 .primary-toolbar.toolbar .raised.linked:nth-child(first) .button:active {
-    border-width: 1 0 1 1;
+    border-width: 1px 0 1px 1px;
 
     box-shadow: none;
 }
@@ -1173,7 +1173,7 @@ GtkTreeMenu .menuitem * {
 .primary-toolbar.toolbar .raised.linked.button:active:nth-child(last),
 .primary-toolbar.toolbar .raised.linked:nth-child(last) .button,
 .primary-toolbar.toolbar .raised.linked:nth-child(last) .button:active {
-    border-width: 1 1 1 0;
+    border-width: 1px 1px 1px 0;
 }
 
 .primary-toolbar.toolbar .entry {
@@ -1189,8 +1189,8 @@ GtkTreeMenu .menuitem * {
                                      from (@trough_bg_color_a),
                                      to (@trough_bg_color_b));
 
-    border-width: 1;
-    border-radius: 2;
+    border-width: 1px;
+    border-radius: 2px;
     border-style: solid;
     border-color: shade(@internal_element_color, 1.10);
     border-image: none;
@@ -1205,13 +1205,13 @@ GtkTreeMenu .menuitem * {
  *******************/
 
 .inline-toolbar.toolbar {
-    border-width: 1;
+    border-width: 1px;
     border-radius: 0;
     border-style: solid;
 
     -GtkToolbar-button-relief: normal;
 
-    padding: 4;
+    padding: 4px;
 
     background-image: -gtk-gradient (linear,
 				     left top,
@@ -1225,22 +1225,22 @@ GtkTreeMenu .menuitem * {
 }
 
 .inline-toolbar.toolbar:nth-child(last) {
-    border-width: 0 1 1 1;
-    border-radius: 0 0 3 3;
+    border-width: 0 1px 1px 1px;
+    border-radius: 0 0 3px 3px;
 }
 
 /* setup shadows */
 .inline-toolbar.toolbar .button {
-    padding: 1;
-    icon-shadow: 0 1 @theme_base_color;
+    padding: 1px;
+    icon-shadow: 0 1px @theme_base_color;
 
     border-image: none;
     border-color: shade(@button_border, 0.95);
     border-radius: 0;
-    border-width: 1 0 1 1;
+    border-width: 1px 0 1px 1px;
     border-style: solid;
 
-    box-shadow: inset 1 1 alpha(@theme_base_color, 0.50);
+    box-shadow: inset 1px 1px alpha(@theme_base_color, 0.50);
 }
 
 .inline-toolbar.toolbar .button:insensitive {
@@ -1259,14 +1259,14 @@ GtkTreeMenu .menuitem * {
 /* nth-child for inline toolbar button groups */
 .inline-toolbar.toolbar .button:nth-child(first),
 .inline-toolbar.toolbar GtkToolButton:nth-child(first) .button {
-    border-radius: 3 0 0 3;
+    border-radius: 3px 0 0 3px;
     box-shadow: none;
 }
 
 .inline-toolbar.toolbar .button:nth-child(last),
 .inline-toolbar.toolbar GtkToolButton:nth-child(last) .button {
-    border-radius: 0 3 3 0;
-    border-width: 1;
+    border-radius: 0 3px 3px 0;
+    border-width: 1px;
 }
 
 /***********
@@ -1290,10 +1290,10 @@ GtkAssistant .sidebar .highlight {
 }
 
 GtkAssistant .sidebar {
-    padding: 12;
+    padding: 12px;
 
-    border-width: 1;
-    border-radius: 2;
+    border-width: 1px;
+    border-radius: 2px;
     border-style: solid;
     border-color: @inactive_frame_color;
 
@@ -1313,8 +1313,8 @@ GtkSwitch {
 GtkSwitch.trough {
     color: shade (@internal_element_color, 0.60);
 
-    border-radius: 1;
-    border-width: 1;
+    border-radius: 1px;
+    border-width: 1px;
     border-style: none;
     /* border-image defined in the -assets variant */
 
@@ -1341,12 +1341,12 @@ GtkSwitch.trough:insensitive {
 }
 
 GtkSwitch.slider {
-    border-width: 1;
-    border-radius: 1;
+    border-width: 1px;
+    border-radius: 1px;
     border-style: none;
     /* border-image defined in -assets variant */
 
-    padding: 2;
+    padding: 2px;
 
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
@@ -1369,14 +1369,14 @@ GtkSwitch.slider:insensitive {
 
 GtkViewport,
 GtkIconView {
-    border-radius: 3;
+    border-radius: 3px;
     padding: 0;
 }
 
 GtkIconView.view.cell:selected,
 GtkIconView.view.cell:selected:focused {
     background-color: #7fa5d5;
-    border-radius: 4;
+    border-radius: 4px;
 
     /* FIXME: this probably needs to be better;
      * see https://bugzilla.gnome.org/show_bug.cgi?id=644157
@@ -1416,11 +1416,11 @@ GtkTreeView row:nth-child(odd):hover {
 }
 
 column-header {
-    padding: 1 2;
+    padding: 1px 2px;
 }
 
 column-header .button {
-    border-width: 0 1 1 0;
+    border-width: 0 1px 1px 0;
     border-radius: 0;
     border-style: solid;
 
@@ -1435,7 +1435,7 @@ column-header .button GtkArrow {
 }
 
 column-header:nth-child(last) .button {
-    border-width: 0 0 1 0;
+    border-width: 0 0 1px 0;
 }
 
 row:hover {
@@ -1463,7 +1463,7 @@ row:selected {
 
 .cell {
     color: @theme_text_color;
-    padding: 2;
+    padding: 2px;
     border-width: 0;
 }
 
@@ -1473,8 +1473,8 @@ row:selected {
 
 .expander {
     border-style: solid;
-    border-width: 1;
-    border-radius: 2;
+    border-width: 1px;
+    border-radius: 2px;
     border-color: shade (@internal_element_color, 1.40);
 
     color: @internal_element_color;
@@ -1483,7 +1483,7 @@ row:selected {
 
 .expander:active {
     border-style: solid;
-    border-width: 1;
+    border-width: 1px;
 
     color: @internal_element_color;
     border-color: shade (@internal_element_color, 1.40);
@@ -1493,7 +1493,7 @@ row:selected {
 
 .expander:prelight {
     border-style: solid;
-    border-width: 1;
+    border-width: 1px;
 
     color: @internal_element_color;
     border-color: shade (@internal_element_color, 1.40);
@@ -1504,7 +1504,7 @@ row:selected {
 .expander row:selected,
 .expander row:selected:focused {
     border-style: solid;
-    border-width: 1;
+    border-width: 1px;
 
     border-color: @expander_row_selected_color;
     color: @expander_row_selected_color;
@@ -1513,14 +1513,14 @@ row:selected {
 
 /* Calendars */
 GtkCalendar {
-    padding: 2;
+    padding: 2px;
 }
 
 GtkCalendar.view {
-    border-radius: 3;
+    border-radius: 3px;
     border-style: solid;
-    border-width: 1;
-    padding: 2;
+    border-width: 1px;
+    padding: 2px;
 }
 
 GtkCalendar.header {
@@ -1628,7 +1628,7 @@ PanelApplet GtkToggleButton {
     background-color: @os_chrome_bg_color;
     background-image: none;
     border-color: @os_chrome_bg_color;
-    border-width: 1;
+    border-width: 1px;
     color: @os_chrome_fg_color;
 }
 
@@ -1637,7 +1637,7 @@ PanelApplet GtkToggleButton:active {
     background-color: @os_chrome_selected_bg_color;
     background-image: none;
     border-color: lighter (@os_chrome_selected_bg_color);
-    border-width: 1;
+    border-width: 1px;
     color: @os_chrome_selected_fg_color;
 }
 
@@ -1645,7 +1645,7 @@ PanelApplet GtkToggleButton:prelight {
     background-color: @os_chrome_bg_color;
     background-image: none;
     border-color: @os_chrome_bg_color;
-    border-width: 1;
+    border-width: 1px;
     color: @os_chrome_selected_fg_color;
 }
 

--- a/gtk-themes/TraditionalOkTest/gtkrc
+++ b/gtk-themes/TraditionalOkTest/gtkrc
@@ -283,7 +283,7 @@ style "clearlooks-tooltips" {
 
 style "clearlooks-caja_location" {
 
-	bg[NORMAL]        = mix (0.60, shade (1.05, @bg_color), @selected_bg_color)
+	bg[NORMAL]        = mix (0.60, shade (1.05, @bg_color), @bg_color)
 }
 
 # Wrokaroudn style for places where the text color is used instead of the fg color.


### PR DESCRIPTION
1. the caja improvement fix a theme issue with my caja-terminal.
   before in ie. Aldabra
   https://dl.dropbox.com/u/49862637/Mate-desktop/Bugs/caja-aldabra.png
   after
   https://dl.dropbox.com/u/49862637/Mate-desktop/Bugs/caja-aldabra2.png
2. fix "Not using units is deprecated. Assuming 'px' " in gtk3 themes.

Hope that's better now.
