### PR TITLE
GTK3 Use transparent background for menu items

### DIFF
--- a/desktop-themes/TraditionalGreen/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/TraditionalGreen/gtk-3.0/gtk-widgets.css
@@ -1106,6 +1106,7 @@ GtkTreeMenu .menuitem * {
 .menubar .menuitem {
 	border-style: none;
 	padding: 3px 5px;
+	background-color: transparent;
 }
 
 .menubar .menuitem:hover {

--- a/desktop-themes/TraditionalOk/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/TraditionalOk/gtk-3.0/gtk-widgets.css
@@ -1106,6 +1106,7 @@ GtkTreeMenu .menuitem * {
 .menubar .menuitem {
 	border-style: none;
 	padding: 3px 5px;
+	background-color: transparent;
 }
 
 .menubar .menuitem:hover {

--- a/desktop-themes/TraditionalOkTest/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/TraditionalOkTest/gtk-3.0/gtk-widgets.css
@@ -1106,6 +1106,7 @@ GtkTreeMenu .menuitem * {
 .menubar .menuitem {
 	border-style: none;
 	padding: 3px 5px;
+	background-color: transparent;
 }
 
 .menubar .menuitem:hover {


### PR DESCRIPTION
In the Gtk3 theme the menuitem background has a different colour of grey then the menubar. This does not match the Gtk2 version and this needs to be fixed. We now set the menu item background to transparent so the menubar gradient is shown. 

Before:
![menuitem_background_prefix](https://f.cloud.github.com/assets/3465730/1608820/6be3bb12-5517-11e3-9ee6-75c76c47d178.png)
After:
![menuitem_background_postfix](https://f.cloud.github.com/assets/3465730/1608824/b8dc7238-5517-11e3-8d0a-a7fcb1d56c45.png)
