### PR TITLE
Switch to black window text by default on TOKTest

### DIFF
--- a/desktop-themes/TraditionalOkTest/gtk-2.0/gtkrc
+++ b/desktop-themes/TraditionalOkTest/gtk-2.0/gtkrc
@@ -1,7 +1,7 @@
 
 # Please keep this gtkrc in sync with the other ones from Clearlooks based themes.
 
-gtk-color-scheme = "base_color:#babdb6\nfg_color:#f5f5f5\ntooltip_fg_color:#000000\nselected_bg_color:#f57900\nselected_fg_color:#ffffff\ntext_color:#000000\nbg_color:#888a85\ntooltip_bg_color:#F5F5B5\nlink_color:#0000ee\nvisited_link_color:#551a8b"
+gtk-color-scheme = "base_color:#babdb6\nfg_color:#000000\ntooltip_fg_color:#000000\nselected_bg_color:#f57900\nselected_fg_color:#ffffff\ntext_color:#000000\nbg_color:#888a85\ntooltip_bg_color:#F5F5B5\nlink_color:#0000ee\nvisited_link_color:#551a8b"
 
 style "default" {
 	xthickness = 1


### PR DESCRIPTION
Notifications are unreadable out of the box. Switch to black text. Easier on the eyes and notifications are readable.
