### PR TITLE
fix case for icon theme

### DIFF
--- a/desktop-themes/GreenLaguna/index.theme.in
+++ b/desktop-themes/GreenLaguna/index.theme.in
@@ -6,7 +6,7 @@ Encoding=UTF-8
 GtkTheme=GreenLaguna
 MetacityTheme=GreenLaguna
 IconTheme=matefaenza
-CursorTheme=MATE
+CursorTheme=mate
 CursorSize=24
 
 [Desktop Entry]

--- a/desktop-themes/TraditionalGreen/index.theme.in
+++ b/desktop-themes/TraditionalGreen/index.theme.in
@@ -12,6 +12,6 @@ Encoding=UTF-8
 GtkTheme=TraditionalGreen
 MetacityTheme=TraditionalGreen
 IconTheme=mate
-CursorTheme=MATE
+CursorTheme=mate
 CursorSize=16
 ButtonLayout=:minimize,maximize,close

--- a/desktop-themes/TraditionalOk/index.theme.in
+++ b/desktop-themes/TraditionalOk/index.theme.in
@@ -12,6 +12,6 @@ Encoding=UTF-8
 GtkTheme=TraditionalOk
 MetacityTheme=TraditionalOk
 IconTheme=mate
-CursorTheme=MATE
+CursorTheme=mate
 CursorSize=16
 ButtonLayout=:minimize,maximize,close

--- a/desktop-themes/TraditionalOkTest/index.theme.in
+++ b/desktop-themes/TraditionalOkTest/index.theme.in
@@ -12,6 +12,6 @@ Encoding=UTF-8
 GtkTheme=TraditionalOkTest
 MetacityTheme=TraditionalOkTest
 IconTheme=mate
-CursorTheme=MATE
+CursorTheme=mate
 CursorSize=16
 ButtonLayout=:minimize,maximize,close


### PR DESCRIPTION
The theme name should be all lowercase IMHO:

```
root@rotten-fruit share/themes# grep CursorTheme */*theme
Aldabra/index.theme:CursorTheme=mate
BlackMATE/index.theme:CursorTheme=mate
GreenLaguna/index.theme:CursorTheme=MATE
Menta/index.theme:CursorTheme=mate
TraditionalGreen/index.theme:CursorTheme=MATE
TraditionalOk/index.theme:CursorTheme=MATE
```
