### PR TITLE
GTK3: Menta themes: fix mate-panel separator background

### DIFF
--- a/desktop-themes/BlueMenta/gtk-3.0/mate-applications.css
+++ b/desktop-themes/BlueMenta/gtk-3.0/mate-applications.css
@@ -415,7 +415,7 @@ MatePanelApplet {
 MatePanelAppletFrameDBus PanelSeparator,
 PanelSeparator {
     border-width: 0;
-    background-color: @theme_fg_color;
+    background-color: @theme_bg_color;
     color: shade (@theme_fg_color, 4.30);
     text-shadow: none;
 }

--- a/desktop-themes/Menta/gtk-3.0/mate-applications.css
+++ b/desktop-themes/Menta/gtk-3.0/mate-applications.css
@@ -417,7 +417,7 @@ MatePanelApplet {
 MatePanelAppletFrameDBus PanelSeparator,
 PanelSeparator {
     border-width: 0;
-    background-color: @theme_fg_color;
+    background-color: @theme_bg_color;
     color: shade (@theme_fg_color, 4.30);
     text-shadow: none;
 }


### PR DESCRIPTION
It was a small typo. The panel separator background was invisible before commit https://github.com/mate-desktop/mate-panel/commit/6f634c680fbc5ee5051253554f2710e39f9ea80a, so you didn't see this bug.