### PR TITLE
CSD updates for traditional themes

### DIFF
--- a/desktop-themes/TraditionalGreen/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/TraditionalGreen/gtk-3.0/gtk-widgets.css
@@ -1933,8 +1933,19 @@ GtkInfoBar:last-child,
 	border-width: 1px;
 	border-radius: 7px 7px 0 0;
 	border-style: solid;
+	box-shadow: 0 2px 8px 3px alpha(black, 0.5);
 	margin: 10px;
 }
+
+.window-frame:backdrop {
+	box-shadow: 0 2px 5px 1px alpha(black, 0.5);
+}
+
+.window-frame.tiled {
+    border-radius: 0;
+    background-color: @theme_bg_color;
+}
+
 */
 
 /**************

--- a/desktop-themes/TraditionalGreen/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/TraditionalGreen/gtk-3.0/gtk-widgets.css
@@ -1890,7 +1890,7 @@ GtkInfoBar:last-child,
 	                  @theme_base_color,
 	                  @theme_bg_color);
 	background-color: transparent;
-	border-radius: 0px;
+	border-radius: 7px 7px 0 0;
 	border-bottom: 1px solid;
 	border-color: shade(@border_color, 1.30);
 	padding: 5px 4px 4px 4px;

--- a/desktop-themes/TraditionalGreen/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/TraditionalGreen/gtk-3.0/gtk-widgets.css
@@ -1921,14 +1921,10 @@ GtkInfoBar:last-child,
 	border-image: none;
 }
 
-/****************************************************************************************
-* Give and take related to recent gtk3.3.14 development,                                *
-* to achieve full size of the icon menu of some of the applications whose notification  *
-* icons appear in the system tray, the "shadow" is disabled.                            *
-* same affect in mate-panel main menu, csd apps, header-bars apps                       *
-* if compositor is disable !!!!!                                                        *
-*****************************************************************************************/
-/*
+/*******
+ * CSD *
+ * *****/
+
 .window-frame {
 	border-width: 1px;
 	border-radius: 7px 7px 0 0;
@@ -1946,7 +1942,6 @@ GtkInfoBar:last-child,
     background-color: @theme_bg_color;
 }
 
-*/
 
 /**************
  * Action bar *

--- a/desktop-themes/TraditionalOk/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/TraditionalOk/gtk-3.0/gtk-widgets.css
@@ -1937,8 +1937,20 @@ GtkInfoBar:last-child,
 	border-width: 1px;
 	border-radius: 7px 7px 0 0;
 	border-style: solid;
+	box-shadow: 0 2px 8px 3px alpha(black, 0.5);
 	margin: 10px;
 }
+
+
+.window-frame:backdrop {
+	box-shadow: 0 2px 5px 1px alpha(black, 0.5);
+}
+
+.window-frame.tiled {
+    border-radius: 0;
+    background-color: @theme_bg_color;
+}
+
 */
 
 /**************

--- a/desktop-themes/TraditionalOk/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/TraditionalOk/gtk-3.0/gtk-widgets.css
@@ -1925,14 +1925,10 @@ GtkInfoBar:last-child,
 	border-image: none;
 }
 
-/****************************************************************************************
-* Give and take related to recent gtk3.3.14 development,                                *
-* to achieve full size of the icon menu of some of the applications whose notification  *
-* icons appear in the system tray, the "shadow" is disabled.                            *
-* same affect in mate-panel main menu, csd apps, header-bars apps                       *
-* if compositor is disable !!!!!                                                        *
-*****************************************************************************************/
-/*
+/*******
+ * CSD *
+ * *****/
+
 .window-frame {
 	border-width: 1px;
 	border-radius: 7px 7px 0 0;
@@ -1951,7 +1947,6 @@ GtkInfoBar:last-child,
     background-color: @theme_bg_color;
 }
 
-*/
 
 /**************
  * Action bar *

--- a/desktop-themes/TraditionalOk/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/TraditionalOk/gtk-3.0/gtk-widgets.css
@@ -1894,7 +1894,7 @@ GtkInfoBar:last-child,
 	                  @theme_base_color,
 	                  @theme_bg_color);
 	background-color: transparent;
-	border-radius: 0px;
+	border-radius: 7px 7px 0 0;
 	border-bottom: 1px solid;
 	border-color: shade(@border_color, 1.30);
 	padding: 5px 4px 4px 4px;

--- a/desktop-themes/TraditionalOkTest/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/TraditionalOkTest/gtk-3.0/gtk-widgets.css
@@ -1932,7 +1932,17 @@ GtkInfoBar:last-child,
 	border-width: 1px;
 	border-radius: 7px 7px 0 0;
 	border-style: solid;
+	box-shadow: 0 2px 8px 3px alpha(black, 0.5);
 	margin: 10px;
+}
+
+.window-frame:backdrop {
+	box-shadow: 0 2px 5px 1px alpha(black, 0.5);
+}
+
+.window-frame.tiled {
+    border-radius: 0;
+    background-color: @theme_bg_color;
 }
 */
 

--- a/desktop-themes/TraditionalOkTest/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/TraditionalOkTest/gtk-3.0/gtk-widgets.css
@@ -1889,7 +1889,7 @@ GtkInfoBar:last-child,
 	                  @theme_base_color,
 	                  @theme_bg_color);
 	background-color: transparent;
-	border-radius: 0px;
+	border-radius: 7px 7px 0 0;
 	border-bottom: 1px solid;
 	border-color: shade(@border_color, 1.30);
 	padding: 5px 4px 4px 4px;

--- a/desktop-themes/TraditionalOkTest/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/TraditionalOkTest/gtk-3.0/gtk-widgets.css
@@ -1920,14 +1920,10 @@ GtkInfoBar:last-child,
 	border-image: none;
 }
 
-/****************************************************************************************
-* Give and take related to recent gtk3.3.14 development,                                *
-* to achieve full size of the icon menu of some of the applications whose notification  *
-* icons appear in the system tray, the "shadow" is disabled.                            *
-* same affect in mate-panel main menu, csd apps, header-bars apps                       *
-* if compositor is disable !!!!!                                                        *
-*****************************************************************************************/
-/*
+/*******
+ * CSD *
+ * *****/
+
 .window-frame {
 	border-width: 1px;
 	border-radius: 7px 7px 0 0;
@@ -1944,7 +1940,6 @@ GtkInfoBar:last-child,
     border-radius: 0;
     background-color: @theme_bg_color;
 }
-*/
 
 /**************
  * Action bar *


### PR DESCRIPTION
Just for review and to document the CSD discussion from this morning I had with @NiceandGently.

These are the changes to make CSD windows look nice for me on Gentoo with Gtk+ 3.14.6.

 * I update the ``border-radius`` as we discussed, I'll let you try out in the next couple of days as you said.
 * I also added a commit that adds a drop-shadow and make CSD windows not have rounded corners when tiles.
 * I enabled the CSD part. I only have black border when I turn off the compositor but then an app restart makes them go away.

I can push this myself to all relevant branches if we all agree on these :smile: 