### PR TITLE
Port BlackMATE and Green-Submarine to Gtk3.20

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,5 @@
+1.13.0 (GTK 3.20)
+
 1.12.2 (GTK 3.18)
 
 - GTK3 GreenLaguna: fix padding osd-toolbar volume button

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ(2.53)
 
-AC_INIT([mate-themes], [1.12.2], [https://github.com/mate-desktop/mate-themes/issues], [mate-themes-gtk3.18], [http://www.mate-desktop.org])
+AC_INIT([mate-themes], [1.13.0], [https://github.com/mate-desktop/mate-themes/issues], [mate-themes-gtk3.18], [http://www.mate-desktop.org])
 AC_CONFIG_SRCDIR([icon-themes])
 
 AM_INIT_AUTOMAKE([1.9 tar-ustar dist-xz no-dist-gzip check-news])

--- a/desktop-themes/BlackMATE/gtk-3.0/gnome-applications.css
+++ b/desktop-themes/BlackMATE/gtk-3.0/gnome-applications.css
@@ -193,7 +193,6 @@ NautilusWindow .view {
 
 /* the small line between sidebar and view */
 NautilusWindow * {
-	-GtkPaned-handle-size: 2px;
 }
 
 NautilusWindow GtkPaned {

--- a/desktop-themes/BlackMATE/gtk-3.0/gnome-applications.css
+++ b/desktop-themes/BlackMATE/gtk-3.0/gnome-applications.css
@@ -248,39 +248,39 @@ NautilusWindow .toolbar {
 	                                  shade(@less_dark_color, 1.36));
 }
 
-ContactsWindow .scrollbar.slider:prelight,
-ContactsWindow .scrollbar.slider:prelight:active,
-ContactsWindow .scrollbar.slider.vertical:prelight,
-ContactsWindow .scrollbar.slider.vertical:prelight:active,
-FrWindow .scrollbar.slider:prelight,
-FrWindow .scrollbar.slider:prelight:active,
-FrWindow .scrollbar.slider.vertical:prelight,
-FrWindow .scrollbar.slider.vertical:prelight:active,
-NautilusWindow .scrollbar.slider:prelight,
-NautilusWindow .scrollbar.slider:prelight:active,
-NautilusWindow .scrollbar.slider.vertical:prelight,
-NautilusWindow .scrollbar.slider.vertical:prelight:active {
+ContactsWindow .scrollbar.slider:hover,
+ContactsWindow .scrollbar.slider:hover:active,
+ContactsWindow .scrollbar.slider.vertical:hover,
+ContactsWindow .scrollbar.slider.vertical:hover:active,
+FrWindow .scrollbar.slider:hover,
+FrWindow .scrollbar.slider:hover:active,
+FrWindow .scrollbar.slider.vertical:hover,
+FrWindow .scrollbar.slider.vertical:hover:active,
+NautilusWindow .scrollbar.slider:hover,
+NautilusWindow .scrollbar.slider:hover:active,
+NautilusWindow .scrollbar.slider.vertical:hover,
+NautilusWindow .scrollbar.slider.vertical:hover:active {
 	border-color: shade(@scroll_slider_color, 1.1);
 }
 
 ContactsWindow .scrollbar.button,
 ContactsWindow .scrollbar.button.horizontal,
 ContactsWindow .scrollbar.button.vertical,
-ContactsWindow .scrollbar.button:insensitive,
-ContactsWindow .scrollbar.button.horizontal:insensitive,
-ContactsWindow .scrollbar.button.vertical:insensitive,
+ContactsWindow .scrollbar.button:disabled,
+ContactsWindow .scrollbar.button.horizontal:disabled,
+ContactsWindow .scrollbar.button.vertical:disabled,
 FrWindow .scrollbar.button,
 FrWindow .scrollbar.button.horizontal,
 FrWindow .scrollbar.button.vertical,
-FrWindow .scrollbar.button:insensitive,
-FrWindow .scrollbar.button.horizontal:insensitive,
-FrWindow .scrollbar.button.vertical:insensitive,
+FrWindow .scrollbar.button:disabled,
+FrWindow .scrollbar.button.horizontal:disabled,
+FrWindow .scrollbar.button.vertical:disabled,
 NautilusWindow .scrollbar.button,
 NautilusWindow .scrollbar.button.horizontal,
 NautilusWindow .scrollbar.button.vertical,
-NautilusWindow .scrollbar.button:insensitive,
-NautilusWindow .scrollbar.button.horizontal:insensitive,
-NautilusWindow .scrollbar.button.vertical:insensitive {
+NautilusWindow .scrollbar.button:disabled,
+NautilusWindow .scrollbar.button.horizontal:disabled,
+NautilusWindow .scrollbar.button.vertical:disabled {
 	background-image: none;
 }
 
@@ -419,7 +419,7 @@ NautilusDesktopWindow GtkPaned {
 }
 
 .nautilus-desktop.nautilus-canvas-item:active,
-.nautilus-desktop.nautilus-canvas-item:prelight,
+.nautilus-desktop.nautilus-canvas-item:hover,
 .nautilus-desktop.nautilus-canvas-item:selected {
 	text-shadow: none;
 }
@@ -433,4 +433,3 @@ NautilusDesktopWindow GtkPaned {
 .primary-toolbar.toolbar.horizontal RBHeader.horizontal GtkVolumeButton.button.flat:hover {
 	padding: 0px 6px;
 }
-

--- a/desktop-themes/BlackMATE/gtk-3.0/gtk-widgets-assets-dark.css
+++ b/desktop-themes/BlackMATE/gtk-3.0/gtk-widgets-assets-dark.css
@@ -4,247 +4,249 @@
 
 /* First draw regular check and radio items */
 
-.check,
-.check row:selected,
-.check row:selected:focus {
+check,
+check row:selected,
+check row:selected:focus {
 	-gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked-dark.svg"));
 }
 
-.notebook .check,
-.notebook .check row:selected,
-.notebook .check row:selected:focus,
-GtkTreeView.check,
-GtkTreeView.check row:selected,
-GtkTreeView.check row:selected:focus {
+notebook check,
+notebook check row:selected,
+notebook check row:selected:focus,
+treeview check,
+treeview check row:selected,
+treeview check row:selected:focus {
 	-gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked-lessdark.svg"));
 }
 
-.check:insensitive,
-.check row:selected:insensitive,
-.check row:selected:focus:insensitive {
+check:disabled,
+check row:selected:disabled,
+check row:selected:focus:disabled {
 	-gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked-insensitive-dark.svg"));
 }
 
-.check:checked,
-.check:active,
-.check row:selected:checked,
-.check row:selected:active,
-.check row:selected:focus:checked,
-.check row:selected:focus:active {
+check:checked,
+check:active,
+check row:selected:checked,
+check row:selected:active,
+check row:selected:focus:checked,
+check row:selected:focus:active {
 	-gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked-dark.svg"));
 }
 
-.notebook .check:checked,
-.notebook .check row:selected:checked,
-.notebook .check row:selected:focus:checked,
-GtkTreeView.check:checked,
-GtkTreeView.check row:selected:checked,
-GtkTreeView.check row:selected:focus:checked,
-.notebook .check:active,
-.notebook .check row:selected:active,
-.notebook .check row:selected:focus:active,
-GtkTreeView.check:active,
-GtkTreeView.check row:selected:active,
-GtkTreeView.check row:selected:focus:active {
+notebook check:checked,
+notebook check row:selected:checked,
+notebook check row:selected:focus:checked,
+treeview check:checked,
+treeview check row:selected:checked,
+treeview check row:selected:focus:checked,
+notebook check:active,
+notebook check row:selected:active,
+notebook check row:selected:focus:active,
+treeview check:active,
+treeview check row:selected:active,
+treeview check row:selected:focus:active {
 	-gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked-lessdark.svg"));
 }
 
-.check:checked:insensitive,
-.check row:selected:checked:insensitive,
-.check row:selected:focus:checked:insensitive,
-.check:active:insensitive,
-.check row:selected:active:insensitive,
-.check row:selected:focus:active:insensitive
+check:checked:disabled,
+check row:selected:checked:disabled,
+check row:selected:focus:checked:disabled,
+check:active:disabled,
+check row:selected:active:disabled,
+check row:selected:focus:active:disabled
 {
 	-gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked-insensitive-dark.svg"));
 }
 
-.check:inconsistent,
-.check row:selected:inconsistent,
-.check row:selected:focus:inconsistent {
+check:indeterminate,
+check row:selected:indeterminate,
+check row:selected:focus:indeterminate {
 	-gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed-dark.svg"));
 }
 
-.notebook .check:inconsistent,
-.notebook .check row:selected:inconsistent,
-.notebook .check row:selected:focus:inconsistent,
-GtkTreeView.check:inconsistent,
-GtkTreeView.check row:selected:inconsistent,
-GtkTreeView.check row:selected:focus:inconsistent {
+notebook check:indeterminate,
+notebook check row:selected:indeterminate,
+notebook check row:selected:focus:indeterminate,
+treeview check:indeterminate,
+treeview check row:selected:indeterminate,
+treeview check row:selected:focus:indeterminate {
 	-gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed-lessdark.svg"));
 }
 
-.check:inconsistent:insensitive,
-.check row:selected:inconsistent:insensitive,
-.check row:selected:focus:inconsistent:insensitive {
+check:indeterminate:disabled,
+check row:selected:indeterminate:disabled,
+check row:selected:focus:indeterminate:disabled {
 	-gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed-insensitive-dark.svg"));
 }
 
-.radio,
-.radio row:selected,
-.radio row:selected:focus {
+radio,
+radio row:selected,
+radio row:selected:focus {
 	-gtk-icon-source: -gtk-scaled(url("assets/radio-unselected-dark.svg"));
 }
 
-.notebook .radio,
-.notebook .radio row:selected,
-.notebook .radio row:selected:focus,
-GtkTreeView.radio,
-GtkTreeView.radio row:selected,
-GtkTreeView.radio row:selected:focus {
+notebook radio,
+notebook radio row:selected,
+notebook radio row:selected:focus,
+treeview radio,
+treeview radio row:selected,
+treeview radio row:selected:focus {
 	-gtk-icon-source: -gtk-scaled(url("assets/radio-unselected-lessdark.svg"));
 }
 
-.radio:insensitive,
-.radio row:selected:insensitive,
-.radio row:selected:focus:insensitive {
+radio:disabled,
+radio row:selected:disabled,
+radio row:selected:focus:disabled {
 	-gtk-icon-source: -gtk-scaled(url("assets/radio-unselected-insensitive-dark.svg"));
 }
 
-.radio:checked,
-.radio:active,
-.radio row:selected:checked,
-.radio row:selected:active,
-.radio row:selected:focus:checked,
-.radio row:selected:focus:active {
+radio:checked,
+radio:active,
+radio row:selected:checked,
+radio row:selected:active,
+radio row:selected:focus:checked,
+radio row:selected:focus:active {
 	-gtk-icon-source: -gtk-scaled(url("assets/radio-selected-dark.svg"));
 }
 
-.notebook .radio:checked,
-.notebook .radio row:selected:checked,
-.notebook .radio row:selected:focus:checked,
-GtkTreeView.radio:checked,
-GtkTreeView.radio row:selected:checked,
-GtkTreeView.radio row:selected:focus:checked,
-.notebook .radio:active,
-.notebook .radio row:selected:active,
-.notebook .radio row:selected:focus:active,
-GtkTreeView.radio:active,
-GtkTreeView.radio row:selected:active,
-GtkTreeView.radio row:selected:focus:active {
+notebook radio:checked,
+notebook  radio row:selected:checked,
+notebook  radio row:selected:focus:checked,
+treeview radio:checked,
+treeview radio row:selected:checked,
+treeview radio row:selected:focus:checked,
+notebook  radio:active,
+notebook  radio row:selected:active,
+notebook  radio row:selected:focus:active,
+treeview radio:active,
+treeview radio row:selected:active,
+treeview radio row:selected:focus:active {
 	-gtk-icon-source: -gtk-scaled(url("assets/radio-selected-lessdark.svg"));
 }
 
-.radio:checked:insensitive,
-.radio row:selected:checked:insensitive,
-.radio row:selected:focus:checked:insensitive,
-.radio:active:insensitive,
-.radio row:selected:active:insensitive,
-.radio row:selected:focus:active:insensitive {
+radio:checked:disabled,
+radio row:selected:checked:disabled,
+radio row:selected:focus:checked:disabled,
+radio:active:disabled,
+radio row:selected:active:disabled,
+ adio row:selected:focus:active:disabled {
 	-gtk-icon-source: -gtk-scaled(url("assets/radio-selected-insensitive-dark.svg"));
 }
 
-.radio:inconsistent,
-.radio row:selected:inconsistent,
-.radio row:selected:focus:inconsistent {
+radio:indeterminate,
+radio row:selected:indeterminate,
+radio row:selected:focus:indeterminate {
 	-gtk-icon-source: -gtk-scaled(url("assets/radio-mixed-dark.svg"));
 }
 
-.notebook .radio:inconsistent,
-.notebook .radio row:selected:inconsistent,
-.notebook .radio row:selected:focus:inconsistent,
-GtkTreeView.radio:inconsistent,
-GtkTreeView.radio row:selected:inconsistent,
-GtkTreeView.radio row:selected:focus:inconsistent {
+notebook radio:indeterminate,
+notebook radio row:selected:indeterminate,
+notebook radio row:selected:focus:indeterminate,
+treeview radio:indeterminate,
+treeview radio row:selected:indeterminate,
+treeview radio row:selected:focus:indeterminate {
 	-gtk-icon-source: -gtk-scaled(url("assets/radio-mixed-lessdark.svg"));
 }
 
-.radio:inconsistent:insensitive,
-.radio row:selected:inconsistent:insensitive,
-.radio row:selected:focus:inconsistent:insensitive {
+radio:indeterminate:disabled,
+radio row:selected:indeterminate:disabled,
+radio row:selected:focus:indeterminate:disabled {
 	-gtk-icon-source: -gtk-scaled(url("assets/radio-mixed-insensitive-dark.svg"));
 }
 
-.sidebar .radio:checked,
-.sidebar .radio:checked:focus,
-.sidebar .radio:checked:prelight,
-.sidebar .radio:active,
-.sidebar .radio:active:focus,
-.sidebar .radio:active:prelight {
+sidebar radio:checked,
+sidebar radio:checked:focus,
+sidebar radio:checked:hover,
+sidebar radio:active,
+sidebar radio:active:focus,
+sidebar radio:active:hover {
 	-gtk-icon-source: -gtk-scaled(url("assets/sidebar-radio-checked-dark.svg"));
 }
 
-.sidebar .radio:prelight {
+sidebar  radio:hover {
 	-gtk-icon-source: -gtk-scaled(url("assets/sidebar-radio-prelight.svg"));
 }
 
-.sidebar .radio:checked:selected,
-.sidebar .radio:checked:selected:focus,
-.sidebar .radio:active:selected,
-.sidebar .radio:active:selected:focus {
+sidebar radio:checked:selected,
+sidebar radio:checked:selected:focus,
+sidebar radio:active:selected,
+sidebar radio:active:selected:focus {
 	-gtk-icon-source: -gtk-scaled(url("assets/sidebar-radio-selected-dark.svg"));
 }
 
-.sidebar .radio:selected:prelight,
-.sidebar .radio:selected:focus {
+sidebar radio:selected:hover,
+sidebar radio:selected:focus {
 	-gtk-icon-source: -gtk-scaled(url("assets/sidebar-radio-selected-prelight.svg"));
 }
 
 /* Now draw menu check and radio items */
 
-.menuitem.radio,
-.menuitem.radio:hover,
-.menuitem.radio:insensitive,
-.menuitem.check,
-.menuitem.check:hover,
-.menuitem.check:insensitive {
+menuitem radio,
+menuitem radio:hover,
+menuitem radio:disabled,
+menuitem check,
+menuitem check:hover,
+menuitem check:disabled {
 	background-color: transparent;
 	background-image: none;
 	border-style: none;
 	border-image: none;
+	min-height: 12px;
+  	min-width: 12px;
 }
 
-.menuitem.radio:checked,
-.menuitem.radio:active {
+menuitem radio:checked,
+menuitem radio:active {
 	-gtk-icon-source: -gtk-scaled(url("assets/radio-menuitem-checked.svg"));
 }
 
-.menuitem.radio:checked:hover,
-.menuitem.radio:active:hover {
+menuitem radio:checked:hover,
+menuitem radio:active:hover {
 	-gtk-icon-source: -gtk-scaled(url("assets/radio-menuitem-checked-prelight.svg"));
 }
 
-.menuitem.radio:checked:insensitive,
-.menuitem.radio:active:insensitive {
+menuitem radio:checked:disabled,
+menuitem radio:active:disabled {
 	-gtk-icon-source: -gtk-scaled(url("assets/radio-menuitem-checked-insensitive.svg"));
 }
 
-.menuitem.radio:inconsistent {
+menuitem radio:indeterminate {
 	-gtk-icon-source: -gtk-scaled(url("assets/radio-menuitem-mixed.svg"));
 }
 
-.menuitem.radio:inconsistent:hover {
+menuitem radio:indeterminate:hover {
 	-gtk-icon-source: -gtk-scaled(url("assets/radio-menuitem-mixed-prelight.svg"));
 }
 
-.menuitem.radio:inconsistent:insensitive {
+menuitem radio:indeterminate:disabled {
 	-gtk-icon-source: -gtk-scaled(url("assets/radio-menuitem-mixed-insensitive.svg"));
 }
 
-.menuitem.check:checked,
-.menuitem.check:active {
+menuitem check:checked,
+menuitem check:active {
 	-gtk-icon-source: -gtk-scaled(url("assets/checkbox-menuitem-checked.svg"));
 }
 
-.menuitem.check:checked:hover,
-.menuitem.check:active:hover {
+menuitem check:checked:hover,
+menuitem check:active:hover {
 	-gtk-icon-source: -gtk-scaled(url("assets/checkbox-menuitem-checked-prelight.svg"));
 }
 
-.menuitem.check:checked:insensitive,
-.menuitem.check:active:insensitive {
+menuitem check:checked:disabled,
+menuitem check:active:disabled {
 	-gtk-icon-source: -gtk-scaled(url("assets/checkbox-menuitem-checked-insensitive.svg"));
 }
 
-.menuitem.check:inconsistent {
+menuitem check:indeterminate {
 	-gtk-icon-source: -gtk-scaled(url("assets/checkbox-menuitem-mixed.svg"));
 }
 
-.menuitem.check:inconsistent:hover {
+menuitem check:indeterminate:hover {
 	-gtk-icon-source: -gtk-scaled(url("assets/checkbox-menuitem-mixed-prelight.svg"));
 }
 
-.menuitem.check:inconsistent:insensitive {
+ menuitem check:indeterminate:disabled {
 	-gtk-icon-source: -gtk-scaled(url("assets/checkbox-menuitem-mixed-insensitive.svg"));
 }
 
@@ -256,16 +258,16 @@ GtkTreeView.radio row:selected:focus:inconsistent {
     border-image: url("assets/entry-border-focused-dark.svg") 3 / 3px stretch;
 }*/
 
-.primary-toolbar GtkComboBox.combobox-entry .button:checked,
-.primary-toolbar GtkComboBox.combobox-entry .button:hover:checked,
-.primary-toolbar GtkComboBox.combobox-entry .button:active,
-.primary-toolbar GtkComboBox.combobox-entry .button:hover:active,
-.primary-toolbar GtkComboBox.combobox-entry .button,
-GtkComboBox.combobox-entry .button:checked,
-GtkComboBox.combobox-entry .button:hover:checked,
-GtkComboBox.combobox-entry .button:active,
-GtkComboBox.combobox-entry .button:hover:active,
-GtkComboBox.combobox-entry .button {
+primary-toolbar combobox.combobox-entry  button:checked,
+primary-toolbar combobox.combobox-entry  button:hover:checked,
+primary-toolbar combobox.combobox-entry  button:active,
+primary-toolbar combobox.combobox-entry  button:hover:active,
+primary-toolbar combobox.combobox-entry  button,
+combobox.combobox-entry  button:checked,
+combobox.combobox-entry  button:hover:checked,
+combobox.combobox-entry  button:active,
+combobox.combobox-entry  button:hover:active,
+combobox.combobox-entry  button {
 	border-image: url("assets/entry-border-normal-dark.svg") 3 / 3px stretch;
 }
 
@@ -273,53 +275,53 @@ GtkComboBox.combobox-entry .button {
  * Sliders *
  ***********/
 
-GtkScale.slider,
-GtkScale.slider.horizontal {
+scale slider,
+scale slider.horizontal {
 	background-image: url("assets/scale-slider-horizontal-dark.svg");
 }
 
-GtkScale.slider:insensitive,
-GtkScale.slider.horizontal:insensitive {
+scale slider:disabled,
+scale slider.horizontal:disabled {
 	background-image: url("assets/scale-slider-horizontal-insensitive-dark.svg");
 }
 
-GtkScale.slider.vertical {
+scale slider.vertical {
 	background-image: url("assets/scale-slider-vertical-dark.svg");
 }
 
-GtkScale.slider.vertical:insensitive {
+scale slider.vertical:disabled {
 	background-image: url("assets/scale-slider-vertical-insensitive-dark.svg");
 }
 
-GtkScale.scale-has-marks-above.slider.horizontal {
+scale.scale-has-marks-above slider.horizontal {
 	background-image: url("assets/scale-slider-marks-above-horizontal-dark.svg");
 }
 
-GtkScale.scale-has-marks-above.slider.horizontal:insensitive {
+scale.scale-has-marks-above slider.horizontal:disabled {
 	background-image: url("assets/scale-slider-marks-above-horizontal-insensitive-dark.svg");
 }
 
-GtkScale.scale-has-marks-above.slider.vertical {
+scale.scale-has-marks-above slider.vertical {
 	background-image: url("assets/scale-slider-marks-above-vertical-dark.svg");
 }
 
-GtkScale.scale-has-marks-above.slider.vertical:insensitive {
+scale.scale-has-marks-above slider.vertical:disabled {
 	background-image: url("assets/scale-slider-marks-above-vertical-insensitive-dark.svg");
 }
 
-GtkScale.scale-has-marks-below.slider.horizontal {
+scale.scale-has-marks-below slider.horizontal {
 	background-image: url("assets/scale-slider-marks-below-horizontal-dark.svg");
 }
 
-GtkScale.scale-has-marks-below.slider.horizontal:insensitive {
+scale.scale-has-marks-below slider.horizontal:disabled {
 	background-image: url("assets/scale-slider-marks-below-horizontal-insensitive-dark.svg");
 }
 
-GtkScale.scale-has-marks-below.slider.vertical {
+scale.scale-has-marks-below slider.vertical {
 	background-image: url("assets/scale-slider-marks-below-vertical-dark.svg");
 }
 
-GtkScale.scale-has-marks-below.slider.vertical:insensitive {
+scale.scale-has-marks-below slider.vertical:disabled {
 	background-image: url("assets/scale-slider-marks-below-vertical-insensitive-dark.svg");
 }
 
@@ -333,7 +335,7 @@ GtkScale.scale-has-marks-below.slider.vertical:insensitive {
 
 /*the little usefull helper*/
 
-.grip {
+grip {
 background-color: transparent;
 background-image: url("assets/resize-grip.svg");
 }
@@ -342,48 +344,48 @@ background-image: url("assets/resize-grip.svg");
  * Buttons *
  ***********/
 
-.button {
+button {
 	border-image: url("assets/button-border-dark.svg") 3 / 3px stretch;
 }
 
-.button:checked,
-.button:hover:checked,
-.button:active,
-.button:hover:active
-.list-row.button:hover,
-.list-row.button:selected,
-.list-row.button:selected:hover {
+button:checked,
+button:hover:checked,
+button:active,
+button:hover:active
+list-row button:hover,
+list-row button:selected,
+list-row button:selected:hover {
 	border-image: url("assets/button-active-border-dark.svg") 3 / 3px stretch;
 }
 
-.button.default,
-.notebook .button.default {
+button.default,
+notebook  button.default {
 	border-image: url("assets/button-default-border-dark.svg") 3 / 3px stretch;
 }
 
-.button.default:checked,
-.notebook .button.default:checked,
-.button.default:active,
-.notebook .button.default:active {
+button.default:checked,
+notebook  button.default:checked,
+button.default:active,
+notebook  button.default:active {
 	border-image: url("assets/button-default-active-border-dark.svg") 3 / 3px stretch;
 }
 
-.toolbar .button:checked,
-.primary-toolbar .button:checked,
-.primary-toolbar .toolbar .button:checked,
-.primary-toolbar.toolbar .button:checked,
-.toolbar .button:active,
-.primary-toolbar .button:active,
-.primary-toolbar .toolbar .button:active,
-.primary-toolbar.toolbar .button:active,
-.toolbar GtkComboBox .button,
-.primary-toolbar .toolbar GtkComboBox .button,
-.primary-toolbar.toolbar GtkComboBox .button/*,
-.toolbar .button:active:hover,
-.primary-toolbar .toolbar .button:active:hover,
-.primary-toolbar.toolbar .button:active:hover,
-.primary-toolbar .toolbar GtkComboBox .button:hover,
-.primary-toolbar.toolbar GtkComboBox .button:hover*/ {
+toolbar  button:checked,
+primary-toolbar button:checked,
+primary-toolbar toolbar button:checked,
+primary-toolbar.toolbar button:checked,
+toolbar  button:active,
+primary-toolbar button:active,
+primary-toolbar toolbar button:active,
+primary-toolbar toolbar button:active,
+toolbar combobox button,
+primary-toolbar toolbar combobox button,
+primary-toolbar.toolbar combobox button/*,
+toolbar  button:active:hover,
+primary-toolbar .toolbar  button:active:hover,
+primary-toolbar.toolbar  button:active:hover,
+primary-toolbar .toolbar combobox  button:hover,
+primary-toolbar.toolbar combobox  button:hover*/ {
 	border-image: url("assets/primary-toolbar-button-active-border-dark.svg") 3 / 3px stretch;
 }
 
@@ -391,16 +393,16 @@ background-image: url("assets/resize-grip.svg");
  * Tree Views *
  **************/
 
-GtkTreeView row:selected {
+treeview row:selected {
 	border-image: url("assets/treeview-border-dark.svg") 3 / 3px stretch;
 }
 
-GtkTreeView row:selected:focus {
+treeview row:selected:focus {
 	border-image: url("assets/treeview-focus-border-dark.svg") 3 / 3px stretch;
 }
 
-/*.menuitem:hover,
-.menu .menuitem:hover {
+/* menuitem :hover,
+.menu  menuitem :hover {
 	border-image: url("assets/menu-border-dark.svg") 3 / 3px stretch;
 }*/
 
@@ -409,19 +411,18 @@ GtkTreeView row:selected:focus {
  * Notebook and Tabs *
  *********************/
 
-.notebook tab:active {
+notebook tab:active {
 	border-image: url("assets/tab-active-border.svg") 3 3 0 3 / 3px 3px 0px 3px stretch;
 }
 
-.notebook tab.bottom:active {
+notebook tab.bottom:active {
 	border-image: url("assets/tab-bottom-active-border.svg") 0 3 3 3 / 0px 3px 3px 3px stretch;
 }
 
-.notebook tab.left:active {
+notebook tab.left:active {
 	border-image: url("assets/tab-left-active-border.svg") 3 0 3 3 / 3px 0px 3px 3px stretch;
 }
 
-.notebook tab.right:active {
+notebook tab.right:active {
 	border-image: url("assets/tab-right-active-border.svg") 3 3 3 0 / 3px 3px 3px 0px stretch;
 }
-

--- a/desktop-themes/BlackMATE/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/BlackMATE/gtk-3.0/gtk-widgets.css
@@ -772,8 +772,8 @@ notebook tab  button:hover:active {
 	border-radius: 5px;
 	background-color: transparent;
 	background-image: none;
-	-GtkButton-child-displacement-x: 0;
-	-GtkButton-child-displacement-y: 0;
+	/*-GtkButton-child-displacement-x: 0;
+	-GtkButton-child-displacement-y: 0;*/
 }
 
 /*** The contents of notebooks ***/

--- a/desktop-themes/BlackMATE/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/BlackMATE/gtk-3.0/gtk-widgets.css
@@ -997,6 +997,11 @@ treeview .view {
 	color: @theme_fg_color;
 }
 
+/*force separators to appear, stop jumping */
+treeview.view.separator {
+    min-height: 2px; 
+}
+
 /* row as a separator */
 treeview.view.separator,
 treeview.view.separator:hover {

--- a/desktop-themes/BlackMATE/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/BlackMATE/gtk-3.0/gtk-widgets.css
@@ -2,25 +2,15 @@
 	padding: 0px;
 	background-clip: padding-box;
 	/* Style properties */
-	-GtkButton-child-displacement-x: 1;
-	-GtkButton-child-displacement-y: 1;
-	-GtkButton-default-border: 0;
-	-GtkButton-image-spacing: 4;
-	-GtkButton-interior-focus: true;
 	-GtkToolButton-icon-spacing: 4;
 	-textview-error-underline-color: @error_color;
 	-paned-handle-size: 5;
-	-checkbutton-indicator-size: 16;
-	-checkbutton-indicator-spacing: 0;
-	-GtkCheckMenuItem-indicator-size: 12;
 	-scrolledwindow-scrollbar-spacing: 0;
-	/* this is more stylish with this theme */
-	-scrolledwindow-scrollbars-within-bevel: 0;
+	/* this is more stylish with this theme */;
 	-GtkToolItemGroup-expander-size: 12;
 	-expander-expander-size: 12;
 	-treeview-expander-size: 13;
 	-treeview-horizontal-separator: 4;
-	-GtkMenuBar-shadow-type: none;
 	-GtkIMHtml-hyperlink-color: @link_color;
 	-GtkHTML-link-color: @link_color;
 	-WnckTasklist-fade-overlay-rect: 0;
@@ -2664,7 +2654,6 @@ assistant sidebar {
  * GtkSwitch*
  *************/
 switch{
-    -GtkSwitch-slider-width: 45px;
     font-weight: bold;
     font-size: smaller;
 	font: bold condensed;

--- a/desktop-themes/BlackMATE/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/BlackMATE/gtk-3.0/gtk-widgets.css
@@ -1,5 +1,5 @@
 * {
-	padding: 1px;
+	padding: 0px;
 	background-clip: padding-box;
 	/* Style properties */
 	-GtkButton-child-displacement-x: 1;
@@ -8,37 +8,32 @@
 	-GtkButton-image-spacing: 4;
 	-GtkButton-interior-focus: true;
 	-GtkToolButton-icon-spacing: 4;
-	-GtkTextView-error-underline-color: @error_color;
-	-GtkPaned-handle-size: 5;
-	-GtkCheckButton-indicator-size: 16;
-	-GtkCheckButton-indicator-spacing: 0;
+	-textview-error-underline-color: @error_color;
+	-paned-handle-size: 5;
+	-checkbutton-indicator-size: 16;
+	-checkbutton-indicator-spacing: 0;
 	-GtkCheckMenuItem-indicator-size: 12;
-	-GtkScrolledWindow-scrollbar-spacing: 0;
+	-scrolledwindow-scrollbar-spacing: 0;
 	/* this is more stylish with this theme */
-	-GtkScrolledWindow-scrollbars-within-bevel: 0;
+	-scrolledwindow-scrollbars-within-bevel: 0;
 	-GtkToolItemGroup-expander-size: 12;
-	-GtkExpander-expander-size: 12;
-	-GtkTreeView-expander-size: 13;
-	-GtkTreeView-horizontal-separator: 4;
+	-expander-expander-size: 12;
+	-treeview-expander-size: 13;
+	-treeview-horizontal-separator: 4;
 	-GtkMenuBar-shadow-type: none;
-	-GtkMenu-horizontal-padding: 0;
-	-GtkMenu-vertical-padding: 0;
 	-GtkIMHtml-hyperlink-color: @link_color;
 	-GtkHTML-link-color: @link_color;
-	-GtkWidget-wide-separators: true;
 	-WnckTasklist-fade-overlay-rect: 0;
 	/* this makes emacs behave weirdly */
 	/*border-radius: 3px;*/
-	-GtkWidget-focus-padding: 2;
 	/* disable focusline on active notebook tabs if focused*/
-	-GtkWidget-focus-line-width: 0;
 	-GtkWindow-resize-grip-width: 14;
 	-GtkWindow-resize-grip-height: 12; 
 	outline-color: @focus_border;
 	outline-style: dashed;
 	outline-offset: 2px;
 	outline-width: 0px; /* disable ugly focus-line */
-	/*-gtk-icon-style: regular; *//* no symbolic icons */
+	-gtk-icon-style: regular; /* no symbolic icons */
     text-shadow: none;
 }
 
@@ -55,7 +50,7 @@
 
 .background:backdrop {
 	text-shadow: none;
-	icon-shadow: none;
+	-gtk-icon-shadow: none;
 }
 
 *:hover {
@@ -75,10 +70,10 @@
 
 *:selected:backdrop {
 	text-shadow: none;
-	icon-shadow: none;
+	-gtk-icon-shadow: none;
 }
 
-*:insensitive {
+*:disabled {
 	background-color: @less_dark_color; /*@insensitive_bg_color;*/
 	color: @insensitive_fg_color;
 	border-color: @insensitive_border_color;
@@ -93,7 +88,7 @@
 	color: @theme_fg_color;
 }
 
-.gtkstyle-fallback:prelight {
+.gtkstyle-fallback:hover {
 	background-color: shade(@theme_bg_color, 1.10);
 	color: @theme_fg_color;
 }
@@ -103,7 +98,7 @@
 	color: @theme_fg_color;
 }
 
-.gtkstyle-fallback:insensitive {
+.gtkstyle-fallback:disabled {
 	background-color: @less_dark_color; /*@insensitive_bg_color;*/
 	color: @insensitive_fg_color;
 	border-color: @insensitive_border_color;
@@ -118,26 +113,32 @@
  * Tooltips *
  ************/
 
-.tooltip,
-.tooltip.background {
+tooltip,
+tooltip.background {
 	padding: 4px 4px;
-	border-style: none;
+	border-style: solid;
+	border-width: 2px;
 	border-radius: 3px;
+	border-color: #888a85; 
 	background-color: @theme_tooltip_bg_color;
 	color: @theme_tooltip_fg_color;
 }
 
-.tooltip * {
+tooltip * {
 	background-color: @theme_tooltip_bg_color;
 	color: @theme_tooltip_fg_color;
 }
+
 
 /*****************
  * Miscellaneous *
  *****************/
 
+content-view.view.rubberband,
 .content-view.view.rubberband,
+view.rubberband,
 .view.rubberband,
+rubberband,
 .rubberband {
 	background-color: alpha(@theme_selected_bg_color, 0.35);
 
@@ -147,80 +148,58 @@
 	border-radius: 2px;
 }
 
-GtkExpander {
+expander {
     -gtk-icon-style: regular;
 }
 
 /***********
  * Sidebar *
  ***********/
-
-.sidebar,
-.sidebar .view,
-GtkPlacesSidebar.sidebar .view {
+sidebar *,
+sidebar .view,
+placessidebar .view{
     -gtk-icon-style: regular;
     background-color: shade (@theme_bg_color, 1.08);
 }
 
-.sidebar .frame {
+placessidebar label   {
+	color:@theme_text_color;
+    padding: 8px 1px 8px 1px;
+}
+
+placessidebar image   {
+  -gtk-icon-style: regular;
+}
+
+sidebar frame {
     border-style: none;
 }
 
-.sidebar:backdrop {
+sidebar:backdrop {
     background-color: shade (@theme_bg_color, 1.08);
 }
 
-/* dialog open */
-GtkFileChooserWidget GtkPlacesSidebar.sidebar.frame .frame GtkListBox.sidebar.list,
-GtkFileChooserDialog GtkPlacesSidebar.sidebar.frame .frame GtkListBox.sidebar.list,
-GtkFileChooserWidget GtkPlacesSidebar.sidebar.frame .frame .sidebar.list .list-row.activatable.sidebar-row,
-GtkFileChooserDialog GtkPlacesSidebar.sidebar.frame .frame .sidebar.list .list-row.activatable.sidebar-row {
-    background-color: shade (@theme_bg_color, 1.08);
+placessidebar button{
+	background-color: transparent;
+	background-image: none;
+	border-style:none;
+	border-image:none;	
+}  
+
+placessidebar list row:selected, 
+placessidebar list row:active, 
+placessidebar list row:selected *,
+placessidebar list row:active *{
+	    background-image: linear-gradient(to bottom,
+	                                  shade(@theme_selected_bg_color,0.6 ),
+	                                  shade(@theme_selected_bg_color, 1.5));
 }
 
-GtkFileChooserWidget GtkPlacesSidebar.sidebar.frame .frame .sidebar.list .list-row.activatable.sidebar-row:selected,
-GtkFileChooserDialog GtkPlacesSidebar.sidebar.frame .frame .sidebar.list .list-row.activatable.sidebar-row:selected {
-	background-image: linear-gradient(to bottom,
-	                                  shade(@less_dark_color, 1.5),
-	                                  shade(@less_dark_color, 0.6));
-	color: @theme_text_color;
-	border-radius: 2px;
-}
-
-GtkFileChooserWidget GtkPlacesSidebar.sidebar.frame .frame .sidebar.list .list-row.activatable.sidebar-row:hover,
-GtkFileChooserDialog GtkPlacesSidebar.sidebar.frame .frame .sidebar.list .list-row.activatable.sidebar-row:hover {
-	background-color: alpha(@theme_selected_bg_color, 0.4);
-}
-
-GtkFileChooserWidget GtkPlacesSidebar.sidebar.frame .frame .sidebar.list .list-row.activatable.sidebar-row .sidebar-revealer .sidebar-icon,
-GtkFileChooserDialog GtkPlacesSidebar.sidebar.frame .frame .sidebar.list .list-row.activatable.sidebar-row .sidebar-revealer .sidebar-icon {
-    padding: 4px 8px 4px 6px;
-}
-
-GtkFileChooserWidget GtkPlacesSidebar.sidebar.frame .frame .sidebar.list .list-row.activatable.sidebar-row .sidebar-revealer .sidebar-label,
-GtkFileChooserDialog GtkPlacesSidebar.sidebar.frame .frame .sidebar.list .list-row.activatable.sidebar-row .sidebar-revealer .sidebar-label {
-    padding: 4px 0px 4px 1px;
-}
-
-GtkFileChooserWidget GtkPlacesSidebar.sidebar.frame .frame .sidebar.list .list-row.activatable.sidebar-row .sidebar-revealer .sidebar-button.image-button.button,
-GtkFileChooserDialog GtkPlacesSidebar.sidebar.frame .frame .sidebar.list .list-row.activatable.sidebar-row .sidebar-revealer .sidebar-button.image-button.button {
-    background-color: transparent;
-    background-image: none;
-    border-image:none;
-    border-width: 0px;
-    box-shadow: none;
-    padding: 4px 12px 4px 0px;
-}
-
-.sidebar.separator,
-.sidebar.separator:hover {
-	color: alpha(@frame_color, 0.6);
-}
 
 /****************
  * Floating Bar *
  ****************/
-.floating-bar {
+floating-bar {
 	border-radius: 3px;
 	border-width: 0px;
 	border-style: solid;
@@ -232,22 +211,22 @@ GtkFileChooserDialog GtkPlacesSidebar.sidebar.frame .frame .sidebar.list .list-r
 	                                  shade(@button_gradient_color_b, 0.7));
 }
 
-.floating-bar.top {
+floating-bar.top {
     border-top-right-radius: 0;
     border-top-left-radius: 0;
 }
 
-.floating-bar.right {
+floating-bar.right {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
 }
 
-.floating-bar.bottom {
+floating-bar.bottom {
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
 }
 
-.floating-bar.left {
+floating-bar.left {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
 }
@@ -255,56 +234,84 @@ GtkFileChooserDialog GtkPlacesSidebar.sidebar.frame .frame .sidebar.list .list-r
 /*********
  * Views *
  *********/
+
+view,
 .view,
-.view:insensitive {
+.view:disabled {
 	background-color: @less_dark_color;
 	color: @theme_selected_fg_color;
 	border-radius: 0;
 	/*border-width: 3;*/
 }
 
+view:selected,
+view:active, 
 .view:selected,
 .view:active {
 	background-color: shade(@theme_selected_bg_color, 1.23);
 	color: @theme_selected_fg_color;
 }
 
+view:selected:focus, 
 .view:selected:focus {
 	background-color: @theme_selected_bg_color;
 	color: @theme_selected_fg_color;
 }
 
 /* It's better not to have too bright text views. */
-GtkTextView.view,
-GtkTextView.view:insensitive,
+textview text,
+textview.view:disabled,
 GtkHTML { /* For Evolution (not enough; see entries section below) */
 	background-color: @view_color;
 	color: @theme_main_color;
 }
 
+textview text selection, textview text selection:focus {
+	background-color: @theme_selected_bg_color;
+}
+
 /* This is for highlighting the current line in source views. */
-GtkTextView {
+textview {
 	background-color: #D9D9D9; /* #dddddd; */
 	color: @theme_main_color;
 }
 
 /* Exceptional views */
-GtkCalendar.view,
-GtkIconView.view,
-GtkDialog .view {
+calendar.view,
+iconview.view,
+dialog .view,
+dialog view  {
 	background-color: @less_dark_color;
 	color: @theme_fg_color;
 }
 
+
+/****************************
+ * Caret for editable text *
+ ****************************/
+
+view, .view{
+	caret-color:#000000;
+}
+entry, .entry {
+	caret-color:#ffffff;
+}
+/*hide carot when window is not selected*/
+/*do NOT use .view to avoid creating caja desktop flashes*/
+/*works in gedit, pluma, etc*/
+
+view:backdrop, entry:backdrop, .entry:backdrop {
+	caret-color:transparent;
+}
 /**************
  * Separators *
  **************/
-GtkTreeView .separator,
-.separator {
+treeview separator,
+separator {
 	color: darker (@theme_bg_color);
 }
 
-.pane-separator {
+pane-separator {
 	border-style: none;
 	border-image: none;
 	border-width: 0px;
@@ -316,21 +323,21 @@ GtkTreeView .separator,
 	background-image: url("assets/pane-separator-grip.svg");
 }
 
-.pane-separator:hover,
-.pane-separator:selected {
+pane-separator:hover,
+pane-separator:selected {
 	background-image: url("assets/pane-separator-grip-hover.svg");
 }
 
-.pane-separator.vertical {
+pane-separator.vertical {
 	background-image: url("assets/pane-separator-grip-vertical.svg");
 }
 
-.pane-separator.vertical:hover,
-.pane-separator.vertical:selected {
+pane-separator.vertical:hover,
+pane-separator.vertical:selected {
 	background-image: url("assets/pane-separator-grip-vertical-hover.svg");
 }
 
-.dnd {
+dnd {
 	border-width: 1px;
 	border-style: solid;
 	border-color: @theme_selected_bg_color;
@@ -340,34 +347,28 @@ GtkTreeView .separator,
 /*********************
  * Spinner Animation *
  *********************/
-/* This is could be CPU-intensive */
+
+/*taken straight from Adwaita, it works */
 
 @keyframes spin {
-	to { -gtk-icon-transform: rotate(1turn); }
-}
-
-.spinner {
-	background-image: none;
-	background-color: blue;
+	to {
+    -gtk-icon-transform: rotate(1turn); } }
+spinner {
+	background: none;
 	opacity: 0;
-	-gtk-icon-source: -gtk-icontheme("process-working-symbolic");
-}
-
-.spinner:active {
+	/*remove icon, the default w/o it is more like gtk2 version was*/
+	/*-gtk-icon-source: -gtk-icontheme("process-working-symbolic"); */}
+spinner:checked {
 	opacity: 1;
-	animation: spin 1s linear infinite; }
-.spinner:active:insensitive {
-	opacity: 0.5;
-}
+    animation: spin 1s linear infinite; }
+    spinner:checked:disabled {
+	opacity: 0.5; }
 
-.button .spinner:active {
-	color: @theme_fg_color;
-}
 
 /****************
  * Text Entries *
  ****************/
-.entry {
+entry {
 	background-image: linear-gradient(to bottom,
 	                                  shade(@theme_bg_color, 0.2),
 	                                  shade(@theme_bg_color, 0.5) 10%,
@@ -383,28 +384,24 @@ GtkTreeView .separator,
 	            inset 0 -1px alpha(@entry_shadow, 0.07);
 }
 
-.toolbar .entry {
+toolbar entry {
 	background-image: linear-gradient(to bottom,
 	                                  shade(@theme_bg_color, 0.3),
 	                                  shade(@theme_bg_color, 1.1) 50%,
 	                                  mix(#ffffff, @theme_bg_color, 0.75));
 }
 
-.entry:selected {
-	background-color: @theme_selected_bg_color;
-}
-
-.entry:selected:focus {
+entry selection:focus  {
 	background-color: shade(@theme_selected_bg_color, 0.9);
 }
 
-.entry:focus {
+entry:focus {
 	border-image: none;
 	box-shadow: inset 0 -2px alpha(@entry_shadow, 0.05),
 	            inset 0 -1px alpha(@entry_shadow, 0.07);
 }
 
-.entry:insensitive {
+entry:disabled {
 	background-image: linear-gradient(to bottom,
 	                                  shade(@theme_bg_color, 0.8),
 	                                  shade(@theme_bg_color, 1.2));
@@ -415,8 +412,8 @@ GtkTreeView .separator,
 	box-shadow: none;
 }
 
-.entry.progressbar,
-.entry.progressbar:focus {
+entry progressbar,
+entry progressbar:focus {
 	margin-left: 2px;
 	margin-right: 2px;
 	border-image: none;
@@ -433,8 +430,8 @@ GtkTreeView .separator,
 	box-shadow: none;
 }
 
-.entry.progressbar.pulse,
-.entry.progressbar.pulse:focus {
+entry progressbar.pulse,
+entry progressbar.pulse:focus {
 	background-image: linear-gradient(to top, 
 	                                  transparent 2px,
 	                                  white 2px,
@@ -444,27 +441,27 @@ GtkTreeView .separator,
 	                                  transparent 5px);
 }
 
-.entry:active {
+entry:active {
 	background-color: shade(@theme_selected_bg_color, 1.23);
 }
 
 /* Correction for Yelp and Evolution */
-GtkTextView.entry,
+textview.entry,
 GtkHTML.entry {
 	background-color: @view_color;
 	color: @theme_main_color;
 }
 
-.entry.cursor-handle,
-.cursor-handle {
+entry.cursor-handle,
+cursor-handle {
 	background-color: transparent;
 	background-image: none;
 	box-shadow: none;
 	border-style: none;
 }
 
-.cursor-handle.top,
-.cursor-handle.bottom {
+cursor-handle.top,
+cursor-handle.bottom {
 	background-color:transparent;
 	box-shadow: none;
 	border-style: none;
@@ -472,12 +469,12 @@ GtkHTML.entry {
 	border-width: 0px;
 }
 
-.entry.cursor-handle.top,
-.cursor-handle.top {
+entry.cursor-handle.top,
+cursor-handle.top {
 	-gtk-icon-source: -gtk-icontheme("selection-start-symbolic");
 }
-.entry.cursor-handle.bottom,
-.cursor-handle.bottom {
+entry.cursor-handle.bottom,
+cursor-handle.bottom {
 	-gtk-icon-source: -gtk-icontheme("selection-end-symbolic");
 }
 
@@ -490,22 +487,21 @@ GtkHTML.entry {
 /****************
  * Progress bar *
  ****************/
-GtkProgressBar {
-	-GtkProgressBar-min-horizontal-bar-height: 16;
-	-GtkProgressBar-min-vertical-bar-width: 16;
+
+progressbar {
 	border-radius: 16px;
-	padding: 0px;
-	font-size: smaller;
+	border-style: none;
+/* Label font color of progressbar*/
+	color: @theme_text_color;
+	/*border-color: @progressbar_border;*/
 }
 
-.progressbar row,
-.progressbar row.view,
-.progressbar row:hover,
-.progressbar row:selected,
-.progressbar row:selected:focus {
-	border-image: none;
-	border-radius: 2px;
-	color: @theme_main_color;
+progressbar progress{   /*must define borders FIRST to stop drawing failures in Synaptic*/
+	min-height: 19px;
+	border-width: 1px; 
+	border-style:solid;
+	border-color:transparent;
+	border-radius: 3px;
 	background-image: linear-gradient(-45deg,
 	                                  alpha(@progressbar_pattern, 0.09),
 	                                  alpha(@progressbar_pattern, 0.09) 25%,
@@ -523,7 +519,12 @@ GtkProgressBar {
 	                                  shade(@progressbar_background_a, 0.91));
 }
 
-progressbar.vertical {
+progressbar.vertical progress{
+	min-width: 19px;
+	border-width: 1px; 
+	border-style:solid;
+	border-color:transparent;
+	border-radius: 3px;
 	background-image: linear-gradient(-135deg,
 	                                  alpha(@progressbar_pattern, 0.09),
 	                                  alpha(@progressbar_pattern, 0.09) 25%,
@@ -541,124 +542,101 @@ progressbar.vertical {
 	                                  shade(@progressbar_background_a, 0.91));
 }
 
-GtkProgressBar.progressbar {
-	background-image: linear-gradient(to bottom,
-	                                  @progressbar_background_a,
-	                                  shade(@progressbar_background_b, 1.1) 26%,
-	                                  @progressbar_background_b 47%,
-	                                  shade(@progressbar_background_b, 1.09) 48%,
-	                                  shade(@progressbar_background_a, 0.89));
+progressbar {
+	border-radius: 16px;
+	padding: 0px;
+	font-size: smaller;
 }
 
-GtkProgressBar.progressbar.vertical {
-	background-image: linear-gradient(to right,
-	                                  @progressbar_background_a,
-	                                  shade(@progressbar_background_b, 1.1) 26%,
-	                                  @progressbar_background_b 47%,
-	                                  shade(@progressbar_background_b, 1.09) 48%,
-	                                  shade(@progressbar_background_a, 0.89));
-}
-
-.trough row {
-	background-image: linear-gradient(to bottom,
-	                                  shade(@less_dark_color, 0.7),
-	                                  shade(@less_dark_color, 1.6));
-	border-width: 1px;
+progressbar trough {
+	min-height: 19px;
+	border-width: 0px;
 	border-style: solid;
-	border-radius: 2px;
-	/*border-color: shade(@theme_selected_bg_color, 1.6);*/
-	border-color: shade(@theme_bg_color, 1.4);
-	padding: 1px;
+	background-image: linear-gradient(to bottom,
+	                                  shade(@theme_bg_color, 0.4),
+	                                  @theme_bg_color 50%,
+	                                  shade(@theme_bg_color, 1.8));
+
 }
 
-.trough row:selected,
-.trough row:selected:focus {
+progressbar.vertical trough{
+	min-width: 19px;
+	border-width: 0px;
+	border-style: solid;
+	background-image: linear-gradient(to right,
+	                                  shade(@theme_bg_color, 0.4),
+	                                  @theme_bg_color 50%,
+	                                  shade(@theme_bg_color, 1.8));
+}
+
+progressbar trough:selected,
+progressbar trough:selected:focus {
 	border-image: none;
 }
 
-GtkProgressBar.progressbar {
-	border-radius: 16px;
-	border-style: none;
-/* Label font color of progressbar*/
-	color: @theme_text_color;
-	/*border-color: @progressbar_border;*/
-}
 
-GtkProgressBar.trough {
-	background-image: linear-gradient(to bottom,
-	                                  shade(@theme_bg_color, 0.4),
-	                                  @theme_bg_color 50%,
-	                                  shade(@theme_bg_color, 1.8));
-	border-width: 0px;
-	border-style: solid;
-	border-radius: 16px;
-}
-
-GtkProgressBar.trough.vertical {
-	background-image: linear-gradient(to right,
-	                                  shade(@theme_bg_color, 0.4),
-	                                  @theme_bg_color 50%,
-	                                  shade(@theme_bg_color, 1.8));
-}
 
 /**********
  * Frames *
  **********/
-GtkFrame,
-GtkCalendar {
+frame,
+calendar {
 	padding: 2px;
 }
 
-.frame {
+.frame,
+frame {
 	color: lighter (@theme_fg_color);
 	border-style: solid;
 	border-width: 1px;
 	border-color: alpha(@frame_color, 0.6);
-	padding: 2px;
+	padding: 0px;
 	border-radius: 3px;
 }
 
-.frame.flat {
+.frame.flat
+frame.flat {
 	border-style: none;
 }
 
-.frame.action-bar {
+.frame.action-bar
+frame.action-bar {
 	padding: 6px;
 	border-width: 1px 0 0;
 }
 
 /* disable for GTK3-3.16 , issue with caja list-view frame*/
 
-GtkScrolledWindow.frame {
+scrolledwindow.frame {
 /*	background-color: transparent; */
     -gtk-icon-style: regular;
 }
 
 /* no double frames */
-GtkScrolledWindow GtkViewport.frame {
+scrolledwindow viewport.frame {
 	border-style: none;
 }
 
 /***************
- * GtkLevelBar *
+ * levelbar *
  ***************/
-GtkLevelBar {
-	-GtkLevelBar-min-block-width: 34;
-	-GtkLevelBar-min-block-height: 3;
+levelbar {
+	-levelbar-min-block-width: 34;
+	-levelbar-min-block-height: 3;
 
 	background-color: transparent;
 }
 
-GtkLevelBar.vertical {
-	-GtkLevelBar-min-block-width: 3;
-	-GtkLevelBar-min-block-height: 34;
+levelbar.vertical {
+	-levelbar-min-block-width: 3;
+	-levelbar-min-block-height: 34;
 }
 
-.level-bar.trough {
+level-bar.trough {
 	padding: 2px;
 }
 
-.level-bar.fill-block {
+level-bar.fill-block {
 	border-width: 1px;
 	border-style: solid;
 	border-color: @progressbar_border;
@@ -667,32 +645,32 @@ GtkLevelBar.vertical {
 	                                  shade(@link_color, 0.6));
 }
 
-.level-bar.indicator-continuous.fill-block {
+level-bar.indicator-continuous.fill-block {
 	padding: 2px;
 	border-radius: 2px;
 }
 
-.level-bar.indicator-discrete.fill-block.horizontal {
+level-bar.indicator-discrete.fill-block.horizontal {
 	margin: 0 1px;
 }
 
-.level-bar.indicator-discrete.fill-block.vertical {
+level-bar.indicator-discrete.fill-block.vertical {
 	margin: 1px 0;
 }
 
-.level-bar.fill-block.level-high {
+level-bar.fill-block.level-high {
 	background-image: linear-gradient(to bottom,
 	                                  shade(@link_color, 1.2),
 	                                  shade(@link_color, 0.7));
 }
 
-.level-bar.fill-block.level-low {
+level-bar.fill-block.level-low {
 	background-image: linear-gradient(to bottom,
 	                                  shade(@warning_bg_color, 1.2),
 	                                  shade(@warning_bg_color, 0.7));
 }
 
-.level-bar.fill-block.empty-fill-block {
+level-bar.fill-block.empty-fill-block {
 	background-color: transparent;
 	background-image: linear-gradient(to bottom,
 					shade(@less_dark_color, 0.5),
@@ -702,13 +680,13 @@ GtkLevelBar.vertical {
 /*************
  * Notebooks *
  *************/
-GtkNotebook {
+notebook {
 	background-color: transparent;
 	border-radius: 3px;
 }
 
-/* gtk-3.12 */
-.notebook.header {
+
+notebook header {
 	background-image: none;
 	background-color: transparent;
 	border-style: none;
@@ -716,7 +694,8 @@ GtkNotebook {
     border-width: 0px;
 }
 
-.notebook {
+notebook,
+notebook {
 	padding: 1px 0px 1px 1px;
 	background-color: @less_dark_color;
 	/*background-clip: border-box;*/
@@ -725,20 +704,13 @@ GtkNotebook {
 	border-style: solid;
 	border-width: 0px 1px 0px 1px;
 
-	-GtkNotebook-tab-overlap: 1;
-	-GtkNotebook-tab-curvature: 0;
-	-GtkNotebook-initial-gap: 0;
-	-GtkNotebook-has-tab-gap: false;
-	-GtkWidget-focus-padding: 2;
-	-GtkWidget-focus-line-width: 0;
 }
 
-.notebook.arrow:insensitive {
+notebook.arrow:disabled {
 	color: transparent;
 }
 
-.notebook tab {
-	padding: 3px 8px 0px;
+notebook tab {
 	border-style: solid;
 	border-width: 1px 1px 0px 1px;
 	border-color: shade(@less_dark_color, 0.75);
@@ -747,7 +719,7 @@ GtkNotebook {
 	                                  shade(@less_dark_color, 0.5));
 }
 
-.notebook tab:active {
+notebook tab:active {
 	background-image: linear-gradient(to bottom,
 	                                  shade(@less_dark_color, 0.75),
 	                                  shade(@less_dark_color, 0.86) 40%,
@@ -755,17 +727,22 @@ GtkNotebook {
 	                                  @less_dark_color);
 }
 
-.notebook tab.top
-.notebook tab.top:active {
-	/* top right-left bottom */
-	padding: 3px 8px 0px;
+/*Keep pluma (etc) tabs from jumping when saving */
+notebook header tab image,
+notebook header tab spinner{
+	padding: 0px;
 }
 
-.notebook tab.bottom {
+notebook header.top tab label{
+	/* top right-left bottom */
+	padding: 5px 8px 5px;
+}
+
+notebook header.bottom tab label{
 	padding: 0px 8px 3px;
 }
 
-.notebook tab.bottom:active {
+notebook header.bottom tab:active {
    padding: 0px 8px 3px;
 	background-image: linear-gradient(to top,
 	                                  shade(@less_dark_color, 1.25),
@@ -774,35 +751,32 @@ GtkNotebook {
 	                                  @less_dark_color);
 }
 
-.notebook tab.bottom,
-.notebook tab.bottom:active {
+notebook header.bottom tab{
 	border-radius: 0px 0px 3px 3px;
 	border-width: 0px 1px 1px 1px;
 }
 
-.notebook tab.left,
-.notebook tab.left:active {
+notebook header.left tab label{
 	border-radius: 3px 0px 0px 3px;
 	padding: 2px 4px 2px;
 	border-width: 1px 0px 1px 1px;
 }
 
-.notebook tab.right,
-.notebook tab.right:active {
+notebook header.right tab label{
 	border-radius: 0px 3px 3px 0px;
 	padding: 2px 4px 2px;
 	border-width: 1px 1px 1px 0px;
 }
 
-.notebook tab.left:active,
-.notebook tab.right:active {
+notebook header.left tab:active,
+notebook header.right tab:active {
 	background-image: none;
 	background-color: @less_dark_color;
 }
 
-.notebook tab .button,
-.notebook tab .button:hover,
-.notebook tab .button:hover:active {
+notebook tab  button,
+notebook tab  button:hover,
+notebook tab  button:hover:active {
 	border-style: none;
 	border-image: none;
 	border-radius: 5px;
@@ -814,23 +788,23 @@ GtkNotebook {
 
 /*** The contents of notebooks ***/
 
-.notebook GtkViewport,
-.notebook GtkIconView,
-.notebook GtkDrawingArea,
-.notebook GtkPaned,
-.notebook GtkEventBox,
-.notebook GtkFrame {
+notebook viewport,
+notebook iconview,
+/*notebook GtkDrawingArea,*//*no longer recognized by gtk3.20*/
+notebook paned,
+notebook GtkEventBox,
+notebook frame {
 	background-color: @less_dark_color;
 }
 
-.notebook .button {
+notebook  button {
 	background-image: linear-gradient(to bottom,
 	                                  shade(@less_dark_color, 1.3),
 	                                  shade(@less_dark_color, 0.4));
 	border-color: shade(@button_border, 1.4);
 }
 
-.notebook .button:hover {
+notebook  button:hover {
 	background-image: -gtk-gradient (radial,
 					0.5 -2.0, 2.0,
 					0.5 -2.0, 3.0,
@@ -843,22 +817,22 @@ GtkNotebook {
 	border-image: url("assets/button-border-dark1.svg") 3 / 3px stretch;
 }
 
-.notebook .button:checked,
-.notebook .button:hover:checked,
-.notebook .button:active,
-.notebook .button:hover:active {
+notebook  button:checked,
+notebook  button:hover:checked,
+notebook  button:active,
+notebook  button:hover:active {
 	border-image: url("assets/button-active-border-dark1.svg") 3 / 3px stretch;
 }
 
-.notebook .toolbar,
-.notebook .inline-toolbar.toolbar {
+notebook  toolbar,
+notebook  inline-toolbar toolbar {
 	background-image: linear-gradient(to bottom,
 	                                  shade(@less_dark_color, 0.4),
 	                                  shade(@less_dark_color, 1.36));
 	border-color: alpha(@light_frame_color, 0.6); /*shade(@less_dark_color, 0.8);*/
 }
 
-.notebook .entry {
+notebook .entry {
 	background-image: linear-gradient(to bottom,
 	                                  shade(@less_dark_color, 0.2),
 	                                  shade(@less_dark_color, 0.5) 10%,
@@ -869,39 +843,39 @@ GtkNotebook {
 	            inset 0 -1px alpha(@entry_shadow, 0.06);
 }
 
-.notebook .entry:focus {
+notebook .entry:focus {
 	border-color: shade(@less_dark_color, 1.4);
 	box-shadow: inset 0 -2px alpha(@entry_shadow, 0.04),
 	            inset 0 -1px alpha(@entry_shadow, 0.06);
 }
 
-.notebook .entry:insensitive {
+notebook .entry:disabled {
 	background-image: linear-gradient(to bottom,
 	                                  shade(@less_dark_color, 0.8),
 	                                  shade(@less_dark_color, 1.2));
 }
 
-.notebook .toolbar .entry {
+notebook  toolbar .entry {
 	background-image: linear-gradient(to bottom,
 	                                  shade(@less_dark_color, 0.3),
 	                                  shade(@less_dark_color, 1.1) 50%,
 	                                  mix(#ffffff, @less_dark_color, 0.75));
 }
 
-.notebook GtkSpinButton.button,
-.notebook GtkSpinButton.button:insensitive,
-.notebook GtkSpinButton.button:hover,
-.notebook GtkSpinButton.button:active,
-.notebook GtkSpinButton.button:focus {
+notebook GtkSpinButton button,
+notebook GtkSpinButton button:disabled,
+notebook GtkSpinButton button:hover,
+notebook GtkSpinButton button:active,
+notebook GtkSpinButton button:focus {
 	background-image: none;
 	background-color: transparent;
 	border-style: none;
 	border-image: none;
 }
 
-.notebook .scrollbar.button,
-.notebook .scrollbar.button.horizontal,
-.notebook .scrollbar.button.vertical {
+notebook  scrollbar button,
+notebook  scrollbar button.horizontal,
+notebook  scrollbar button.vertical {
 	border-image: none;
 	border-style: none;
 	border-width: 0px;
@@ -909,26 +883,26 @@ GtkNotebook {
 	background-color: transparent;
 }
 
-.notebook .scrollbar.button:hover,
-.notebook .scrollbar.button.horizontal:hover,
-.notebook .scrollbar.button.vertical:hover,
-.notebook .scrollbar.button:hover:active,
-.notebook .scrollbar.button.horizontal:hover:active,
-.notebook .scrollbar.button.vertical:hover:active {
+notebook  scrollbar button:hover,
+notebook  scrollbar button.horizontal:hover,
+notebook  scrollbar button.vertical:hover,
+notebook  scrollbar button:hover:active,
+notebook  scrollbar button.horizontal:hover:active,
+notebook  scrollbar button.vertical:hover:active {
 	border-image: none;
 	border-style: none;
 	border-width: 0px;
 }
 
-.notebook .scrollbar.slider:prelight,
-.notebook .scrollbar.slider:prelight:active,
-.notebook .scrollbar.slider.vertical:prelight,
-.notebook .scrollbar.slider.vertical:prelight:active {
+notebook  scrollbar slider:hover,
+notebook  scrollbar slider:hover:active,
+notebook  scrollbar slider.vertical:hover,
+notebook  scrollbar slider.vertical:hover:active {
 	border-color: shade(@scroll_slider_color, 1.1);
 }
 
-.notebook column-header .button,
-.notebook column-header .button:hover {
+notebook column-header  button,
+notebook column-header  button:hover {
 	border-image: none;
 	border-width: 0px 0px 1px 1px;
 	border-radius: 0;
@@ -936,146 +910,133 @@ GtkNotebook {
 	border-color: @less_dark_color;
 }
 
-.notebook GtkScale.trough {
+notebook GtkScale.trough {
 	background-image: linear-gradient(to bottom,
 					shade(@less_dark_color, 0.5),
 					shade(@less_dark_color, 1.7));
 	border-width: 0px;
 }
 
-.notebook GtkScale.trough.vertical {
+notebook GtkScale.trough.vertical {
 	background-image: linear-gradient(to right,
 	                                  shade(@less_dark_color, 0.5),
 	                                  shade(@less_dark_color, 1.7));
 }
 
-.notebook GtkScale.trough:insensitive {
+notebook GtkScale.trough:disabled {
 	background-image: linear-gradient(to bottom,
 	                                  shade(@less_dark_color, 0.85),
 	                                  shade(@less_dark_color, 1.4));
 }
 
-.notebook GtkScale.trough.vertical:insensitive {
+notebook GtkScale.trough.vertical:disabled {
 	background-image: linear-gradient(to right,
 	                                  shade(@less_dark_color, 0.85),
 	                                  shade(@less_dark_color, 1.4));
 }
 
-.notebook GtkProgressBar.trough {
+notebook progressbar.trough {
 	background-image: linear-gradient(to bottom,
 	                                  shade(@less_dark_color, 0.4),
 	                                  @less_dark_color 50%,
 	                                  shade(@less_dark_color, 1.8));
 }
 
-.notebook GtkProgressBar.trough.vertical {
+notebook progressbar.trough.vertical {
 	background-image: linear-gradient(to right,
 	                                  shade(@less_dark_color, 0.4),
 	                                  @less_dark_color 50%,
 	                                  shade(@less_dark_color, 1.8));
 }
 
-.notebook .pane-separator {
+notebook .pane-separator {
 	color: shade(@theme_selected_bg_color, 2.0);
 	background-repeat: no-repeat;
 	background-position: center;
 	background-image: url("assets/notebook-pane-separator-grip.svg");
 }
 
-.notebook .pane-separator:hover,
-.notebook .pane-separator:selected {
+notebook .pane-separator:hover,
+notebook .pane-separator:selected {
 	background-image: url("assets/notebook-pane-separator-grip-hover.svg");
 }
 
-.notebook .pane-separator.vertical {
+notebook .pane-separator.vertical {
 	background-image: url("assets/notebook-pane-separator-grip-vertical.svg");
 }
 
-.notebook .pane-separator.vertical:hover,
-.notebook .pane-separator.vertical:selected {
+notebook .pane-separator.vertical:hover,
+notebook .pane-separator.vertical:selected {
 	background-image: url("assets/notebook-pane-separator-grip-vertical-hover.svg");
 }
 
-.notebook .sidebar.separator,
-.notebook .sidebar.separator:hover {
+notebook .sidebar.separator,
+notebook .sidebar.separator:hover {
 	color: alpha(@light_frame_color, 0.6);
 }
 
-.notebook .frame {
+notebook .frame {
 	border-color: alpha(@light_frame_color, 0.6);
 }
 
 /***************
- * GtkTreeView *
+ * treeview *
  ***************/
-GtkTreeView {
+treeview {
 	background-color: @less_dark_color;
-	-GtkWidget-wide-separators: false; /* avoid padding issue in file-chooser open */
-	-GtkTreeView-vertical-separator: 0;
-	-GtkWidget-focus-padding: 1;
+	-treeview-vertical-separator: 0;
 }
 
-GtkTreeView.view,
-GtkTreeView.view:insensitive {
+treeview.view,
+treeview.view:disabled {
 	background-color: @less_dark_color;
 	color: @theme_fg_color;
 }
 
-GtkTreeView .view {
+treeview .view {
 	color: @theme_fg_color;
 }
 
 /* row as a separator */
-GtkTreeView.view.separator,
-GtkTreeView.view.separator:hover {
+treeview.view.separator,
+treeview.view.separator:hover {
 	color: alpha(@light_frame_color, 0.6);
 }
 
-GtkTreeView row:hover,
-.notebook GtkContainer GtkTreeView row:hover {
+treeview:hover,
+notebook container treeview:hover {
 	background-color: alpha(@theme_selected_bg_color, 0.4);
 }
-
-GtkTreeView row:selected,
-GtkTreeView row:selected:focus {
+treeview:active,
+treeview:selected,
+treeview:selected:focus {
     background-image: linear-gradient(to bottom,
-	                                  shade(@less_dark_color, 1.5),
-	                                  shade(@less_dark_color, 0.6));
+	                                  shade(@theme_selected_bg_color,0.6 ),
+	                                  shade(@theme_selected_bg_color, 1.5));
 }
 
-/* this breaks GtkTreeView row:hover with gtk3.18 !
-GtkTreeView row:nth-child(odd),
-GtkTreeView row:nth-child(odd):hover {
+/* Rows are no longer recognized in gtk3.20!
+treeview row:nth-child(odd),
+treeview row:nth-child(odd):hover {
 	background-color: @less_dark_color;
 }
 
-GtkTreeView row:nth-child(even),
-GtkTreeView row:nth-child(even):hover {
+treeview row:nth-child(even),
+treeview row:nth-child(even):hover {
 	background-color: shade(@less_dark_color, 1.05);
 }
 */
 
-GtkTreeView row:nth-child(odd):insensitive,
-GtkTreeView row:nth-child(even):insensitive {
+treeview:disabled{
 	color: @insensitive_fg_color;
-}
-
-GtkTreeView column:sorted row:nth-child(odd),
-GtkTreeView column:sorted row:nth-child(odd):hover {
-	background-color: shade(@less_dark_color, 0.85);
-}
-
-GtkTreeView column:sorted row:nth-child(even),
-GtkTreeView column:sorted row:nth-child(even):hover {
-	background-color: shade(@less_dark_color, 0.9);
 }
 
 column-header {
 	padding: 1px 2px;
 }
 
-column-header .button,
-GtkTreeView .button {
+column-header  button,
+treeview  button {
 	border-image: none;
 	border-width: 0px 0px 1px 1px;
 	border-radius: 0;
@@ -1083,20 +1044,20 @@ GtkTreeView .button {
 	border-color: @less_dark_color;
 }
 
-column-header .button {
+column-header  button {
 	background-image: linear-gradient(to bottom,
 	                                  shade(@less_dark_color, 1.3),
 	                                  shade(@less_dark_color, 0.4));
 }
 
-GtkTreeView .button {
+treeview  button {
 	background-image: linear-gradient(to bottom,
 	                                  shade(@less_dark_color, 1.3),
 	                                  shade(@less_dark_color, 0.4));
 }
 
-column-header .button:hover,
-GtkTreeView .button:hover {
+column-header  button:hover,
+treeview  button:hover {
 	border-image: none;
 	border-width: 0px 0px 1px 1px;
 	border-radius: 0;
@@ -1113,25 +1074,25 @@ row {
 	border-width: 0px;
 }
 
-.list-row {
+ list-row {
     transition: all 400ms ease-out;
 }
 
-.list-row.activatable {
+ list-row.activatable {
     background-image: none;
     border-image: none;
     border-color: transparent
 }
 
-.list-row.activatable:selected,
-.list-row.activatable:selected:hover {
+ list-row.activatable:selected,
+ list-row.activatable:selected:hover {
     background-color: transparent;
     background-image: linear-gradient(to bottom,
                                       @button_gradient_color_a,
                                       @button_gradient_color_b);
 }
 
-.list-row.activatable:hover {
+ list-row.activatable:hover {
     background-color: transparent;
     background-image: linear-gradient(to bottom,
 	                                  @button_hover_gradient_color_a,
@@ -1146,37 +1107,38 @@ row {
 /************
  * GtkScale *
  ************/
-.scale {
+ scale {
 	-GtkScale-slider-length: 16;
 	-GtkRange-slider-width: 20;
 	-GtkRange-trough-border: 0;
 }
 
-.scale.slider,
-.scale.slider:hover {
+ scale slider,
+ scale slider:hover {
 	border-width: 0px;
 	border-radius: 0px;
 	border-style: none;
+	color: transparent;
+	background-color: transparent;
+	background-repeat: no-repeat;
+	background-position: center;
+}
 
+scale slider:disabled {
 	color: transparent;
 	background-color: transparent;
 }
 
-.scale.slider:insensitive {
-	color: transparent;
-	background-color: transparent;
-}
-
-.scale.slider.fine-tune:active,
-.scale.slider.fine-tune:active:hover,
-.scale.slider.fine-tune.horizontal:active,
-.scale.slider.fine-tune.horizontal:active:hover {
+scale slider.fine-tune:active,
+scale slider.fine-tune:active:hover,
+scale slider.fine-tune.horizontal:active,
+scale slider.fine-tune.horizontal:active:hover {
 	background-size: 80%;
 	background-repeat: no-repeat;
 	background-position: center;
 }
 
-.scale.trough {
+scale trough {
 	background-image: linear-gradient(to bottom,
 	                                  shade(@theme_bg_color, 0.5),
 	                                  shade(@theme_bg_color, 1.7));
@@ -1185,46 +1147,46 @@ row {
 	margin: 8px 0;
 }
 
-.scale.trough.vertical {
+scale.vertical trough {
 	background-image: linear-gradient(to right,
 	                                  shade(@theme_bg_color, 0.5),
 	                                  shade(@theme_bg_color, 1.7));
 	margin: 0 8px;
 }
 
-.scale.trough.highlight,
-.scale.trough.highlight.vertical {
+scale.highlight trough
+scale.highlight.vertical trough {
     background-image: none;
 	border-color: @progressbar_border;
 	background-color: @link_color;
 }
 
-.scale.trough:insensitive {
+ scale:disabled trough {
 	background-image: linear-gradient(to bottom,
 	                                  shade(@theme_bg_color, 0.85),
 	                                  shade(@theme_bg_color, 1.4));
 }
 
-.scale.trough.vertical:insensitive {
+ scale.vertical:disabled trough {
 	background-image: linear-gradient(to right,
 	                                  shade(@theme_bg_color, 0.85),
 	                                  shade(@theme_bg_color, 1.4));
 }
 
-.scale.progressbar {
+ scale progressbar {
 	background-image: linear-gradient(to bottom,
 	                                  shade(@theme_bg_color, 1.4),
 	                                  shade(@theme_bg_color, 0.8));
 	border-radius: 3px;
 }
 
-.scale.progressbar.vertical {
+ scale.vertical progressbar {
 	background-image: linear-gradient(to right,
 	                                  shade(@theme_bg_color, 1.4),
 	                                  shade(@theme_bg_color, 0.8));
 }
 
-.scale.mark {
+ scale mark {
 	background-color: shade(@theme_bg_color, 0.56);
 }
 
@@ -1232,27 +1194,26 @@ row {
  * ComboBoxes *
  **************/
 
-GtkComboBox {
+combobox{
 	/* align with side buttons */
 	padding: 0;
-	-GtkComboBox-arrow-scaling: 0.5;
 	-GtkComboBox-shadow-type: none;
 	color: @theme_fg_color;
 	text-shadow: none;
 }
 
-GtkComboBox .separator {
+combobox.separator {
     /* always disable separators */
     -GtkWidget-horizontal-separator: 0;
     -GtkWidget-vertical-separator: 0;
 }
 
 /* since gtk+-3.18, avoid flat text background */
-GtkComboBox .button GtkCellView {
+combobox button GtkCellView {
     background-color: transparent;
 }
 
-GtkComboBox .button {
+combobox button {
 	padding: 0px 3px;
 	/* These buttons may be wide. */
 	background-image: linear-gradient(to bottom,
@@ -1260,7 +1221,7 @@ GtkComboBox .button {
 	                                  @button_hover_gradient_color_b);
 }
 
-GtkComboBox .button:hover {
+combobox button:hover {
 	/* These buttons may be wide. */
 	background-image: linear-gradient(to bottom,
 	                                  shade(@button_gradient_color_a, 1.5),
@@ -1269,22 +1230,21 @@ GtkComboBox .button:hover {
 	                                  shade(@button_gradient_color_b, 0.7));
 }
 
-GtkComboBox.combobox-entry .button {
+GtkComboBox.combobox-entry  button {
 	padding: 0px;
 }
 
 /* compensation for combo shadow */
-/*GtkTreeMenu .menuitem *,*/
-GtkComboBox .menu {
+/*GtkTreeMenu  menuitem *,*/
+combobox menu {
 	text-shadow: none;
 }
 
 /***********
  * Buttons *
  ***********/
-.button {
+button {
     -gtk-icon-style: regular;
-    -GtkWidget-focus-line-width: 0;
     padding: 0px;
     border-radius: 3px;
     border-width: 1px;
@@ -1297,20 +1257,21 @@ GtkComboBox .menu {
     transition: all 400ms ease-out;
 }
 
-.button.text-button,
-GtkFontButton.button,
-GtkFileChooserButton .button {
+button.text-button,
+fontbutton button,
+filechooser  button {
     padding: 3px;
 }
 
-.button.default {
+button.default {
     transition: all 400ms ease-out;
     text-shadow: none;
     color: @theme_fg_color;
+	padding: 1px;
 }
 
 /* ie. mate-control-center */
-.button.flat {
+button.flat {
     transition: all 400ms ease-out;
     padding: 0px;
     border-color: transparent;
@@ -1318,15 +1279,15 @@ GtkFileChooserButton .button {
     background-image: none;
     box-shadow: inset 0 1px rgba(255,255,255,0), 0 1px rgba(255,255,255,0);
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     border-image: none;
 }
 
-.button.flat:hover {
+button.flat:hover {
     border-radius: 3px;
 }
 
-.button.image-button.circular-button {
+button.image-button.circular-button {
    border-image: none;
    border-width: 1px;
    border-style: solid;
@@ -1336,31 +1297,31 @@ GtkFileChooserButton .button {
 }
 
 /* ie. controls gnome-mplayer, virtual-manager */
-.button.flat.image-button,
-.button.flat.image-button:hover,
-GtkVolumeButton.button.flat {
+button.flat.image-button,
+button.flat.image-button:hover,
+GtkVolumeButton button.flat {
 	padding: 4px;
 }
 
-.button GtkImage,
-.button GtkImage:hover,
-.button GtkImage:checked,
-.button GtkImage:hover:checked,
-.button GtkImage:active,
-.button GtkImage:hover:active,
-.button GtkImage:insensitive,
-.button GtkLabel,
-.button GtkLabel:hover,
-.button GtkLabel:checked,
-.button GtkLabel:hover:checked,
-.button GtkLabel:active,
-.button GtkLabel:hover:active,
-.button GtkLabel:insensitive {
+button image,
+button image:hover,
+button image:checked,
+button image:hover:checked,
+button image:active,
+button image:hover:active,
+button image:disabled,
+button label,
+button label:hover,
+button label:checked,
+button label:hover:checked,
+button label:active,
+button label:hover:active,
+button label:disabled {
 	background-image: none;
 	background-color: transparent;
 }
 
-.button:hover {
+button:hover {
 	border-image: none;
 	border-style: solid;
 	border-color: shade(@button_border, 1.1);
@@ -1373,10 +1334,10 @@ GtkVolumeButton.button.flat {
 					to (shade(@button_gradient_color_b, 0.7)));
 }
 
-.button:checked,
-.button:hover:checked,
-.button:active,
-.button:hover:active {
+button:checked,
+button:hover:checked,
+button:active,
+button:hover:active {
 	/* some apps need this */
 	color: @theme_fg_color;
 	border-style: solid;
@@ -1386,7 +1347,7 @@ GtkVolumeButton.button.flat {
 	                                  shade(@button_gradient_color_a, 1.5));
 }
 
-.button:insensitive {
+button:disabled {
 	background-color: transparent;
 	background-image: linear-gradient(to bottom,
 	                                  alpha(@button_gradient_color_a, 0.5),
@@ -1397,7 +1358,7 @@ GtkVolumeButton.button.flat {
 	color: @insensitive_fg_color;
 }
 
-.button:active:insensitive {
+button:active:disabled {
 	background-color: transparent;
 	background-image: linear-gradient(to bottom,
 	                                  alpha(@button_gradient_color_b, 0.6),
@@ -1408,8 +1369,8 @@ GtkVolumeButton.button.flat {
 	color: @insensitive_fg_color;
 }
 
-GtkFontButton.button,
-GtkColorButton.button {
+fontbutton button,
+colorbutton button {
     padding: 4px 3px;
 }
 
@@ -1422,11 +1383,11 @@ GtkColorButton.button {
 /*****************
  * GtkSpinButton *
  *****************/
-.spinbutton .button,
-.spinbutton .button:insensitive,
-.spinbutton .button:hover,
-.spinbutton .button:active,
-.spinbutton .button:focus {
+spinbutton button,
+spinbutton button:disabled,
+spinbutton button:hover,
+spinbutton button:active,
+ pinbutton button:focus {
 	background-image: none;
 	background-color: transparent;
 	/*border-width: 1px;*/
@@ -1435,17 +1396,17 @@ GtkColorButton.button {
 	padding: 0px 4px 0px 0px;
 }
 
-.spinbutton .button,
-.spinbutton .button:focus {
+spinbutton button,
+spinbutton button:focus {
 	color: shade(@insensitive_fg_color, 1.1);
 }
 
-.spinbutton .button:hover,
-.spinbutton .button:active {
+spinbutton button:hover,
+spinbutton button:active {
 	color: @theme_text_color;
 }
 
-.spinbutton .button:insensitive {
+spinbutton button:disabled {
 	color: shade(@insensitive_fg_color, 0.7);
 }
 
@@ -1455,10 +1416,10 @@ GtkColorButton.button {
   color: @link_color;
 }
 
-GtkLinkButton.button,
-GtkLinkButton.button:hover,
-GtkLinkButton.button:active,
-GtkLinkButton.button:active:hover {
+linkbutton button,
+linkbutton button:hover,
+linkbutton button:active,
+linkbutton button:active:hover {
     transition: all 400ms ease-in;
     text-shadow: none;
 }
@@ -1466,7 +1427,7 @@ GtkLinkButton.button:active:hover {
 /**************
  * Scrollbars *
  **************/
-.scrollbar {
+scrollbar {
 	background-image: none;
 	border-style: solid;
 	-GtkRange-trough-border: 0;
@@ -1474,12 +1435,12 @@ GtkLinkButton.button:active:hover {
 	-GtkScrollbar-has-forward-stepper: true;
 	-GtkRange-stepper-size: 16;
 	-GtkRange-slider-width: 13;
-	-GtkScrollbar-min-slider-length: 42; /* minimum size for the slider. sadly can't be in '.slider' where it belongs */
+	-GtkScrollbar-min-slider-length: 42; /* minimum size for the slider. sadly can't be in ' slider' where it belongs */
 	-GtkRange-stepper-spacing: 0;
 	-GtkRange-trough-under-steppers: 1;
 }
 
-.scrollbars-junction { /* the small square between scrollbars!!! */
+scrollbars-junction { /* the small square between scrollbars!!! */
     background-image: none;
     background-color: @less_dark_color;
     border-width: 0;
@@ -1488,8 +1449,8 @@ GtkLinkButton.button:active:hover {
     box-shadow: none;
 }
 
-.scrollbar.trough,
-.scrollbar.trough.vertical {
+scrollbar trough,
+scrollbar.vertical trough {
 	background-image: linear-gradient(to right,
 		@scrollbar_trough,
 		shade (@scrollbar_trough, 1.08));
@@ -1500,7 +1461,7 @@ GtkLinkButton.button:active:hover {
 	border-image: none;
 }
 
-.scrollbar.trough.horizontal {
+scrollbar.horizontal trough {
 	background-image: linear-gradient(to bottom,
 		@scrollbar_trough,
 		shade (@scrollbar_trough, 1.08));
@@ -1511,9 +1472,9 @@ GtkLinkButton.button:active:hover {
 	border-image: none;
 }
 
-.scrollbar.button,
-.scrollbar.button.horizontal,
-.scrollbar.button.vertical {
+scrollbar button,
+scrollbar.horizontal buttonl,
+scrollbar.vertical button {
 	color: @theme_fg_color; /*@internal_element_color*/
 	border-image: none;
 	border-style: none;
@@ -1522,9 +1483,9 @@ GtkLinkButton.button:active:hover {
 	background-color: @less_dark_color;
 }
 
-.scrollbar.button:hover,
-.scrollbar.button.horizontal:hover,
-.scrollbar.button.vertical:hover {
+scrollbar button:hover,
+scrollbar button.horizontal:hover,
+scrollbar button.vertical:hover {
 	background-image: none;
 	background-color: shade(@less_dark_color, 1.4);
 	/*border-color: shade(@highlighted_border, 1.1);*/
@@ -1534,9 +1495,9 @@ GtkLinkButton.button:active:hover {
 	border-width: 0px;
 }
 
-.scrollbar.button:hover:active,
-.scrollbar.button.vertical:hover:active,
-.scrollbar.button.horizontal:hover:active {
+scrollbar button:hover:active,
+scrollbar.vertical button:hover:active,
+scrollbar.horizontal button:hover:active {
 	background-color: @less_dark_color;
 	background-image: linear-gradient(to top,
 	                                  shade(@less_dark_color, 1.5),
@@ -1547,9 +1508,9 @@ GtkLinkButton.button:active:hover {
 	border-width: 0px;
 }
 
-.scrollbar.button:insensitive,
-.scrollbar.button.horizontal:insensitive,
-.scrollbar.button.vertical:insensitive {
+scrollbar button:disabled,
+scrollbar button.horizontal:disabled,
+scrollbar button.vertical:disabled {
 	background-image: none;
 	background-color: transparent;
 	color: @insensitive_fg_color;
@@ -1558,7 +1519,7 @@ GtkLinkButton.button:active:hover {
 	border-width: 0px;
 }
 
-.scrollbar.slider {
+scrollbar slider {
 	background-color: transparent;
 	background-image: linear-gradient(to top,
 	                                  shade(@scroll_slider_color, 0.6),
@@ -1570,7 +1531,7 @@ GtkLinkButton.button:active:hover {
 	border-image: none;
 }
 
-.scrollbar.slider.vertical {
+scrollbar.vertical slider {
 	border-width: 1px;
 	background-image: linear-gradient(to top,
 	                                  shade(@scroll_slider_color, 0.6),
@@ -1578,7 +1539,7 @@ GtkLinkButton.button:active:hover {
 	                                  shade(@scroll_slider_color, 2.0));
 }
 
-.scrollbar.slider.horizontal {
+scrollbar.horizontal slider {
 	border-width: 1px;
 	background-image: linear-gradient(to left,
 	                                  shade(@scroll_slider_color, 0.6),
@@ -1586,35 +1547,25 @@ GtkLinkButton.button:active:hover {
 	                                  shade(@scroll_slider_color, 2.0));
 }
 
-.scrollbar.slider:prelight {
+scrollbar slider:hover {
 	border-width: 1px;
 	border-color: @scroll_slider_color;
 	border-radius: 6px;
 }
 
-.scrollbar.slider.vertical:prelight {
+scrollbar.vertical slider:hover {
 	border-width: 1px;
 	border-color: @scroll_slider_color;
 	border-radius: 6px;
 }
 
-.scrollbar.slider.horizontal:prelight {
+scrollbar.horizontal slider:hover {
 	border-width: 1px;
 	border-color: @scroll_slider_color;
 	border-radius: 6px;
 }
 
-.scrollbar.slider:prelight:active {
-	border-width: 1px;
-	border-color: @scroll_slider_color;
-	border-radius: 6px;
-	background-image: linear-gradient(to top,
-	                                  shade(@scroll_slider_color, 2.0),
-	                                  shade(@scroll_slider_color, 1.6) 55%,
-	                                  shade(@scroll_slider_color, 0.6));
-}
-
-.scrollbar.slider.vertical:prelight:active {
+scrollbar slider:hover:active {
 	border-width: 1px;
 	border-color: @scroll_slider_color;
 	border-radius: 6px;
@@ -1624,7 +1575,17 @@ GtkLinkButton.button:active:hover {
 	                                  shade(@scroll_slider_color, 0.6));
 }
 
-.scrollbar.slider.horizontal:prelight:active {
+scrollbar.vertical slider:hover:active {
+	border-width: 1px;
+	border-color: @scroll_slider_color;
+	border-radius: 6px;
+	background-image: linear-gradient(to top,
+	                                  shade(@scroll_slider_color, 2.0),
+	                                  shade(@scroll_slider_color, 1.6) 55%,
+	                                  shade(@scroll_slider_color, 0.6));
+}
+
+scrollbar.horizontal slider:hover:active {
 	border-width: 1px;
 	border-color: @scroll_slider_color;
 	border-radius: 6px;
@@ -1634,12 +1595,12 @@ GtkLinkButton.button:active:hover {
 	                                  shade(@scroll_slider_color, 0.6));
 }
 
-.scrollbar.slider:insensitive {
+scrollbar slider:disabled {
 	background-image: none;
 	background-color: shade(@theme_bg_color, 1.5);
 }
 
-.scrollbar.slider.fine-tune:prelight:active {
+scrollbar slider.fine-tune:hover:active {
 	background-image: url("assets/slider_fine_horizontal.svg"),
 	                  linear-gradient(to top,
 	                                  shade(@scroll_slider_color, 3.3),
@@ -1649,7 +1610,7 @@ GtkLinkButton.button:active:hover {
 	background-position: center;
 }
 
-.scrollbar.slider.vertical.fine-tune:prelight:active {
+scrollbar.vertical slider.fine-tune:hover:active {
 	background-image: url("assets/slider_fine_vertical.svg"),
 	                  linear-gradient(to left,
 	                                  shade(@scroll_slider_color, 3.3),
@@ -1664,7 +1625,7 @@ GtkLinkButton.button:active:hover {
  *********/
 
 /* this controls the general appearance of the menubar */
-.menubar {
+menubar {
     background-image: none;
     background-color: @theme_bg_color;
     border-width: 0px;
@@ -1674,28 +1635,38 @@ GtkLinkButton.button:active:hover {
     -GtkWidget-window-dragging: true;
 }
 
-.menubar .menuitem {
+menubar  menuitem {
     -gtk-icon-style: regular;
     transition: all 300ms ease-out;
     padding: 3px 7px;
 }
 
-.menu .menuitem {
+menu  menuitem {
     padding: 3px 4px;
 }
 
-.menubar .menu .menuitem {
+menubar  menu  menuitem {
     transition: none;
 }
 
-.menubar .menuitem,
-.menu .menuitem {
+menubar  menuitem{
     border-width: 0px;
     border-style: none;
     background-color: transparent;
 }
 
-.menubar .menuitem:hover {
+menu  menuitem {
+    border-width: 0px;
+	border-radius: 3px 3px 0px 0px;
+    border-style: solid;
+    border-width: 1px;
+    border-radius: 3px;
+    border-image: none;
+	border-color:transparent;
+}
+
+
+menubar  menuitem:hover {
     background-image: none;
     background-color: @theme_selected_bg_color;
     border-style: solid;
@@ -1706,14 +1677,14 @@ GtkLinkButton.button:active:hover {
     border-color: @theme_selected_bg_color;
 }
 
-.menubar .menuitem *:insensitive, /* gdebi bug? */
-.menubar .menuitem *:hover {
+menubar  menuitem *:disabled, /* gdebi bug? */
+menubar  menuitem *:hover {
     color: @theme_text_color;
 }
 
-.menu,
-.menubar .menu,
-.menuitem .menu {
+ menu,
+ menubar  menu,
+ menuitem  menu {
     background-color: shade(@theme_selected_bg_color, 0.8);
     background-image: linear-gradient(to bottom,
                                       @theme_selected_bg_color,
@@ -1724,14 +1695,13 @@ GtkLinkButton.button:active:hover {
     padding: 1px;
 }
 
-.menuitem,
-.menuitem * {
-    -GtkMenuItem-arrow-scaling: 0.5;
+menuitem,
+menuitem * {
     padding: 2px 0px;
 }
 
 /* scroll arrows */
-.menu.button {
+menu button {
     border-image: none;
     color: @theme_fg_color;
     background-image: linear-gradient(to bottom,
@@ -1739,21 +1709,21 @@ GtkLinkButton.button:active:hover {
                                       @button_hover_gradient_color_b);
 }
 
-.menu.button:hover {
+menu button:hover {
     color: @theme_main_color;
     background-image: linear-gradient(to bottom,
                                       shade(@theme_selected_bg_color, 1.3),
                                       shade(@theme_selected_bg_color, 0.5));
 }
 
-.menu.button:insensitive {
+menu button:disabled {
     background-image: none;
     background-color: transparent;
     border-style: none;
 }
 
-.menuitem:hover,
-.menu .menuitem:hover {
+menuitem:hover,
+menu  menuitem:hover {
     background-image: linear-gradient(to bottom,
                                       #999999,
                                       #404040);
@@ -1764,28 +1734,26 @@ GtkLinkButton.button:active:hover {
     border-image: url("assets/menu-border-dark.svg") 2 / 2px stretch;
 }
 
-.menu .menuitem:insensitive,
-.menu .menuitem *:insensitive {
+menu  menuitem:disabled,
+menu  menuitem *:disabled {
     color: @insensitive_fg_color;
 }
 
-.menuitem.separator {
+menuitem separator {
     padding: 4px;
     border-style: none;
     border-color: @theme_selected_bg_color;
-    -GtkMenuItem-horizontal-padding: 0;
-    -GtkWidget-separator-height: 1;
 }
 
-.menuitem.accelerator,
-.menu .menuitem.accelerator {
+menuitem accelerator,
+menu  menuitem accelerator {
     color: alpha(@theme_main_color, 0.66);
 }
 
-.menuitem.accelerator:hover,
-.menuitem.accelerator:active,
-.menu .menuitem.accelerator:hover,
-.menu .menuitem.accelerator:active {
+menuitem accelerator:hover,
+menuitem accelerator:active,
+menu  menuitem accelerator:hover,
+menu  menuitem accelerator:active {
     color: alpha(@theme_text_color, 0.45);
 }
 
@@ -1793,14 +1761,14 @@ GtkLinkButton.button:active:hover {
  * Menu Button *
  ***************/
 /* compensation for combo shadow */
-GtkMenuButton .menu {
+menubutton  menu {
     text-shadow: none;
 }
 
 /************
  * Toolbars *
  ************/
-.toolbar {
+toolbar {
 	background-image: linear-gradient(to bottom,
 	                                  @toolbar_gradient_base,
 	                                  @toolbar_gradient_bottom);
@@ -1812,35 +1780,35 @@ GtkMenuButton .menu {
 	-GtkToolbar-button-relief: normal;
 }
 
-.toolbar .button.text-button {
+toolbar button.text-button {
 	padding: 2px 5px;
 }
 
-.toolbar .button.image-button {
+toolbar button.image-button {
 	padding: 5px 4px 4px 5px;
 }
 
 /********************
  * Primary Toolbars *
  ********************/
-.toolbar:insensitive {
+toolbar:disabled {
     background-image: none;
     background-color: shade(@theme_bg_color, 0.97);
 }
 
 /* (primary) toolbar buttons */
-.toolbar .button,
-.primary-toolbar .button,
-.primary-toolbar .toolbar .button,
-.primary-toolbar.toolbar .button,
-.toolbar .button:insensitive,
-.primary-toolbar .button:insensitive,
-.primary-toolbar .toolbar .button:insensitive,
-.primary-toolbar.toolbar .button:insensitive,
-.toolbar .button:insensitive:hover,
-.primary-toolbar .button:insensitive:hover,
-.primary-toolbar .toolbar .button:insensitive:hover,
-.primary-toolbar.toolbar .button:insensitive:hover {
+ toolbar  button,
+primary-toolbar  button,
+primary-toolbar  toolbar  button,
+primary-toolbar toolbar  button,
+toolbar  button:disabled,
+primary-toolbar  button:disabled,
+primary-toolbar  toolbar  button:disabled,
+primary-toolbar toolbar  button:disabled,
+toolbar  button:disabled:hover,
+primary-toolbar  button:disabled:hover,
+primary-toolbar  toolbar  button:disabled:hover,
+primary-toolbar toolbar  button:disabled:hover {
     border-style: solid;
     border-width: 1px;
     border-image: none;
@@ -1849,10 +1817,10 @@ GtkMenuButton .menu {
     background-color: transparent;
 }
 
-.toolbar .button:hover,
-.primary-toolbar .button:hover,
-.primary-toolbar .toolbar .button:hover,
-.primary-toolbar.toolbar .button:hover {
+toolbar  button:hover,
+primary-toolbar  button:hover,
+primary-toolbar  toolbar  button:hover,
+primary-toolbar toolbar  button:hover {
     border-style: solid;
     border-color: shade(@button_border, 1.1);
     border-radius: 3px;
@@ -1865,32 +1833,32 @@ GtkMenuButton .menu {
                       to (shade(@button_gradient_color_b, 0.7)));
 }
 
-.toolbar .button:checked,
-.primary-toolbar .button:checked,
-.primary-toolbar .toolbar .button:checked,
-.primary-toolbar.toolbar .button:checked,
-.toolbar .button:active,
-.primary-toolbar .button:active,
-.primary-toolbar .toolbar .button:active,
-.primary-toolbar.toolbar .button:active,
-.toolbar GtkComboBox .button,
-.primary-toolbar .toolbar GtkComboBox .button,
-.primary-toolbar.toolbar GtkComboBox .button {
+toolbar  button:checked,
+primary-toolbar  button:checked,
+primary-toolbar  toolbar  button:checked,
+primary-toolbar toolbar  button:checked,
+toolbar  button:active,
+primary-toolbar  button:active,
+primary-toolbar  toolbar  button:active,
+primary-toolbar toolbar  button:active,
+toolbar combobox button,
+primary-toolbar  toolbar combobox button,
+primary-toolbar toolbar combobox button {
     border-radius: 3px;
     background-image: none;
 }
 
-.toolbar .button:checked:hover,
-.primary-toolbar .button:checked:hover,
-.primary-toolbar .toolbar .button:checked:hover,
-.primary-toolbar.toolbar .button:checked:hover,
-.toolbar .button:active:hover,
-.primary-toolbar .button:active:hover,
-.primary-toolbar .toolbar .button:active:hover,
-.primary-toolbar.toolbar .button:active:hover,
-.toolbar GtkComboBox .button:hover,
-.primary-toolbar .toolbar GtkComboBox .button:hover,
-.primary-toolbar.toolbar GtkComboBox .button:hover {
+toolbar  button:checked:hover,
+primary-toolbar  button:checked:hover,
+primary-toolbar  toolbar  button:checked:hover,
+primary-toolbar toolbar  button:checked:hover,
+toolbar  button:active:hover,
+primary-toolbar  button:active:hover,
+primary-toolbar  toolbar  button:active:hover,
+primary-toolbar toolbar  button:active:hover,
+toolbar combobox button:hover,
+primary-toolbar  toolbar combobox button:hover,
+primary-toolbar toolbar combobox button:hover {
     border-image: none;
     border-style: solid;
     border-color: shade(@button_border, 1.1);
@@ -1903,17 +1871,17 @@ GtkMenuButton .menu {
                       to (shade(@button_gradient_color_b, 0.7)));
 }
 
-.toolbar .button:checked:insensitive,
-.primary-toolbar .button:checked:insensitive,
-.primary-toolbar .toolbar .button:checked:insensitive,
-.primary-toolbar.toolbar .button:checked:insensitive,
-.toolbar .button:active:insensitive,
-.primary-toolbar .button:active:insensitive,
-.primary-toolbar .toolbar .button:active:insensitive,
-.primary-toolbar.toolbar .button:active:insensitive,
-.toolbar GtkComboBox .button:insensitive,
-.primary-toolbar .toolbar GtkComboBox .button:insensitive,
-.primary-toolbar.toolbar GtkComboBox .button:insensitive {
+toolbar  button:checked:disabled,
+primary-toolbar  button:checked:disabled,
+primary-toolbar  toolbar  button:checked:disabled,
+primary-toolbar toolbar  button:checked:disabled,
+toolbar  button:active:disabled,
+primary-toolbar  button:active:disabled,
+primary-toolbar  toolbar  button:active:disabled,
+primary-toolbar toolbar  button:active:disabled,
+toolbar combobox button:disabled,
+primary-toolbar  toolbar combobox button:disabled,
+primary-toolbar toolbar combobox button:disabled {
     border-image: none;
     border-style: solid;
     border-color: @inactive_frame_color;
@@ -1922,15 +1890,14 @@ GtkMenuButton .menu {
                                       @button_hover_gradient_color_b);
 }
 
-.toolbar GtkSeparatorToolItem {
-    -GtkWidget-separator-width: 1;
+toolbar separatortoolitem {
     border-style: solid;
     border-width: 1px;
     border-color: shade(@theme_bg_color, 0.85);
 }
 
 /* progressbars on primary toolbar entries are special */
-.toolbar .entry.progressbar {
+toolbar entry progressbar {
     background-image: linear-gradient(to bottom,
                                       @trough_bg_color_a,
                                       @trough_bg_color_b);
@@ -1945,7 +1912,7 @@ GtkMenuButton .menu {
 /*******************
  * Inline toolbars *
  *******************/
-.inline-toolbar.toolbar {
+inline-toolbar toolbar {
 	border-width: 1px;
 	border-radius: 3px;
 	border-style: solid;
@@ -1960,49 +1927,49 @@ GtkMenuButton .menu {
  * Stack switcher *
  ******************/
 
-.stack-switcher > .button > GtkLabel,
-.header-bar .stack-switcher > .button.titlebutton > GtkLabel,
-.titlebar .stack-switcher > .button.titlebutton > GtkLabel,
-GtkCalendar.header .stack-switcher > .button.titlebutton > GtkLabel {
+stack-switcher >  button > label,
+header-bar  stack-switcher >  button.titlebutton > label,
+titlebar  stack-switcher >  button.titlebutton > label,
+calendar.header  stack-switcher >  button.titlebutton > label {
 	padding-left: 6px;
 	padding-right: 6px;
 }
-.stack-switcher > .button > GtkImage,
-.header-bar .stack-switcher > .button.titlebutton > GtkImage,
-.titlebar .stack-switcher > .button.titlebutton > GtkImage,
-GtkCalendar.header .stack-switcher > .button.titlebutton > GtkImage {
+stack-switcher >  button > image,
+header-bar stack-switcher >  button.titlebutton > image,
+titlebar stack-switcher >  button.titlebutton > image,
+calendar.header stack-switcher >  button.titlebutton > image {
 	padding-left: 6px;
 	padding-right: 6px;
 	padding-top: 3px;
 	padding-bottom: 3px;
 }
-.stack-switcher > .button.text-button {
+stack-switcher >  button.text-button {
 	padding: 5px 10px 6px;
 }
-.stack-switcher > .button.image-button,
-.header-bar .stack-switcher > .titlebutton.button,
-.titlebar .stack-switcher > .titlebutton.button,
-GtkCalendar.header .stack-switcher > .titlebutton.button {
+stack-switcher >  button.image-button,
+header-bar stack-switcher > titlebutton button,
+titlebar stack-switcher > titlebutton button,
+calendar.header stack-switcher > .titlebutton button {
 	padding: 5px 2px;
 }
-.stack-switcher > .button.needs-attention > GtkLabel,
-.stack-switcher > .button.needs-attention > GtkImage {
+stack-switcher >  button.needs-attention > label,
+stack-switcher >  button.needs-attention > image {
 	animation: needs_attention 150ms ease-in;
 	background-color: transparent;
 	background-size: 6px 6px, 6px 6px;
 	background-repeat: no-repeat;
 	background-position: right 3px, right 4px;
 }
-.stack-switcher > .button.needs-attention > GtkLabel:backdrop,
-.stack-switcher > .button.needs-attention > GtkImage:backdrop {
+stack-switcher >  button.needs-attention > label:backdrop,
+stack-switcher >  button.needs-attention > image:backdrop {
 	background-size: 6px 6px, 0 0;
 }
-.stack-switcher > .button.needs-attention > GtkLabel:dir(rtl),
-.stack-switcher > .button.needs-attention > GtkImage:dir(rtl) {
+stack-switcher >  button.needs-attention > label:dir(rtl),
+stack-switcher >  button.needs-attention > image:dir(rtl) {
 	background-position: left 3px, left 4px;
 }
-.stack-switcher > .button.needs-attention:active > GtkLabel,
-.stack-switcher > .button.needs-attention:active > GtkImage, .stack-switcher > .button.needs-attention:checked > GtkLabel, .stack-switcher > .button.needs-attention:checked > GtkImage {
+stack-switcher >  button.needs-attention:active > label,
+stack-switcher >  button.needs-attention:active > image, stack-switcher >  button.needs-attention:checked > label,  stack-switcher >  button.needs-attention:checked > image {
 	animation: none;
 	background-image: none;
 }
@@ -2010,7 +1977,7 @@ GtkCalendar.header .stack-switcher > .titlebutton.button {
 /***************
  * Header bars *
  ***************/
-.header-bar {
+header-bar {
     border-width: 0 0 1px;
     border-style: solid;
     padding: 0 1px;
@@ -2020,39 +1987,39 @@ GtkCalendar.header .stack-switcher > .titlebutton.button {
     border-color: shade(@theme_bg_color, 0.8);
 }
 
-.header-bar .button.text-button {
+header-bar  button.text-button {
     padding: 2px 16px;
 }
 
-.header-bar .button.image-button {
+header-bar  button.image-button {
     padding: 5px 4px 4px 5px;
 }
 
 /*******
  * OSD *
  *******/
-.background.osd {
+.backgroundosd {
 	color: @osd_fg;
 	background-image: none;
 	background-color: @osd_bg;
 }
 
-GtkOverlay.osd {
+overlayosd {
 	background-color: transparent;
 }
 
-.osd.frame {
+osd.frame {
 	background-clip: border-box;
 	background-origin: border-box;
 }
 
-.osd.button,
-.osd.button:checked,
-.osd.button:active,
-.osd .button,
-.osd .button:hover,
-.osd .button:checked,
-.osd .button:active {
+osd button,
+osd button:checked,
+osd button:active,
+osd button,
+osd button:hover,
+osd button:checked,
+osd button:active {
 	border-width: 1px;
 	border-style: solid;
 	border-image: none;
@@ -2060,8 +2027,8 @@ GtkOverlay.osd {
 	border-radius: 5px;
 }
 
-.osd.button,
-.osd .button {
+osd button,
+osd button {
 	padding: 4px;
 	background-image: linear-gradient(to bottom,
 	                                  @osd_button_bg_a,
@@ -2069,93 +2036,93 @@ GtkOverlay.osd {
 	                                  @osd_button_bg_c);
 	color: @osd_button_fg;
 	text-shadow: none;
-	icon-shadow: 0 -1px @osd_button_shadow;
+	-gtk-icon-shadow: 0 -1px @osd_button_shadow;
 }
 
-.osd.button,
-.osd.button:prelight,
-.osd.button:checked,
-.osd.button:active,
-.osd .button,
-.osd .button:prelight,
-.osd .button:checked,
-.osd .button:hover,
-.osd .button:active {
+osd button,
+osd button:hover,
+osd button:checked,
+osd button:active,
+osd button,
+osd button:hover,
+osd button:checked,
+osd button:hover,
+osd button:active {
 	background-color: transparent;
 }
 
-.osd.button:insensitive,
-.osd .button:insensitive {
+osd button:disabled,
+osd button:disabled {
 	background-image: none;
 	background-color: @osd_button_bg_insensitive;
 }
 
-.osd.button:checked:insensitive,
-.osd .button:checked:insensitive,
-.osd.button:active:insensitive,
-.osd .button:active:insensitive {
+osd button:checked:disabled,
+osd button:checked:disabled,
+osd button:active:disabled,
+osd button:active:disabled {
 	background-image: none;
 	background-color: @osd_button_bg_insensitive_active;
 }
 
-.osd.button:hover,
-.osd .button:hover {
+osd button:hover,
+osd  button:hover {
 	color: @osd_button_fg_hover;
 }
 
-.osd .button:checked,
-.osd .button:hover:checked,
-.osd .button:active,
-.osd .button:hover:active {
+osd button:checked,
+osd button:hover:checked,
+osd button:active,
+osd button:hover:active {
 	color: @osd_button_fg_active;
 }
 
-.osd.button:insensitive,
-.osd.button:insensitive:checked,
-.osd.button:insensitive:active,
-.osd .button:insensitive,
-.osd .button:checked *:insensitive,
-.osd .button:active *:insensitive {
+osd button:disabled,
+osd button:disabled:checked,
+osd button:disabled:active,
+osd button:disabled,
+osd button:checked *:disabled,
+osd button:active *:disabled {
 	color: @osd_button_fg_insensitive;
 }
 
-.osd.button:hover,
-.osd .button:hover {
+osd button:hover,
+osd button:hover {
 	background-image: linear-gradient(to bottom,
 	                                  @osd_button_bg_hover_a,
 	                                  @osd_button_bg_hover_b 68%,
 	                                  @osd_button_bg_hover_c);
 }
 
-.osd.button:checked,
-.osd.button:checked:hover,
-.osd .button:checked,
-.osd .button:checked:hover,
-.osd GtkMenuButton.button:checked,
-.osd.button:active,
-.osd.button:active:hover,
-.osd .button:active,
-.osd .button:active:hover,
-.osd GtkMenuButton.button:active {
+osd button:checked,
+osd button:checked:hover,
+osd button:checked,
+osd button:checked:hover,
+osd menubutton button:checked,
+osd button:active,
+osd button:active:hover,
+osd button:active,
+osd button:active:hover,
+osd menubutton button:active {
 	background-image: linear-gradient(to bottom,
 	                                  @osd_button_bg_active_a,
 	                                  @osd_button_bg_active_b 68%,
 	                                  @osd_button_bg_active_c);
 }
 
-.osd GtkMenuButton.button:checked,
-.osd GtkMenuButton.button:active {
+osd menubutton button:checked,
+osd menubutton button:active {
     background-color: transparent;
     border-color: @osd_button_border;
 }
 
-.osd GtkMenuButton.button *:checked,
-.osd GtkMenuButton.button *:active {
+osd menubutton button *:checked,
+osd menubutton button *:active {
     color: @osd_button_fg_active;
     text-shadow: none;
 }
 
-.osd.toolbar {
+osd toolbar {
 	color: @osd_fg;
 	text-shadow: none;
 	padding: 10px;
@@ -2169,8 +2136,8 @@ GtkOverlay.osd {
 	-GtkToolbar-button-relief: normal;
 }
 
-.osd.toolbar .button,
-.osd.toolbar .linked .button {
+osd toolbar  button,
+osd toolbar .linked  button {
 	background-color: transparent;
 	border-color: @osd_button_border;
 	padding: 6px;
@@ -2179,48 +2146,48 @@ GtkOverlay.osd {
 	box-shadow: @osd_button_inset;
 }
 
-.osd.toolbar .button:hover {
+osd toolbar  button:hover {
 	padding: 6px;
 }
 
-.osd.toolbar .button:first-child {
+osd toolbar  button:first-child {
 	border-radius: 5px 0 0 5px;
 	border-width: 1px 0 1px 1px;
 	box-shadow: inset -1px 0 @osd_button_inset;
 }
 
-.osd.toolbar .button:last-child {
+osd toolbar  button:last-child {
 	box-shadow: none;
 	border-radius: 0 5px 5px 0;
 	border-width: 1px 1px 1px 0;
 }
 
-.osd.toolbar .button:only-child,
-.osd.toolbar GtkToolButton .button,
-.osd.toolbar GtkToolButton:only-child .button,
-.osd.toolbar GtkToolButton:last-child .button,
-.osd.toolbar GtkToolButton:first-child .button {
+osd toolbar  button:only-child,
+osd toolbar GtkToolButton  button,
+osd toolbar GtkToolButton:only-child  button,
+osd toolbar GtkToolButton:last-child  button,
+osd toolbar GtkToolButton:first-child  button {
 	border-width: 1px;
 	border-radius: 5px;
 	border-style: solid;
 	box-shadow: none;
 }
 
-.osd.toolbar .separator {
+osd toolbar .separator {
 	color: shade(@osd_lowlight, 0.80);
 }
 
 /* used by gnome-settings-daemon's media-keys OSD
    and Epiphany */
-.osd.trough {
+osd.trough {
 	background-color: @osd_trough_bg;
 }
 
-.osd.progressbar {
+osd progressbar {
 	background-color: @osd_fg;
 }
 
-.osd .scale.trough {
+osd  scale trough {
 	border-color: @osd_button_border;
 	background-image: linear-gradient(to bottom,
 	                                  shade(@osd_button_border, 0.70),
@@ -2228,18 +2195,18 @@ GtkOverlay.osd {
 	background-color: transparent;
 }
 
-.osd .scale.trough.highlight {
+osd  scale trough.highlight {
 	background-image: none;
 	background-color: @theme_selected_bg_color;
 }
 
-.osd .scale.trough:insensitive,
-.osd .scale.trough.highlight:insensitive {
+osd scale.trough:disabled,
+osd scale.trough.highlight:disabled {
 	background-image: none;
 	background-color: transparent;
 }
 
-.osd .scale-popup.popover.background {
+osd  scale-popup popover.background {
 	color: @osd_fg;
 	text-shadow: none;
     border-color: shade (@theme_selected_bg_color, 0.5);
@@ -2251,7 +2218,7 @@ GtkOverlay.osd {
 	background-color: transparent;
 }
 
-.osd .popover.scale-popup .flat.button.image-button {
+osd  popover scale-popup .flat button.image-button {
 	background-color: transparent;
     border-radius: 4px;
     border-width: 1px;
@@ -2260,20 +2227,20 @@ GtkOverlay.osd {
     padding: 2px;
 }
 
-.osd .popover.scale-popup .flat.button.image-button:insensitive {
+osd  popover scale-popup .flat button.image-button:disabled {
     border-color: alpha (@osd_button_border, 0.0);
 }
 
-.osd GtkProgressBar,
-GtkProgressBar.osd {
+osd progressbar,
+progressbarosd {
 	padding: 0;
-	-GtkProgressBar-xspacing: 0;
-	-GtkProgressBar-yspacing: 3px;
-	-GtkProgressBar-min-horizontal-bar-height: 3px;
+	-progressbar-xspacing: 0;
+	-progressbar-yspacing: 3px;
+	-progressbar-min-horizontal-bar-height: 3px;
 }
 
-.osd GtkProgressBar.trough,
-GtkProgressBar.osd.trough {
+osd progressbar.trough,
+progressbarosd.trough {
 	padding: 0;
 	border-image: none;
 	border-style: none;
@@ -2283,8 +2250,8 @@ GtkProgressBar.osd.trough {
 	border-radius: 0;
 }
 
-.osd GtkProgressBar.progressbar,
-GtkProgressBar.osd.progressbar {
+osd progressbar.progressbar,
+progressbarosd.progressbar {
 	border-style: none;
 	background-color: shade(@progressbar_background_b, 1.3);
 	background-image: linear-gradient(to bottom,
@@ -2293,29 +2260,29 @@ GtkProgressBar.osd.progressbar {
 	border-radius: 0; 
 }
 
-.osd .view,
-.osd.view {
+osd .view,
+osd.view {
 	background-color: @osd_view_bg;
 }
 
-.osd .scrollbar.trough {
+osd  scrollbar.trough {
 	background-color: @osd_scrollbar_trough;
 }
 
-.osd .scrollbar.slider {
+osd  scrollbar slider {
 	background-color: @osd_scrollbar_slider;
 }
 
-.osd .scrollbar.slider:hover {
+osd  scrollbar slider:hover {
 	background-color: @osd_scrollbar_slider_prelight;
 }
 
-.osd .scrollbar.slider:active {
+osd  scrollbar slider:active {
 	background-color: @osd_scrollbar_slider_active;
 }
 
-.osd GtkIconView.cell:selected,
-.osd GtkIconView.cell:selected:focus {
+osd iconview.cell:selected,
+osd iconview.cell:selected:focus {
 	background-color: transparent;
 	border-style: solid;
 	border-radius: 15px;
@@ -2325,7 +2292,7 @@ GtkProgressBar.osd.progressbar {
 }
 
 /* used by Documents */
-.osd .page-thumbnail {
+osd .page-thumbnail {
 	border-style: solid;
 	border-width: 1px;
 	border-color: @osd_lowlight;
@@ -2337,7 +2304,7 @@ GtkProgressBar.osd.progressbar {
  * Popovers *
  *************/
 
-.popover {
+ popover {
 	background-clip: initial;
 	margin: 10px;
 	padding: 2px;
@@ -2351,86 +2318,87 @@ GtkProgressBar.osd.progressbar {
 	                                  shade(@theme_selected_bg_color, 0.5));
 	box-shadow: 0 1px 5px @wm_shadow;
 	text-shadow: none;
-	icon-shadow: none;
+	-gtk-icon-shadow: none;
 }
 
-.popover > .list,
-.popover > .view,
-.popover > .toolbar .popover.osd > .toolbar,
-.popover > .inline-toolbar .popover.osd > .toolbar,
-.popover > .search-bar .popover.osd > .toolbar,
-.popover > .location-bar .popover.osd > .toolbar,
-.popover > .toolbar .popover.osd > .inline-toolbar,
-.popover > .inline-toolbar .popover.osd > .inline-toolbar,
-.popover > .search-bar .popover.osd > .inline-toolbar,
-.popover > .location-bar .popover.osd > .inline-toolbar,
-.popover > .toolbar .popover.osd > .search-bar,
-.popover > .inline-toolbar .popover.osd > .search-bar,
-.popover > .search-bar .popover.osd > .search-bar,
-.popover > .location-bar .popover.osd > .search-bar,
-.popover > .toolbar .popover.osd > .location-bar,
-.popover > .inline-toolbar .popover.osd > .location-bar,
-.popover > .search-bar .popover.osd > .location-bar,
-.popover > .location-bar .popover.osd > .location-bar {
+popover >  list,
+popover > .view,
+popover > view,
+popover > toolbar  popoveosd > toolbar,
+popover > inline-toolbar  popoverosd > toolbar,
+popover >  search-bar  popoverosd > toolbar,
+popover >  location-bar  popoverosd > toolbar,
+popover >  toolbar  popoverosd > inline-toolbar,
+popover >  inline-toolbar  popoverosd > inline-toolbar,
+popover >  search-bar  popoverosd > inline-toolbar,
+popover >  location-bar  popoverosd >  inline-toolbar,
+popover >  toolbar  popoverosd > search-bar,
+popover >  inline-toolbar  popoverosd > search-bar,
+popover >  search-bar  popoverosd > search-bar,
+popover >  location-bar  popoverosd > search-bar,
+popover >  toolbar  popoverosd >  location-bar,
+popover >  inline-toolbar  popoverosd >  location-bar,
+popover >  search-bar  popoverosd >  location-bar,
+popover >  location-bar  popoverosd >  location-bar {
 	border-style: none;
 	background-color: transparent;
 }
 
-.popover .separator {
+popover separator {
 	font-size: 80%;
 	font-weight: bold;
 	color: alpha(@theme_fg_color,0.1);
 	text-shadow: none;
 	background-color: transparent;
-	icon-shadow: none;
+	-gtk-icon-shadow: none;
 	border: 0;
 }
 
-.popover.osd {
+popoverosd {
 	background-image: none;
 	background-color: alpha(shade(#3D3E40, 0.85), 0.75);
 	border: 1px solid black;
 	box-shadow: none;
 	color: @theme_selected_fg_color;
 }
-.popover.osd .toolbar {
+popoverosd  toolbar {
 	background-image: none;
 	background-color: transparent;
 	border: none;
 	box-shadow: none;
 }
-.popover.osd .button {
+popoverosd  button {
 	text-shadow: none;
-	icon-shadow: 0 -1px @osd_text_shadow;
+	-gtk-icon-shadow: 0 -1px @osd_text_shadow;
 }
-.popover.osd .button:active,
-.popover.osd .button:checked {
+popoverosd  button:active,
+popoverosd  button:checked {
         box-shadow: none;
 }
-.popover.osd .button:insensitive {
+popoverosd  button:disabled {
 	color: alpha(@theme_selected_fg_color, 0.4);
 }
 
-.popover .list {
+popover  list {
 	background-color: @theme_base_color;
 }
 
-GtkModelButton.button {
+modelbutton button {
 	background-image: none;
 	background-color: transparent;
 	color: @theme_fg_color;
 	border-radius: 3px;
 }
 
-GtkModelButton.button:checked,
-GtkModelButton.button:active,
-GtkModelButton.button:insensitive,
-GtkModelButton.button:active:insensitive,
-GtkModelButton.button:checked:insensitive,
-GtkModelButton.button,
-GtkModelButton.button:focus,
-GtkModelButton.button:active:focus,
-GtkModelButton.button:checked:focus {
+modelbutton button:checked,
+modelbutton button:active,
+modelbutton button:disabled,
+modelbutton button:active:disabled,
+modelbutton button:checked:disabled,
+modelbutton button,
+modelbutton button:focus,
+modelbutton button:active:focus,
+modelbutton button:checked:focus {
 	background-image: none;
 	border-color: transparent;
 	border-image: none;
@@ -2439,10 +2407,10 @@ GtkModelButton.button:checked:focus {
 	border-radius: 3px;
 }
 
-GtkModelButton.button:checked:hover,
-GtkModelButton.button:active:hover,
-GtkModelButton.button:hover,
-GtkModelButton.button:selected {
+modelbutton button:checked:hover,
+modelbutton button:active:hover,
+modelbutton button:hover,
+modelbutton button:selected {
 	background-image: linear-gradient(to bottom,
 	                                  #999999,
 	                                  #404040);
@@ -2453,13 +2421,13 @@ GtkModelButton.button:selected {
 	border-radius: 3px;
 }
 
-GtkPopover .separator {
+popover .separator {
 	font-size: 80%;
 	font-weight: bold;
 	color: alpha(@theme_text_color,0.4);
 	text-shadow: none;
 	background-color: transparent;
-	icon-shadow: none;
+	-gtk-icon-shadow: none;
 	border: 0;
 }
 
@@ -2467,19 +2435,21 @@ GtkPopover .separator {
  * CSD *
  *******/
 
-.titlebar {
+decoration,
+.titlebar  {
     text-shadow: none;
     background-image: linear-gradient(to bottom,
                                       shade (@theme_bg_color, 1.50),
                                       shade (@theme_bg_color, 1.0));
     border-radius: 7px 7px 0 0;
+	padding: 3px;
 }
 
-.tiled .titlebar {
+.tiled  .titlebar {
     border-radius: 0;
 }
 
-.maximized .titlebar {
+.maximized  .titlebar {
     border-radius: 0;
 }
 
@@ -2487,7 +2457,7 @@ GtkPopover .separator {
  * when client-side decorations are in use and the application
  * did not set a custom titlebar.
  */
-.titlebar.default-decoration {
+decoration {
     border: none;
     box-shadow: none;
 }
@@ -2499,7 +2469,7 @@ GtkPopover .separator {
 }
 
  /* Colour when unfocused? does this work?*/
-.titlebar:backdrop {
+decoration:backdrop {
     color: #747473;
     text-shadow: none;
     background-image: none;
@@ -2507,8 +2477,8 @@ GtkPopover .separator {
 }
 
 .titlebar .titlebutton,
-.header-bar.frame.titlebar .button.image-button.titlebutton,
-.button.text-button.titlebutton {
+header-bar.frame titlebar  button.image-button.titlebutton,
+button.text-button.titlebutton {
 	padding: 4px 4px 4px 4px;
 	border-radius: 3px;
 	border-width: 1px;
@@ -2532,8 +2502,8 @@ GtkPopover .separator {
 }
  
 .titlebar .titlebutton:hover,
-.header-bar.frame.titlebar .button.image-button.titlebutton:hover,
-.button.text-button.titlebutton:hover {
+header-bar.frame titlebar  button.image-button.titlebutton:hover,
+button.text-button.titlebutton:hover {
 	border-image: none;
 	border-style: solid;
 	border-color: shade(@button_border, 1.1);
@@ -2553,20 +2523,20 @@ GtkPopover .separator {
 
 .titlebar .titlebutton:active,
 .titlebar .titlebutton:active:hover,
-.header-bar.frame.titlebar:active,
-.header-bar.frame.titlebar:active:hover,
-.button.image-button.titlebutton:active,
-.button.image-button.titlebutton:active:hover,
-.button.text-button.titlebutton:active,
-.button.text-button.titlebutton:active:hover,
+header-bar.frame titlebar:active,
+header-bar.frame titlebar:active:hover,
+button.image-button.titlebutton:active,
+button.image-button.titlebutton:active:hover,
+button.text-button.titlebutton:active,
+button.text-button.titlebutton:active:hover,
 .titlebar .titlebutton:checked,
 .titlebar .titlebutton:checked:hover,
-.header-bar.frame.titlebar:checked,
-.header-bar.frame.titlebar:checked:hover,
-.button.image-button.titlebutton:checked,
-.button.image-button.titlebutton:checked:hover,
-.button.text-button.titlebutton:checked,
-.button.text-button.titlebutton:checked:hover {
+header-bar.frame titlebar:checked,
+header-bar.frame titlebar:checked:hover,
+button.image-button.titlebutton:checked,
+button.image-button.titlebutton:checked:hover,
+button.text-button.titlebutton:checked,
+button.text-button.titlebutton:checked:hover {
 	color: @theme_fg_color;
 	border-style: solid;
 	background-image: linear-gradient(to bottom,
@@ -2589,70 +2559,55 @@ GtkPopover .separator {
  
 .titlebar .titlebutton:backdrop,
 .titlebar .titlebutton:hover:backdrop,
-.header-bar.frame.titlebar .button.image-button.titlebutton:backdrop,
-.header-bar.frame.titlebar .button.image-button.titlebutton:hover:backdrop {
+header-bar.frame titlebar  button.image-button.titlebutton:backdrop,
+header-bar.frame titlebar  button.image-button.titlebutton:hover:backdrop {
     background: none;
     color: @theme_main_color;
     border-image: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
 }
 
 .titlebar .titlebutton:hover:backdrop,
-.header-bar.frame.titlebar .button.image-button.titlebutton:hover:backdrop {
+header-bar.frame titlebar  button.image-button.titlebutton:hover:backdrop {
 	color: #747473;
 }
 
-/* workaround to avoid unwanted black frames if switching compositor on/off */
-.background .window-frame  {
-    box-shadow: none;
-}
 
-.background.csd .window-frame {
+decoration{
     border-radius: 7px 7px 0px 0px;
     border-width: 0px;
     box-shadow: 0 0 0 2px @wm_csd_border_color, 0 2px 8px 3px @wm_shadow;
     /* this is used for the resize cursor area */
-    margin: 10px;
+   margin: 10px;
 }
 
-.window-frame.tiled {
+.background.ssd decoration {
+    box-shadow: 0 0 0 2px @wm_csd_border_color, 0 2px 8px 3px @wm_shadow;
+    /* this is used for the resize cursor area */
+  margin: 1px;
+}
+/*fix for CSD apps w/o compositing */
+.solid-csd decoration {
+    box-shadow: none;
+	border-width: 1px;
+	border-image: none;
+	border-color: @theme_bg_color;
+	margin: 1px;
+}
+
+.csd.popup decoration {
+    border-radius: 0;
+    box-shadow: none;
+}
+
+.tiled decoration {
     border-radius: 0;
     background-color: @theme_bg_color;
 }
 
-/* workaround to avoid unwanted black frames if switching compositor on/off */
-.window-frame:backdrop {
-/*    box-shadow: 0 0 0 2px shade(@wm_border,1.1), 0 2px 5px 1px @wm_shadow;*/
-    box-shadow: none;
-}
-
-.window-frame.ssd {
-    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.23);
-}
-
-.window-frame.solid-csd {
+tooltip.csd decoration {
     border-radius: 0px;
-    margin: 2px;
-    margin-top: 0px;
-    background-color: @wm_a;
-    border: solid 2px @wm_csd_solid_border_color;
-    box-shadow: none;
-}
-
-.window-frame.csd.popup {
-    border-radius: 0;
-    box-shadow: none;
-}
-
-.window-frame.csd.tooltip {
-    border-radius: 5px;
-    box-shadow: 0 1px 5px @wm_shadow;
-}
-
-.window-frame.csd.message-dialog {
-    border-radius: 7px;
-    box-shadow: 0 1px 5px @wm_shadow;
-}
+    box-shadow: none; }
 
 /****************************
  * Suggested action buttons *
@@ -2675,7 +2630,7 @@ GtkPopover .separator {
 /****************
  * GtkAssistant *
  ****************/
-GtkAssistant .sidebar .highlight {
+assistant sidebar .highlight {
 	color: @theme_fg_color;
 	background-image: linear-gradient(to bottom,
 	                                  shade(@less_dark_color, 0.8),
@@ -2690,7 +2645,7 @@ GtkAssistant .sidebar .highlight {
 	            inset -1px -1px 1px alpha(@entry_shadow, 0.2);
 }
 
-GtkAssistant .sidebar {
+assistant sidebar {
 	padding: 12px;
 	border-radius: 0px 3px 0px 0px;
 	border-style: solid;
@@ -2701,17 +2656,17 @@ GtkAssistant .sidebar {
 }
 
 /*************
- * GtkSwitch *
+ * GtkSwitch*
  *************/
-GtkSwitch {
+switch{
     -GtkSwitch-slider-width: 45px;
     font-weight: bold;
     font-size: smaller;
 	font: bold condensed;
 }
 
-GtkSwitch.trough,
-GtkSwitch.trough:backdrop {
+switch.trough,
+switch.trough:backdrop {
 	color: @internal_element_color;
 	border-radius: 3px;
 	border-width: 1px;
@@ -2723,8 +2678,8 @@ GtkSwitch.trough:backdrop {
 	                                  @trough_bg_color_b);
 }
 
-GtkSwitch.trough:active,
-GtkSwitch.trough:backdrop:active {
+switch.trough:active,
+switch.trough:backdrop:active {
 	color: @theme_main_color;
 	border-image: none;
 	border-color: shade(@frame_color, 1.22);
@@ -2733,24 +2688,24 @@ GtkSwitch.trough:backdrop:active {
 	                                  @active_switch_bg_color_b);
 }
 
-GtkSwitch.trough:insensitive,
-GtkSwitch.trough:backdrop:insensitive {
+switch.trough:disabled,
+switch.trough:backdrop:disabled {
 	background-image: none;
 	background-color: shade(@theme_bg_color, 0.9);
 	border-color: shade(@inactive_frame_color, 0.845);
 	border-image: none;
 }
 
-.notebook GtkContainer GtkSwitch.trough:insensitive {
+notebook container switch.trough:disabled {
 	background-color: shade(@theme_bg_color, 0.9);
 }
 
-GtkSwitch.trough:insensitive {
+switch.trough:disabled {
 	color: @insensitive_fg_color;
 }
 
-GtkSwitch.slider,
-GtkSwitch.slider:backdrop {
+switch slider,
+switch slider:backdrop {
 	border-width: 1px;
 	border-radius: 2px;
 	border-color: shade(@frame_color, 0.8);
@@ -2766,83 +2721,91 @@ GtkSwitch.slider:backdrop {
 	background-position: center;
 }
 
-GtkSwitch.slider:active,
-GtkSwitch.slider:backdrop:active {
+switch slider:active,
+switch slider:backdrop:active {
 	border-color: @switch_slider_border;
 }
 
-GtkSwitch.slider:insensitive,
-GtkSwitch.slider:backdrop:insensitive {
+switch slider:disabled,
+switch slider:backdrop:disabled {
 	border-style: none;
 	background-image: none;
 	background-color: shade(@switch_slider_color, 0.6);
 }
 
-.list-row GtkSwitch,
-.list-row GtkSwitch:backdrop,
-.list-row:selected GtkSwitch,
-.list-row:selected GtkSwitch:backdrop {
-    box-shadow: none;
+list-row switch,
+list-row switch:backdrop,
+list-row:selected switch,
+list-row:selected switch:backdrop {
+   box-shadow: none;
     border-color: shade(@button_border, 1.0);
 }
 
-.list-row:selected GtkSwitch.slider:dir(rtl) {
+list-row:selected switchslider:dir(rtl) {
     border-left-color: @borders;
 }
 
-.list-row:selected GtkSwitch.slider:dir(ltr) {
+list-row:selected switchslider:dir(ltr) {
     border-right-color: @borders;
 }
 
-.list-row:selected GtkSwitch.slider,
-.list-row:selected GtkSwitch.slider:active {
+list-row:selected switchslider,
+list-row:selected switchslider:active {
     border-color: shade(@button_border, 1.0);
 }
 
-GtkStatusbar {
-	padding: 5px;
+statusbar {
+	padding: 0px;
 	color: @theme_fg_color;
-	-GtkStatusbar-shadow-type: none;
+	-statusbar-shadow-type: none;
 	font-size: smaller;
 }
 
-GtkStatusbar .frame {
+statusbar .frame {
 	background-image: none;
 	background-color: transparent;
 	padding: 0px;
 	border-width: 0;
 }
 
-GtkImage,
-GtkImage:hover,
-GtkImage:active,
-GtkImage:hover:active,
-GtkImage:insensitive,
-GtkLabel,
-GtkLabel:hover,
-GtkLabel:active,
-GtkLabel:hover:active,
-GtkLabel:insensitive,
-GtkBox,
-GtkBox:insensitive,
+image,
+image:hover,
+image:active,
+image:hover:active,
+image:disabled,
+label,
+label:hover,
+label:active,
+label:hover:active,
+label:disabled,
+box,
+box:disabled,
 GtkGrid,
-GtkGrid:insensitive {
+GtkGrid:disabled {
 	background-image: none;
 	background-color: transparent;
 }
 
-GtkViewport,
-GtkIconView {
+image, label {
+	padding: 3px;
+}
+
+statusbar label {
+	padding: 1px;	
+}
+
+viewport,
+iconview {
 	border-radius: 3px;
 	padding: 0px;
 }
 
-GtkViewport {
+viewport {
 	background-color: @less_dark_color;
 }
 
-GtkIconView.view.cell:selected,
-GtkIconView.view.cell:selected:focus {
+iconview.view.cell:selected,
+iconview.view.cell:selected:focus {
 	background-color: transparent;
 	border-style: solid;
 	border-width: 3px;
@@ -2857,22 +2820,22 @@ GtkIconView.view.cell:selected:focus {
 /* These are for Evolution, whose new version can also
    be made fully readable with this theme fortunately. */
 EMailDisplay,
-EPreviewPane .entry {
+EPreviewPane entry {
 	background-color: @view_color;
 	color: @theme_main_color;
 }
 
 /* make plain-text preview readable */
-EMailDisplay GtkExpander GtkLabel {
+EMailDisplay expander label {
 	color: @theme_main_color;
 }
 
-EMailDisplay .expander:hover {
+EMailDisplay expander:hover {
 	color: @theme_fg_color;
 	border-color: @theme_fg_color;
 }
 
-GtkHTML GtkExpander GtkLabel {
+GtkHTML expander label {
 	color: #000000;
 }
 
@@ -2884,165 +2847,151 @@ EShellWindow *:active {
 	background-color: #717175;
 }
 
-EShellWindow .button *:active {
+EShellWindow  button *:active {
 	background-color: transparent;
 }
 
-EShellWindow:insensitive { /* removes the "flash" when quitting */
+EShellWindow:disabled { /* removes the "flash" when quitting */
 	background-color: @theme_bg_color;
 }
 
 /*****************
  * Color Chooser *
  *****************/
-GtkColorSwatch,
-GtkColorSwatch:selected {
+colorswatch,
+colorswatch:selected {
 	background-image: none;
 	background-color: transparent;
 }
 
-GtkColorSwatch.color-dark:hover {
+colorswatch.color-dark:hover {
 	background-image: linear-gradient(to bottom,
 	                                  alpha(white, 0) 40%,
 	                                  alpha(white, 0.3));
 }
 
-GtkColorSwatch.color-light:hover {
+colorswatch.color-light:hover {
 	background-image: linear-gradient(to top,
 	                                  alpha(black, 0) 40%,
 	                                  alpha(black, 0.1));
 }
 
-GtkColorSwatch:selected {
+colorswatch:selected {
 	border-style: solid;
 	border-color: alpha(black, 0.2);
 	border-width: 1px;
 }
 
-GtkColorSwatch:selected:hover {
+colorswatch:selected:hover {
 	border-color: alpha(black, 0.5);
 }
 
-GtkColorSwatch.color-light:selected:hover,
-GtkColorSwatch.color-dark:selected:hover {
+colorswatch.color-light:selected:hover,
+colorswatch.color-dark:selected:hover {
 	background-image: none;
 }
 
 /***************************
  * Radio and Check Buttons *
  ***************************/
-.radio,
-.check,
-.radio:selected,
-.check:selected,
-.radio:selected:focus,
-.check:selected:focus,
-.cell.radio,
-.cell.check,
-.cell.radio:selected,
-.cell.check:selected,
-.cell.radio:selected:focus,
-.cell.check:selected:focus {
+radio,
+check,
+radio:selected,
+check:selected,
+radio:selected:focus,
+check:selected:focus,
+cell.radio,
+cell.check,
+cell.radio:selected,
+cell.check:selected,
+cell.radio:selected:focus,
+cell.check:selected:focus {
 	background-color: transparent;
 	border-width: 0px;
 	border-style: none;
 }
 
-.check:hover,
-.check:selected:hover,
-.radio:hover,
-.radio:selected:hover {
+check:hover,
+check:selected:hover,
+radio:hover,
+radio:selected:hover {
 	background-color: transparent;
 }
 
 /*****************
- * GtkCheckButton *
+ * GtkCheckbutton *
  *****************/
-GtkCheckButton:hover {
+checkbutton:hover {
 	background-color: alpha(@theme_main_color, 0.09);
 }
 
-GtkCheckButton:selected:hover {
+checkbutton:selected:hover {
 	background-color: alpha(@theme_main_color, 0.15);
 }
 
 /*****************
  * GtkRadioButton *
  *****************/
-GtkRadioButton:hover {
+radiobutton:hover {
 	background-color: alpha(@theme_main_color, 0.09);
 }
 
-GtkRadioButton:selected:hover {
+radiobutton:selected:hover {
 	background-color: alpha(@theme_main_color, 0.15);
 }
 
 /*************
  * Expanders *
  *************/
-.expander {
+expander title{
 	border-style: solid;
 	border-width: 1px;
 	border-radius: 2px;
-	border-color: @internal_element_color;
+	border-color: transparent;
 	color: @internal_element_color;
 	background-image: none;
 	background-color: transparent;
 }
 
-.expander:active {
+expander title:active {
 	border-color: @internal_element_color;
 	color: @internal_element_color;
 	background-color: transparent;
 }
 
-.expander:hover {
+expander title:hover {
 	border-color: @internal_element_prelight;
 	color: @internal_element_prelight;
 }
 
-.expander row {
-	border-color: @internal_element_color;
-	color: @internal_element_color;
-}
 
-.expander row:selected,
-.expander row:selected:focus {
-	border-image: none;
-	border-color: shade(@internal_element_prelight, 1.3);
-	color: shade(@internal_element_prelight, 1.3);
-	background-image: none;
-	background-color: transparent;
-}
 
-.expander row:selected:hover {
-	background-color: transparent;
-}
-
-.expander column:sorted:selected,
-.expander column:sorted:selected:hover {
-	background-image: none;
-	background-color: transparent;
+expander arrow {
+	min-height: 16px;
+	-gtk-icon-source: -gtk-icontheme("pan-end-symbolic");
+} 
+	expander arrow:checked {
+    -gtk-icon-source: -gtk-icontheme("pan-down-symbolic"); 
 }
 
 /****************
  * Content view *
  ****************/
-.content-view.view {
+content-view.view {
 	background-color: @content_view_bg;
 }
 
-.content-view.view:hover {
+content-view.view:hover {
 	background-color: shade(@content_view_bg, 1.1);
 	color: @theme_text_color;
 }
 
-.content-view.view:selected,
-.content-view.view:active {
+content-view.view:selected,
+content-view.view:active {
 	background-color: @theme_selected_bg_color;
 }
 
-.content-view.view:insensitive {
+content-view.view:disabled {
 	background-color: @theme_unfocused_base_color;
 }
 
@@ -3050,24 +2999,24 @@ GdMainIconView.content-view {
 	-GdMainIconView-icon-size: 40;
 }
 
-GtkIconView.content-view.check {
+iconview.content-view.check {
 	background-image: url("assets/grid-selection-unchecked.svg");
 	background-color: transparent;
 }
 
-GtkIconView.content-view.check:active {
+iconview.content-view.check:active {
 	background-image: url("assets/grid-selection-checked.svg");
 	background-color: transparent;
 }
 
-.content-view.view.check,
-.content-view.view.check:active {
+content-view.view.check,
+content-view.view.check:active {
 	background-color: transparent;
 }
 
-GtkIconView.content-view.check:hover,
-GtkIconView.content-view.check:insensitive,
-GtkIconView.content-view.check:selected {
+iconview.content-view.check:hover,
+iconview.content-view.check:disabled,
+iconview.content-view.check:selected {
 	background-color: transparent;
 }
 
@@ -3075,8 +3024,8 @@ GtkIconView.content-view.check:selected {
  * App Notifications *
  *********************/
 
-.app-notification,
-.app-notification.frame {
+app-notification,
+app-notification.frame {
     color: @theme_fg_color;
     padding: 10px;
     border: none;
@@ -3088,19 +3037,19 @@ GtkIconView.content-view.check:selected {
     background-clip: padding-box;
 }
 
-.app-notification:backdrop,
-.app-notification.frame:backdrop {
+app-notification:backdrop,
+app-notification.frame:backdrop {
     background-image: none;
 }
 
-.app-notification .button,
-.app-notification .header-bar .button.titlebutton,
-.header-bar .app-notification .button.titlebutton,
-.app-notification .titlebar .button.titlebutton,
-.titlebar .app-notification .button.titlebutton,
-.app-notification GtkCalendar.header .button.titlebutton,
-GtkCalendar.header .app-notification .button.titlebutton,
-.app-notification.frame .button {
+app-notification  button,
+app-notification  header-bar  button.titlebutton,
+ header-bar .app-notification  button.titlebutton,
+app-notification  titlebar  button.titlebutton,
+ titlebar .app-notification  button.titlebutton,
+app-notification calendar.header  button.titlebutton,
+calendar.header .app-notification  button.titlebutton,
+app-notification.frame  button {
     color: @theme_fg_color;
     border-color: rgba(75, 89, 112, 0.7);
     background-image: linear-gradient(to bottom,
@@ -3108,32 +3057,32 @@ GtkCalendar.header .app-notification .button.titlebutton,
     background-clip: padding-box;
     box-shadow: inset 0 1px rgba(255, 255, 255, 0.1);
     text-shadow: none;
-    icon-shadow: 0 1px black;
+    -gtk-icon-shadow: 0 1px black;
     outline-color: rgba(238, 238, 236, 0.3);
     border-radius: 3px;
     padding: 0 0px 2px 0px;
 }
 
-.app-notification .button.flat,
-.app-notification .header-bar .titlebutton.button,
-.header-bar .app-notification .titlebutton.button,
-.app-notification .titlebar .titlebutton.button,
-.titlebar .app-notification .titlebutton.button,
-.app-notification GtkCalendar.header .titlebutton.button,
-GtkCalendar.header .app-notification .titlebutton.button,
-.app-notification.frame .button.flat,
-.app-notification.frame .header-bar .titlebutton.button,
-.header-bar .app-notification.frame .titlebutton.button,
-.app-notification.frame .titlebar .titlebutton.button,
-.titlebar .app-notification.frame .titlebutton.button,
-.app-notification.frame GtkCalendar.header .titlebutton.button,
-GtkCalendar.header .app-notification.frame .titlebutton.button {
-    icon-shadow: 0 1px black;
+app-notification  button.flat,
+app-notification  header-bar .titlebutton button,
+header-bar .app-notification .titlebutton button,
+app-notification  titlebar .titlebutton button,
+titlebar .app-notification .titlebutton button,
+app-notification calendar.header .titlebutton button,
+calendar.header .app-notification .titlebutton button,
+app-notification.frame  button.flat,
+app-notification.frame  header-bar .titlebutton button,
+header-bar .app-notification.frame .titlebutton button,
+app-notification.frame  titlebar .titlebutton button,
+titlebar .app-notification.frame .titlebutton button,
+app-notification.frame calendar.header .titlebutton button,
+calendar.header .app-notification.frame .titlebutton button {
+    -gtk-icon-shadow: 0 1px black;
     text-shadow: 0 1px black;
 }
 
-.app-notification .button:hover,
-.app-notification.frame .button:hover {
+app-notification  button:hover,
+app-notification.frame  button:hover {
     color: white;
     border-color: rgba(0, 0, 0, 0.7);
     background-image: linear-gradient(to bottom,
@@ -3141,20 +3090,20 @@ GtkCalendar.header .app-notification.frame .titlebutton.button {
     background-clip: padding-box;
     box-shadow: inset 0 1px rgba(255, 255, 255, 0.1);
     text-shadow: none;
-    icon-shadow: 0 1px black;
+    -gtk-icon-shadow: 0 1px black;
     outline-color: rgba(238, 238, 236, 0.3);
     border-radius: 3px;
     padding: 0 0px 2px 0px;
 }
 
-.app-notification .button:active,
-.app-notification .button:checked,
-.app-notification .button:backdrop:active,
-.app-notification .button:backdrop:checked,
-.app-notification.frame .button:active,
-.app-notification.frame .button:checked,
-.app-notification.frame .button:backdrop:active,
-.app-notification.frame .button:backdrop:checked {
+app-notification  button:active,
+app-notification  button:checked,
+app-notification  button:backdrop:active,
+app-notification  button:backdrop:checked,
+app-notification.frame  button:active,
+app-notification.frame  button:checked,
+app-notification.frame  button:backdrop:active,
+app-notification.frame  button:backdrop:checked {
     color: white;
     border-color: rgba(0, 0, 0, 0.7);
     background-image: linear-gradient(to bottom,
@@ -3162,15 +3111,15 @@ GtkCalendar.header .app-notification.frame .titlebutton.button {
     background-clip: padding-box;
     box-shadow: none;
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     outline-color: rgba(238, 238, 236, 0.3);
     border-radius: 3px;
 }
 
-.app-notification .button:insensitive,
-.app-notification .button:backdrop:insensitive,
-.app-notification.frame .button:insensitive,
-.app-notification.frame .button:backdrop:insensitive {
+app-notification  button:disabled,
+app-notification  button:backdrop:disabled,
+app-notification.frame  button:disabled,
+app-notification.frame  button:backdrop:disabled {
     color: #878989;
     border-color: rgba(0, 0, 0, 0.7);
     background-image: linear-gradient(to bottom,
@@ -3178,13 +3127,13 @@ GtkCalendar.header .app-notification.frame .titlebutton.button {
     background-clip: padding-box;
     box-shadow: none;
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     border-radius: 3px;
     padding: 0px;
 }
 
-.app-notification .button:backdrop,
-.app-notification.frame .button:backdrop {
+app-notification  button:backdrop,
+app-notification.frame  button:backdrop {
     color: #eeeeec;
     border-color: rgba(0, 0, 0, 0.7);
     background-image: linear-gradient(to bottom,
@@ -3192,7 +3141,7 @@ GtkCalendar.header .app-notification.frame .titlebutton.button {
     background-clip: padding-box;
     box-shadow: none;
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     border-radius: 3px;
     padding: 0px;
 }
@@ -3200,7 +3149,7 @@ GtkCalendar.header .app-notification.frame .titlebutton.button {
 /*************
  * Calendars *
  *************/
-GtkCalendar.view {
+calendar.view {
 	border-radius: 3px;
 	border-style: solid;
 	border-width: 1px;
@@ -3208,7 +3157,7 @@ GtkCalendar.view {
 	padding: 2px;
 }
 
-GtkCalendar.header {
+calendar.header {
 	border-radius: 0;
 	background-image: linear-gradient(to bottom,
 	                                  shade(@theme_bg_color, 1.1),
@@ -3216,14 +3165,14 @@ GtkCalendar.header {
 	border-width: 0;
 }
 
-GtkCalendar.button,
-GtkCalendar.button:insensitive {
+calendar button,
+calendar button:disabled {
 	background-image: none;
 	background-color: transparent;
 }
 
 .highlight,
-GtkCalendar.highlight {
+calendar.highlight {
 	background-color: @theme_selected_bg_color;
 	color: @theme_selected_fg_color;
 	border-radius: 0;
@@ -3232,9 +3181,9 @@ GtkCalendar.highlight {
 }
 
 /**************
- * GtkInfoBar *
+ * GtkInfobar *
  **************/
-GtkInfoBar {
+infobar {
 	border-width: 0;
 	border-style: none;
 	border-radius: 3px;
@@ -3242,22 +3191,22 @@ GtkInfoBar {
 
 .info .entry,
 .info .entry:focus,
-.info .button,
-.info .button:insensitive,
-.info .button:checked,
-.info .button:active,
+.info  button,
+.info  button:disabled,
+.info  button:checked,
+.info  button:active,
 .warning .entry,
 .warning .entry:focus,
-.warning .button,
-.warning .button:insensitive,
-.warning .button:checked,
-.warning .button:active,
+.warning  button,
+.warning  button:disabled,
+.warning  button:checked,
+.warning  button:active,
 .error .entry,
 .error .entry:focus,
-.error .button,
-.error .button:insensitive,
-.error .button:checked,
-.error .button:active {
+.error  button,
+.error  button:disabled,
+.error  button:checked,
+.error  button:active {
 	border-image: none;
 	border-style: none;
 }
@@ -3282,23 +3231,23 @@ GtkInfoBar {
 	color: @error_fg_color;
 }
 
-GtkLabel {
+label {
 	color: @theme_fg_color;
 }
 
 /**************
  * Dim labels *
  **************/
-.dim-label,
-.dim-label:hover,
-.dim-label:focus,
-.view.dim-label {
+dim-label,
+dim-label:hover,
+dim-label:focus,
+.view dim-label {
 	color: mix (@theme_fg_color, @theme_bg_color, 0.50);
 	text-shadow: none;
 }
 
-.dim-label:selected,
-.dim-label:selected:focus {
+dim-label:selected,
+dim-label:selected:focus {
 	color: mix (@theme_selected_fg_color, @theme_base_color, 0.50);
 	text-shadow: none;
 }
@@ -3307,12 +3256,12 @@ GtkLabel {
  * Gtk-file-chooser-dialog *
  ***************************/
 
-GtkFileChooserDialog GtkTreeView.view {
+filechooserdialog treeview.view {
     background-color: @less_dark_color;
 }
 
-GtkFileChooserWidget.vertical GtkPaned.horizontal {
-    -GtkPaned-handle-size: 3px;
+filechooserwidget.vertical paned.horizontal {
+    -paned-handle-size: 3px;
     border-color: transparent;
 }
 
@@ -3502,15 +3451,15 @@ GtkFileChooserWidget.vertical GtkPaned.horizontal {
  * GtkActionBar *
  ****************/
 
-GtkActionBar .frame.action-bar {
+actionbar .frame.action-bar {
     padding: 2px;
 }
 
-GtkActionBar .frame.action-bar .button.image-button {
+actionbar .frame.action-bar  button.image-button {
     padding: 6px;
 }
 
-GtkActionBar .frame.action-bar .horizontal.stack-switcher.linked .button.image-button  {
+actionbar .frame.action-bar .horizontal stack-switcher.linked  button.image-button  {
     padding: 4px 2px;
 }
 
@@ -3518,7 +3467,7 @@ GtkActionBar .frame.action-bar .horizontal.stack-switcher.linked .button.image-b
  * GtkStack *
  ************/
 
-GtkStackSidebar.sidebar GtkScrolledWindow {
+stacksidebar scrolledwindow {
     background-image: linear-gradient(to bottom,
                                                              @toolbar_gradient_base,
                                                              @toolbar_gradient_bottom);
@@ -3527,7 +3476,7 @@ GtkStackSidebar.sidebar GtkScrolledWindow {
    padding: 0px;
 }
 
-.frame .horizontal GtkStack {
+frame .horizontal GtkStack {
     background-color: @less_dark_color;
     border-radius: 0px 3px 3px 0px;
     background-image: linear-gradient(to bottom,
@@ -3535,11 +3484,10 @@ GtkStackSidebar.sidebar GtkScrolledWindow {
                                                              @toolbar_gradient_bottom);
 }
 
-GtkStackSidebar.sidebar GtkViewport.frame {
+stacksidebar viewport.frame {
  background-color:transparent;
 }
 
-GtkStackSidebar.sidebar GtkViewport.frame .list-row.button {
+stacksidebar viewport.frame  list-row button {
     transition: none;
 }
-

--- a/desktop-themes/BlackMATE/gtk-3.0/mate-applications.css
+++ b/desktop-themes/BlackMATE/gtk-3.0/mate-applications.css
@@ -2,24 +2,22 @@
  * CAJA File manager *
  *********************/
 
-/**** View ***/
 
-/* background of all views */
-CajaNavigationWindow .view {
-    background-color: @less_dark_color;
+/**** Caja Navigation Window ***/
+
+window.background>*>paned>box>paned>box>notebook>stack>box>box>scrolledwindow.frame{ 							
+	background-color: @less_dark_color;
 	color: @theme_fg_color;
     border-color: transparent;
+	border-style: none;
 }
 
+/* selector not supported, not sure how to fix this */
+/*
 .caja-inactive-pane .view {
 	background-color: shade(@less_dark_color, 1.3);
 }
-
-/**** Window ***/
-
-CajaNavigationWindow .horizontal .vertical {
-    background-color: @theme_bg_color;
-}
+*/
 
 /* don't override gtktooglebutton */
 CajaNavigationWindow .toolbar.horizontal.primary-toolbar .vertical {
@@ -27,35 +25,22 @@ CajaNavigationWindow .toolbar.horizontal.primary-toolbar .vertical {
 }
 
 /* the small line between sidebar and view */
-CajaWindow GtkPaned.horizontal {
+/* another unsupported selector and with too short a "widget chain" not to match others
+CajaWindow paned.horizontal {
     -GtkPaned-handle-size: 3px;
     border-color: transparent;
     background-color: @theme_bg_color;
 }
+*/
 
-CajaWindow GtkScrolledWindow.frame {
-	border-style: none;
-}
-
-/* Caja pathbar */
-CajaNavigationWindow .horizontal .vertical .horizontal .vertical .horizontal CajaPathBar .button ,
-CajaNavigationWindow .horizontal .vertical .horizontal .vertical .horizontal .button.image-button {
-    padding: 5px;
-}
-
-/* View toogle button */
-CajaNavigationWindow .toolbar.horizontal.primary-toolbar .vertical .button {
-        padding: 6px;
-}
-
-CajaWindow .button {
+window.background>*>paned>box>box>button {
 	border-image: url("assets/button-border-dark1.svg") 3 / 3px stretch;
 	background-image: linear-gradient(to bottom,
 	                                  shade(@less_dark_color, 1.3),
 	                                  shade(@less_dark_color, 0.4));
 }
 
-CajaWindow .button:hover {
+window.background>*>paned>box>box>button:hover {
 	background-image: -gtk-gradient (radial,
 					0.5 -2.0, 2.0,
 					0.5 -2.0, 3.0,
@@ -66,10 +51,10 @@ CajaWindow .button:hover {
 
 }
 
-CajaWindow .button:checked,
-CajaWindow .button:hover:checked,
-CajaWindow .button:active,
-CajaWindow .button:hover:active {
+window.background>*>paned>box>box>button:checked,
+window.background>*>paned>box>box>button:hover:checked,
+window.background>*>paned>box>box>button:active,
+window.background>*>paned>box>box>button:hover:active {
 	background-image: linear-gradient(to bottom,
 	                                  shade(@button_gradient_color_b, 0.7),
 	                                  @theme_bg_color 40%,
@@ -87,7 +72,6 @@ CajaWindow column-header .button:hover {
 }
 
 CajaWindow .toolbar {
-	/*border-radius: 3px 0px 0px 3px;*/
 	background-image: linear-gradient(to bottom,
 	                                  shade(@less_dark_color, 0.4),
 	                                  shade(@less_dark_color, 1.36));
@@ -97,19 +81,19 @@ CajaToolbar .toolbar {
 	border-radius: 0px;
 }
 
-CajaWindow .scrollbar.slider:prelight,
-CajaWindow .scrollbar.slider:prelight:active,
-CajaWindow .scrollbar.slider.vertical:prelight,
-CajaWindow .scrollbar.slider.vertical:prelight:active {
+CajaWindow .scrollbar.slider:hover,
+CajaWindow .scrollbar.slider:hover:active,
+CajaWindow .scrollbar.slider.vertical:hover,
+CajaWindow .scrollbar.slider.vertical:hover:active {
 	border-color: shade(@scroll_slider_color, 1.1);
 }
 
 CajaWindow .scrollbar.button,
 CajaWindow .scrollbar.button.horizontal,
 CajaWindow .scrollbar.button.vertical,
-CajaWindow .scrollbar.button:insensitive,
-CajaWindow .scrollbar.button.horizontal:insensitive,
-CajaWindow .scrollbar.button.vertical:insensitive {
+CajaWindow .scrollbar.button:disabled,
+CajaWindow .scrollbar.button.horizontal:disabled,
+CajaWindow .scrollbar.button.vertical:disabled {
 	background-image: none;
 }
 
@@ -169,22 +153,18 @@ CajaWindow .button.flat:hover {
 /**** Sidebar ***/
 
 /* caja sidebar */
-CajaWindow FMTreeView .view,
-CajaWindow CajaNotesViewer .view,
-CajaWindow CajaPlacesSidebar .view,
-CajaWindow CajaHistorySidebar .view,
-CajaWindow CajaEmblemSidebar .frame,
-CajaWindow CajaInformationPanel .vertical {
-    background-color: shade (@theme_bg_color, 1.08);
+window.background*>paned>box>notebook>stack>scrolledwindow.frame treeview.view {
+    background-color: shade(@theme_bg_color, 1.08);
 }
 
-CajaWindow .sidebar .frame {
-	border-width: 0px;
+window.background*>paned>box>notebook>stack>scrolledwindow{
+		border-width: 0px;
 }
 
 /* moved eject button to left better for overlay scrollbars */
-CajaWindow CajaPlacesSidebar .view row {
+window.background*>paned>box>notebook>stack>scrolledwindow.frame treeview.view {
     padding: 0px 4px 0px 0px;
+	border-width: 0px;
 }
 
 CajaWindow .sidebar .scrollbar.button {
@@ -294,7 +274,7 @@ CajaDesktopWindow.background .caja-canvas-item:selected {
 }
 
 CajaDesktopWindow.background .caja-canvas-item:active,
-CajaDesktopWindow.background .caja-canvas-item:prelight,
+CajaDesktopWindow.background .caja-canvas-item:hover,
 CajaDesktopWindow.background .caja-canvas-item:selected {
 	text-shadow: none;
 }
@@ -304,28 +284,9 @@ CajaDesktopWindow.background .caja-canvas-item:selected {
  * Mate-Panel   *
  ****************/
 
-/* first make all transparent */
-PanelToplevel.background.horizontal {
-    background-color: transparent;
-}
-
-WnckSelector.menubar,
-PanelMenuBar.menubar,
-WnckSelector GtkMenuItem,
-PanelMenuBar GtkMenuItem,
-MatePanelApplet GtkToggleButton.button {
-    border-image: none;
-    border-color: transparent;
-    background-image: none;
-    background-color: transparent;
-    box-shadow: none;
-}
 
 /* let's started */
 /* the panel bar itself */
-PanelToplevel.background.horizontal {
-    background-color: @theme_bg_color;
-}
 
 .mate-panel-menu-bar {
     background-color: @theme_bg_color;
@@ -342,6 +303,17 @@ PanelToplevel.background.horizontal {
     box-shadow: none;
 }
 
+
+.mate-panel-menu-bar menubar,
+.mate-panel-menu-bar menubar menuitem,
+.mate-panel-menu-bar togglebutton {
+    border-image: none;
+    border-color: transparent;
+    background-image: none;
+    background-color: transparent;
+    box-shadow: none;
+}
+
 /* panel grip */
 PanelToplevel.background {
     border-radius: 3px;
@@ -353,7 +325,7 @@ PanelToplevel.background {
 }
 
 /* hide buttons */
-PanelToplevel.background .button {
+.mate-panel-menu-bar button {
     background: transparent;
     border-image: none;
     border-radius: 3px;
@@ -362,7 +334,7 @@ PanelToplevel.background .button {
     box-shadow: none;
 }
 
-PanelToplevel.background .button:hover {
+.mate-panel-menu-bar button:hover {
     border-style: solid;
     border-width: 0px;
     border-color: shade(@button_border, 1.1);
@@ -373,13 +345,19 @@ PanelToplevel.background .button:hover {
                                       shade(@less_dark_color, 0.4));
 }
 
-PanelToplevel.background .button:hover:active {
+.mate-panel-menu-bar button:hover:active {
     border-style: solid;
     border-width: 0px;
     background-image: linear-gradient(to bottom,
                                       shade(@button_gradient_color_b, 0.7),
                                       @theme_bg_color 50%,
                                       shade(@button_gradient_color_a, 1.5));
+}
+
+/*sliders now need a background*/
+
+.mate-panel-applet-slider frame{
+	background-color:@theme_bg_color;
 }
 
 MatePanelApplet {
@@ -416,43 +394,33 @@ MatePanelAppletFrameDBus {
 }
 
 /* set normal menubar button */
-PanelMenuBar.menubar .menuitem {
+.mate-panel-menu-bar menuitem {
     transition: all 300ms ease-out;
 }
 
 /* set selected menubar button */
-PanelMenuBar.menubar .menuitem:hover {
-}
-
-/* set normal menubar menuitem */
-PanelMenuBar.menubar .menu .menuitem {
-    padding: 6px;
+.mate-panel-menu-bar menuitem:hover {
 }
 
 /* set selected menubar menuitem */
-PanelMenuBar.menubar .menu .menuitem:checked:hover,
-PanelMenuBar.menubar .menu .menuitem:active:hover,
-PanelMenuBar.menubar .menu .menuitem:hover {
+.mate-panel-menu-bar menu menuitem:checked:hover,
+.mate-panel-menu-bar menu menuitem:active:hover,
+.mate-panel-menu-bar menu menuitem:hover {
 }
 
 /* Mate menu button normal */
 /* makes the arrow visible, nothing more works */
-PanelMenuButton.button {
+.mate-panel-menu-bar menu menuitem button {
     background-image: none;
     background-color: transparent;
     color: shade (@menu_fg_color, 1.00);
 }
 
-/* Mate menu menuitem */
-PanelMenuButton .menu .menuitem,
-PanelMenuButton .menu .menuitem:hover {
-    padding: 6px;
-}
 
 /* desktop-applet, clockapplet, drivemount, character-map,
 dictionary */
-MatePanelApplet .button,
-MatePanelApplet .button.flat {
+.mate-panel-menu-bar .button,
+.mate-panel-menu-bar .button.flat {
     transition: all 400ms ease-out;
     border-radius: 1px;
     padding: 2px;
@@ -467,10 +435,10 @@ MatePanelApplet .button.flat {
     background-image: none;
 }
 
-MatePanelApplet .button:checked:hover,
-MatePanelApplet .button:checked,
-MatePanelApplet .button:active:hover,
-MatePanelApplet .button:active {
+.mate-panel-menu-bar .button:checked:hover,
+.mate-panel-menu-bar .button:checked,
+.mate-panel-menu-bar .button:active:hover,
+.mate-panel-menu-bar .button:active {
     border-radius: 3px;
     color: @theme_fg_color;
     border-style: solid;
@@ -480,8 +448,8 @@ MatePanelApplet .button:active {
                                       shade(@button_gradient_color_a, 1.5));
 }
 
-MatePanelApplet .button:hover,
-MatePanelApplet .button.flat:hover {
+.mate-panel-menu-bar .button:hover,
+.mate-panel-menu-bar .button.flat:hover {
     border-radius: 3px;
     border-image: none;
     border-style: solid;
@@ -669,6 +637,11 @@ NaTrayApplet {
  * Pluma *
  *********/
 
+#pluma-status-combo-button * {
+	padding : 0px;
+}
+
+
 /* text view */
 /* remove general frame color to avoid double edges */
 PlumaWindow.background .vertical .horizontal .vertical .notebook .vertical .frame {
@@ -704,14 +677,14 @@ PlumaWindow .notebook tab .button.flat:hover {
     background-image: none;
     box-shadow: inset 0 1px rgba(255,255,255,0), 0 1px rgba(255,255,255,0);
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     border-image: none;
 }
 
 PlumaCloseButton.button.flat,
 PlumaCloseButton.button.flat:hover,
-PlumaCloseButton:prelight.button.flat,
-PlumaCloseButton:prelight.button.flat:hover {
+PlumaCloseButton:hover.button.flat,
+PlumaCloseButton:hover.button.flat:hover {
     padding: 0px;
 }
 
@@ -846,7 +819,6 @@ EomThumbNav .button.flat:hover:last-child {
                                       shade(@button_gradient_color_a, 0.8));
 }
 
-EomThumbNav .button.flat:insensitive {
+EomThumbNav .button.flat:disabled {
     background-image: none;
 }
-

--- a/desktop-themes/BlackMATE/gtk-3.0/mate-applications.css
+++ b/desktop-themes/BlackMATE/gtk-3.0/mate-applications.css
@@ -27,7 +27,6 @@ CajaNavigationWindow .toolbar.horizontal.primary-toolbar .vertical {
 /* the small line between sidebar and view */
 /* another unsupported selector and with too short a "widget chain" not to match others
 CajaWindow paned.horizontal {
-    -GtkPaned-handle-size: 3px;
     border-color: transparent;
     background-color: @theme_bg_color;
 }

--- a/desktop-themes/BlackMATE/gtk-3.0/mate-applications.css
+++ b/desktop-themes/BlackMATE/gtk-3.0/mate-applications.css
@@ -62,8 +62,8 @@ window.background>*>paned>box>box>button:hover:active {
 	border-image: url("assets/button-active-border-dark1.svg") 3 / 3px stretch;
 }
 
-CajaWindow column-header .button,
-CajaWindow column-header .button:hover {
+window.background>*>paned>box>paned>box>notebook>stack>box>box>scrolledwindow>*>treeview.view header button,
+window.background>*>paned>box>paned>box>notebook>stack>box>box>scrolledwindow>*>treeview.view header button:hover {
 	border-image: none;
 	border-width: 0px 0px 1px 1px;
 	border-radius: 0;
@@ -71,16 +71,18 @@ CajaWindow column-header .button:hover {
 	border-color: @less_dark_color;
 }
 
-CajaWindow .toolbar {
+/* Disable this is it as the defaults seem to march it and the widget chain is too short not to match something else */
+/*
+window.background>*>toolbar {
 	background-image: linear-gradient(to bottom,
 	                                  shade(@less_dark_color, 0.4),
 	                                  shade(@less_dark_color, 1.36));
 }
 
-CajaToolbar .toolbar {
+window.background>*>toolbar {
 	border-radius: 0px;
 }
-
+*/
 CajaWindow .scrollbar.slider:hover,
 CajaWindow .scrollbar.slider:hover:active,
 CajaWindow .scrollbar.slider.vertical:hover,
@@ -97,25 +99,25 @@ CajaWindow .scrollbar.button.vertical:disabled {
 	background-image: none;
 }
 
-CajaWindow GtkStatusbar,
-CajaWindow .floating-bar {
+window.background>*>paned>box>statusbar>frame>box>label/*,
+CajaWindow .floating-bar*/ {
 	font: italic;
 }
-
+/*
 CajaWindow .floating-bar.right,
 CajaWindow .floating-bar.left {
     border-top-right-radius: 3px;
     border-top-left-radius: 3px;
 }
-
+*/
 /**** Notebook ***/
 
-.caja-inactive-pane .notebook {
+.caja-inactive-pane notebook {
 	background-color: shade(@less_dark_color, 1.3);
 	border-color: @less_dark_color;
 }
 
-.caja-inactive-pane .notebook tab.top:active {
+.caja-inactive-pane notebook header.top tab:active {
 	background-image: linear-gradient(to bottom,
 	                                  shade(@less_dark_color, 1.05),
 	                                  shade(@less_dark_color, 1.16) 40%,
@@ -123,33 +125,30 @@ CajaWindow .floating-bar.left {
 	                                  shade(@less_dark_color, 1.3));
 }
 
-CajaWindow .notebook .view.rubberband,
-CajaWindow .notebook .rubberband {
-	background-color: alpha(@theme_selected_bg_color, 0.35);
-}
 
-CajaNavigationWindow GtkPaned.horizontal GtkPaned.horizontal .vertical .notebook tab {
+window.background>*>paned>box>paned.horizontal .vertical notebook tab {
 	padding: 3px 0px;
 }
 
-CajaNavigationWindow GtkPaned.horizontal GtkPaned.horizontal .vertical .notebook tab .button.flat {
+window.background>*>paned>box>paned.horizontal .vertical .notebook tab .button.flat {
     border-image: none;
 }
 
 /* Caja places bar */
-CajaWindow .button.flat {
+/* Disable this as it does not seem to change the default and the widget chain is dangerously short 
+window.background>*>paned>box>paned>box>box>button.flat {
     border-style: none;
     border-image: url("assets/primary-toolbar-button-active-border-dark.svg") 3 / 3px stretch;
     border-radius: 3px;
     padding: 2px 5px;
 }
 
-CajaWindow .button.flat:hover {
+window.background>*>paned>box>paned>box>box>button.flat:hover {
     border-image: none;
     border-radius: 3px;
     padding: 2px 5px;
 }
-
+*/
 /**** Sidebar ***/
 
 /* caja sidebar */
@@ -167,40 +166,14 @@ window.background*>paned>box>notebook>stack>scrolledwindow.frame treeview.view {
 	border-width: 0px;
 }
 
-CajaWindow .sidebar .scrollbar.button {
+window.background*>paned>box>notebook>stack>scrolledwindow scrollbar button {
 	color: transparent;
 }
 
-CajaWindow .sidebar .scrollbar.button:hover {
+window.background*>paned>box>notebook>stack>scrolledwindow scrollbar button:hover {
 	color: @theme_fg_color;
 }
 
-CajaPlacesSidebar .cell,
-CajaPlacesSidebar *.cell {
-	color: @theme_text_color;
-}
-
-CajaPlacesSidebar .cell:hover,
-CajaPlacesSidebar *.cell:hover {
-	color: @theme_text_color;
-}
-
-CajaPlacesSidebar .cell:selected,
-CajaPlacesSidebar *.cell:selected {
-	background-image: linear-gradient(to bottom,
-	                                  shade(@less_dark_color, 1.5),
-	                                  shade(@less_dark_color, 0.6));
-	color: @theme_text_color;
-	border-radius: 2px;
-}
-
-CajaPlacesSidebar .cell:selected:focus,
-CajaPlacesSidebar *.cell:selected:focus {
-	color: @theme_text_color;
-	background-image: linear-gradient(to top,
-					 shade(@less_dark_color, 1.5),
-					 shade(@less_dark_color, 0.6));
-}
 
 /**** Infos ***/
 
@@ -249,33 +222,33 @@ EelEditableLabel.entry {
 }
 
 /* view */
-CajaNavigationWindow.background .view.caja-canvas-item {
+window.background>*>paned>box>paned>box>notebook>stack>box>box>scrolledwindow.frame .view .caja-canvas-item {
     color: @theme_fg_color;
 }
 
-CajaNavigationWindow.background .view.caja-canvas-item:active,
-CajaNavigationWindow.background .view.caja-canvas-item:selected {
+window.background>*>paned>box>paned>box>notebook>stack>box>box>scrolledwindow.frame .view .caja-canvas-item:active,
+window.background>*>paned>box>paned>box>notebook>stack>box>box>scrolledwindow.frame.view .caja-canvas-item:selected {
     color: @theme_selected_fg_color;
 }
 
 /**** Desktop Drawn ***/
 
-CajaDesktopWindow.background .caja-canvas-item {
+window>*>box>box>box>scrolledwindow>.view .caja-canvas-item {
 	color: @theme_fg_color;
     text-shadow: 1px 1px alpha (#000000, 0.8);
 }
 
-CajaDesktopWindow.background .caja-canvas-item:active {
+window>*>box>box>box>scrolledwindow>.view .caja-canvas-item:active {
 	color: @theme_text_color;
 }
 
-CajaDesktopWindow.background .caja-canvas-item:selected {
+window>*>box>box>box>scrolledwindow>.view .caja-canvas-item:selected {
 	color: @theme_selected_fg_color;
 }
 
-CajaDesktopWindow.background .caja-canvas-item:active,
-CajaDesktopWindow.background .caja-canvas-item:hover,
-CajaDesktopWindow.background .caja-canvas-item:selected {
+window>*>box>box>box>scrolledwindow>.view .caja-canvas-item:active,
+window>*>box>box>box>scrolledwindow>.view .caja-canvas-item:hover,
+window>*>box>box>box>scrolledwindow>.view .caja-canvas-item:selected {
 	text-shadow: none;
 }
 
@@ -315,7 +288,7 @@ CajaDesktopWindow.background .caja-canvas-item:selected {
 }
 
 /* panel grip */
-PanelToplevel.background {
+.mate-panel-menu-bar.background {
     border-radius: 3px;
 /* enable for making borders visible */
 /*    box-shadow: inset  0px  1px shade (@theme_selected_bg_color, 1.3),
@@ -360,6 +333,7 @@ PanelToplevel.background {
 	background-color:@theme_bg_color;
 }
 
+/*
 MatePanelApplet {
     border-width: 0;
 }
@@ -373,7 +347,7 @@ PanelSeparator {
     color: shade (@theme_fg_color, 0.45);
     text-shadow: none;
 }
-
+*/
 /* dictionary applet */
 GdictApplet .entry,
 GdictApplet .entry:focus {
@@ -464,12 +438,13 @@ dictionary */
 }
 
 /*Wncklist */
-WnckTasklist .button {
+.mate-panel-menu-bar button {
     transition: all 400ms ease-out;
     padding: 2px;
     border-radius: 3px;
     border-width: 1px;
     border-style: solid;
+	border-color:transparent;
     text-shadow: none;
     color: @theme_fg_color;
     background-image: -gtk-gradient (radial,
@@ -481,10 +456,10 @@ WnckTasklist .button {
                       to (shade(@button_gradient_color_b, 0.7)));
 }
 
-WnckTasklist .button:checked:hover,
-WnckTasklist .button:checked,
-WnckTasklist .button:active:hover,
-WnckTasklist .button:active {
+.mate-panel-menu-bar button:checked:hover,
+.mate-panel-menu-bar button:checked,
+.mate-panel-menu-bar button:active:hover,
+.mate-panel-menu-bar button:active {
     border-radius: 3px;
     color: @theme_fg_color;
     border-style: solid;
@@ -494,7 +469,7 @@ WnckTasklist .button:active {
                                       shade(@button_gradient_color_a, 1.5));
 }
 
-WnckTasklist .button:hover {
+.mate-panel-menu-bar button .button:hover {
     border-radius: 3px;
     border-image: none;
     border-style: solid;
@@ -507,7 +482,7 @@ WnckTasklist .button:hover {
 }
 
 /* set normal button WnckSelector */
-WnckSelector.menubar .menuitem {
+.mate-panel-menu-bar button menubar menuitem {
     border-radius: 3px;
     color: @theme_fg_color;
     border-style: solid;
@@ -515,7 +490,7 @@ WnckSelector.menubar .menuitem {
 }
 
 /* set selected button WnckSelector */
-WnckSelector.menubar .menuitem:hover {
+.mate-panel-menu-bar button menubar menuitem:hover {
     color: @theme_fg_color;
     border-style: solid;
     background-image: linear-gradient(to bottom,
@@ -525,7 +500,7 @@ WnckSelector.menubar .menuitem:hover {
 }
 
 /* set WnckSelector menuitem */
-WnckSelector.menubar .menu .menuitem {
+.mate-panel-menu-bar button menubar menuitem {
     background-image:  none;
     color: @theme_text_color;
     border-style: none;
@@ -534,7 +509,7 @@ WnckSelector.menubar .menu .menuitem {
 }
 
 /* set WnckSelector selected menuitem */
-WnckSelector.menubar .menu .menuitem:hover {
+.mate-panel-menu-bar button menubar menuitem:hover {
     border-image: none;
     color: @theme_fg_color;
     background-image: linear-gradient(to bottom,
@@ -542,13 +517,13 @@ WnckSelector.menubar .menu .menuitem:hover {
                                       shade(@theme_selected_bg_color, 0.5));
 }
 
-ClockBox,
+#clock-applet-button,
 .mate-panel-menu-bar.menubar,
 MatePanelApplet > GtkMenuBar.menubar {
     font: normal;
 }
-
-WnckPager {
+/*WnckPager is unnamed in GTK inspector so try this*/
+#PanelPlug>#PanelApplet * {
     background-image: none;
     border-color: transparent;
     background-color: transparent;
@@ -556,14 +531,14 @@ WnckPager {
 }
 
 /* selected WnckPager */
-WnckPager:selected {
+#PanelPlug>#PanelApplet *:selected {
     background-image: linear-gradient(to bottom,
                                       @theme_selected_bg_color,
                                       shade (@theme_selected_bg_color, 0.36));
 }
 
 /* prelight of WnckPager */
-WnckPager:hover {
+#PanelPlug>#PanelApplet *:hover {
     background-image: linear-gradient(to bottom,
                                       @theme_bg_color,
                                       shade (@theme_selected_bg_color, 0.86));
@@ -591,7 +566,7 @@ MatePanelApplet .horizontal .vertical .frame {
     border-style: none;
     border-radius: 5px;
 }
-
+/*These seem to work, tray did not come up in GtkInspector so don't know why*/
 /* no background for icon-padding area */
 GtkTrayIcon.background {
     background-color: transparent;

--- a/desktop-themes/BlackMATE/gtk-3.0/mate-applications.css
+++ b/desktop-themes/BlackMATE/gtk-3.0/mate-applications.css
@@ -11,12 +11,6 @@ CajaNavigationWindow .view {
     border-color: transparent;
 }
 
-/* do not flash the desktop with a color during theme switching */
-CajaDesktopWindow FMDesktopIconView .view {
-    background-color: transparent;
-    background-image: none;
-}
-
 .caja-inactive-pane .view {
 	background-color: shade(@less_dark_color, 1.3);
 }
@@ -269,30 +263,42 @@ CajaQueryEditor .toolbar .entry:focus {
 	            inset 0 -1px alpha(@entry_shadow, 0.06);
 }
 
-.caja-canvas-item {
-	border-radius: 5px;
+.caja-canvas-item,
+EelEditableLabel.entry {
+	border-radius: 4px;
+}
+
+/* view */
+CajaNavigationWindow.background .view.caja-canvas-item {
+    color: @theme_fg_color;
+}
+
+CajaNavigationWindow.background .view.caja-canvas-item:active,
+CajaNavigationWindow.background .view.caja-canvas-item:selected {
+    color: @theme_selected_fg_color;
 }
 
 /**** Desktop Drawn ***/
 
-.caja-desktop.caja-canvas-item {
+CajaDesktopWindow.background .caja-canvas-item {
 	color: @theme_fg_color;
-	text-shadow: none;
+    text-shadow: 1px 1px alpha (#000000, 0.8);
 }
 
-.caja-desktop.caja-canvas-item:active {
+CajaDesktopWindow.background .caja-canvas-item:active {
 	color: @theme_text_color;
 }
 
-.caja-desktop.caja-canvas-item:selected {
+CajaDesktopWindow.background .caja-canvas-item:selected {
 	color: @theme_selected_fg_color;
 }
 
-.caja-desktop.caja-canvas-item:active,
-.caja-desktop.caja-canvas-item:prelight,
-.caja-desktop.caja-canvas-item:selected {
+CajaDesktopWindow.background .caja-canvas-item:active,
+CajaDesktopWindow.background .caja-canvas-item:prelight,
+CajaDesktopWindow.background .caja-canvas-item:selected {
 	text-shadow: none;
 }
+
 
 /****************
  * Mate-Panel   *

--- a/desktop-themes/BlackMATE/gtk-3.0/other-applications.css
+++ b/desktop-themes/BlackMATE/gtk-3.0/other-applications.css
@@ -27,18 +27,21 @@ NemoWindow > GtkGrid > .pane-separator.vertical:selected {
 
 /**** View ***/
 
-NemoView .view {
-	background-color: shade (@theme_bg_color, 1.08);
+window.background>grid>paned>box>paned>box>notebook>stack>box>*>scrolledwindow {
+	background-color: @less_dark_color;
 	color: @theme_fg_color;
+    border-color: transparent;
+	border-style: none;
 }
 
+/* can do nothing with this right now 
 .nemo-inactive-pane .view {
 	background-color: shade(@less_dark_color, 1.3);
 }
-
+*/
 /* file renaming */
-NemoView .view .entry,
-NemoView .view .entry:focus {
+window>*>box>box>box>scrolledwindow>.view .entry,
+window>*>box>box>box>scrolledwindow>.view .entry:focus {
 	background-image: none;
 	border-image: none;
 	border-style: solid;
@@ -47,12 +50,6 @@ NemoView .view .entry:focus {
 	background-color: shade(@theme_selected_bg_color, 0.3);
 }
 
-/**** Window ***/
-
-NemoWindow .view {
-	background-color: shade (@theme_bg_color, 1.08);
-	color: @theme_fg_color;
-}
 
 /* the small line between sidebar and view */
 NemoWindow * {
@@ -115,19 +112,19 @@ NemoToolbar .toolbar {
 	border-radius: 0px;
 }
 
-NemoWindow .scrollbar.slider:prelight,
-NemoWindow .scrollbar.slider:prelight:active,
-NemoWindow .scrollbar.slider.vertical:prelight,
-NemoWindow .scrollbar.slider.vertical:prelight:active {
+NemoWindow .scrollbar.slider:hover,
+NemoWindow .scrollbar.slider:hover:active,
+NemoWindow .scrollbar.slider.vertical:hover,
+NemoWindow .scrollbar.slider.vertical:hover:active {
 	border-color: shade(@scroll_slider_color, 1.1);
 }
 
 NemoWindow .scrollbar.button,
 NemoWindow .scrollbar.button.horizontal,
 NemoWindow .scrollbar.button.vertical,
-NemoWindow .scrollbar.button:insensitive,
-NemoWindow .scrollbar.button.horizontal:insensitive,
-NemoWindow .scrollbar.button.vertical:insensitive {
+NemoWindow .scrollbar.button:disabled,
+NemoWindow .scrollbar.button.horizontal:disabled,
+NemoWindow .scrollbar.button.vertical:disabled {
 	background-image: none;
 }
 
@@ -161,17 +158,22 @@ NemoWindow .notebook .rubberband {
 	background-color: alpha(@theme_selected_bg_color, 0.35);
 }
 
-/**** Sidebar ***/
+/**** NemoSidebar ***/
 
-NemoWindow .sidebar .frame {
+window.background>grid>paned>box>scrolledwindow>viewport.frame,
+window.background>grid>paned>box>scrolledwindow>viewport treeview.view{
+	background-color: shade(@theme_bg_color, 1.08);
+}
+
+NemoWindow sidebar frame {
 	border-width: 0px;
 }
 
-NemoWindow .sidebar .scrollbar.button {
+NemoWindow sidebar scrollbar button {
 	color: @theme_fg_color;
 }
 
-NemoWindow .sidebar .scrollbar.button:hover {
+NemoWindow sidebar scrollbar button:hover {
 	color: @theme_fg_color;
 }
 
@@ -263,7 +265,7 @@ NemoQueryEditor .toolbar .entry:focus {
 }
 
 .nemo-desktop.nemo-canvas-item:active,
-.nemo-desktop.nemo-canvas-item:prelight,
+.nemo-desktop.nemo-canvas-item:hover,
 .nemo-desktop.nemo-canvas-item:selected {
 	text-shadow: none;
 }
@@ -296,4 +298,3 @@ DConfWindow GtkPaned.horizontal {
     border-color: transparent;
     background-color: @theme_bg_color;
 }
-

--- a/desktop-themes/BlackMATE/gtk-3.0/other-applications.css
+++ b/desktop-themes/BlackMATE/gtk-3.0/other-applications.css
@@ -51,11 +51,6 @@ window>*>box>box>box>scrolledwindow>.view .entry:focus {
 }
 
 
-/* the small line between sidebar and view */
-NemoWindow * {
-	-GtkPaned-handle-size: 2px;
-}
-
 NemoWindow GtkPaned {
 	background-color: @less_dark_color;
 }
@@ -294,7 +289,6 @@ DConfWindow DConfKeyView.view {
 
 /* the small line between sidebar and view */
 DConfWindow GtkPaned.horizontal {
-    -GtkPaned-handle-size: 3px;
     border-color: transparent;
     background-color: @theme_bg_color;
 }

--- a/desktop-themes/BlackMATE/gtk-3.0/unity.css
+++ b/desktop-themes/BlackMATE/gtk-3.0/unity.css
@@ -76,7 +76,7 @@ UnityPanelWidget,
 .unity-panel.menuitem,
 .unity-panel .menuitem {
     border-width: 1px 1px 0 1px;
-    icon-shadow: 0 -1px #000000;
+    -gtk-icon-shadow: 0 -1px #000000;
 }
 
 .unity-panel.menubar:backdrop,

--- a/desktop-themes/Blue-Submarine/gtk-3.0/mate-applications.css
+++ b/desktop-themes/Blue-Submarine/gtk-3.0/mate-applications.css
@@ -2,15 +2,7 @@
  * CAJA File manager *
  *********************/
 
-/**** Desktop View ***/
-
-/* do not flash the desktop with a color during theme switching */
-CajaDesktopWindow FMDesktopIconView .view {
-    background-color: transparent;
-    background-image: none;
-}
-
-/**** View ***/
+/**** Window ***/
 
 /* background of all views */
 CajaNavigationWindow .view {
@@ -22,8 +14,6 @@ CajaNavigationWindow .view {
 CajaNavigationWindow FMListView .view {
     background-color: shade (@base_color, 1.0);
 }
-
-/**** Window ***/
 
 /* caja sidebar */
 CajaWindow FMTreeView .view,
@@ -612,35 +602,32 @@ CajaNavigationWindow CajaNotebook.notebook tab .button.flat {
     border-radius: 4px;
 }
 
-.caja-canvas-item {
-    border-radius: 3px;
-}
-/*
-.caja-canvas-item {
-    border-radius: 3px;
+EelEditableLabel.entry,
+EelEditableLabel.entry:focused {
+   border-image: none;
+   border-width: 1px;
+   border-color: @theme_fg_color;
+   box-shadow: none;
+   border-radius: 3px;
+   text-shadow: none;
 }
 
-*//* desktop mode *//*
-.caja-desktop.caja-canvas-item {
+.caja-canvas-item {
+    border-radius: 4px;
+}
+
+/* desktop mode */
+CajaDesktopWindow.background .caja-canvas-item {
     color: white;
-    text-shadow: 1px 1px black;
+    text-shadow: 1px 1px alpha (#000000, 0.8);
 }
 
-.caja-desktop.caja-canvas-item:checked {
-    background-image: none;
-    color: @theme_text_color;
-}
-
-.caja-desktop.caja-canvas-item:selected {
-    color: @theme_selected_fg_color;
-}
-
-.caja-desktop.caja-canvas-item:checked,
-.caja-desktop.caja-canvas-item:prelight,
-.caja-desktop.caja-canvas-item:selected {
+CajaDesktopWindow.background .caja-canvas-item:active,
+CajaDesktopWindow.background .caja-canvas-item:prelight,
+CajaDesktopWindow.background .caja-canvas-item:selected {
     text-shadow: none;
 }
-*/
+
 /****************
  * Mate-Panel *
  ****************/

--- a/desktop-themes/Blue-Submarine/gtk-3.0/other-applications.css
+++ b/desktop-themes/Blue-Submarine/gtk-3.0/other-applications.css
@@ -753,3 +753,30 @@ DConfWindow GtkPaned.horizontal {
     background-color: @theme_bg_color;
 }
 
+DConfKeyView.view row:selected,
+DConfKeyView.view row:selected:hover  {
+    background-image: -gtk-gradient (linear,
+                                     left top,
+                                     left bottom,
+                                     from (shade(@sidebar_selected_bg, 0.90)),
+                                     color-stop (0.40, shade (@sidebar_selected_bg, 0.98)),
+                                     to (shade(@sidebar_selected_bg, 1.05)));
+    color:  @theme_selected_fg_color;
+}
+
+DConfKeyView.view .entry.spinbutton {
+    padding: 2px 0px 2px 4px;
+    box-shadow: none;
+    border-style: none;
+}
+
+DConfKeyView.view .spinbutton .button,
+DConfKeyView.view .spinbutton .button:hover {
+    border-style: none;
+}
+
+DConfKeyView.view .spinbutton .button:last-child,
+DConfKeyView.view .spinbutton .button:hover:last-child {
+    border-radius: 0 5px 5px 0;
+}
+

--- a/desktop-themes/BlueMenta/gtk-3.0/mate-applications.css
+++ b/desktop-themes/BlueMenta/gtk-3.0/mate-applications.css
@@ -2,12 +2,6 @@
  * CAJA File manager *
  *********************/
 
-/* do not flash the desktop with a color during theme switching */
-CajaDesktopWindow FMDesktopIconView .view {
-    background-color: transparent;
-    background-image: none;
-}
-
 /* for breadcrumbs path bar */
 
 .caja-pathbar-button,
@@ -239,27 +233,40 @@ CajaWindow CajaHistorySidebar .vertical.scrollbar.overlay-indicator {
 	-GtkRange-slider-width: 11;
 }
 
-/* desktop mode */
-.caja-desktop.caja-canvas-item {
-    color: @theme_bg_color;
-    text-shadow: 1px 1px alpha (#000000, 0.8);
+.caja-canvas-item {
+    border-radius: 3px;
 }
 
-.caja-desktop.caja-canvas-item:active {
-    background-image: none;
-    background-color: alpha (@theme_bg_color, 0.84);
+/* view */
+CajaNavigationWindow.background .view.caja-canvas-item {
     color: @theme_fg_color;
 }
 
-.caja-desktop.caja-canvas-item:selected {
-    background-image: none;
-    background-color: alpha (@theme_selected_bg_color, 0.84);
+CajaNavigationWindow.background .view.caja-canvas-item:active,
+CajaNavigationWindow.background .view.caja-canvas-item:selected {
     color: @theme_selected_fg_color;
 }
 
-.caja-desktop.caja-canvas-item:active,
-.caja-desktop.caja-canvas-item:prelight,
-.caja-desktop.caja-canvas-item:selected {
+/* desktop mode */
+CajaDesktopWindow.background FMIconContainer.view EelEditableLabel.entry {
+   border-image: none;
+   border-width: 1px;
+   text-shadow: none;
+}
+
+CajaDesktopWindow.background .caja-canvas-item {
+    color: @theme_selected_fg_color;
+    text-shadow: 1px 1px alpha (#000000, 0.8);
+}
+
+CajaDesktopWindow.background .caja-canvas-item:selected {
+    background-color: @theme_selected_bg_color;
+    color: @theme_selected_fg_color;
+}
+
+CajaDesktopWindow.background .caja-canvas-item:active,
+CajaDesktopWindow.background .caja-canvas-item:prelight,
+CajaDesktopWindow.background .caja-canvas-item:selected {
     text-shadow: none;
 }
 

--- a/desktop-themes/BlueMenta/gtk-3.0/other-applications.css
+++ b/desktop-themes/BlueMenta/gtk-3.0/other-applications.css
@@ -355,6 +355,28 @@ DConfWindow GtkPaned.horizontal {
     background-color: @theme_bg_color;
 }
 
+DConfKeyView.view row:selected,
+DConfKeyView.view row:selected:hover  {
+    color:  @theme_selected_fg_color;
+}
+
+DConfKeyView.view .entry.spinbutton {
+    padding: 1px 0px 1px 4px;
+}
+
+DConfKeyView.view .spinbutton .button {
+    border-image: none;
+    border-style: solid;
+    border-width: 0px 0px 0px 1px;
+    border-color: @theme_selected_bg_color;
+    border-radius: 0px;
+    box-shadow: none;
+}
+
+DConfKeyView.view .spinbutton .button:last-child {
+    border-radius: 0 2px 2px 0;
+}
+
 /*****************
  * Ubuntu styles *
  *****************/

--- a/desktop-themes/ContrastHigh/gtk-3.0/mate-applications.css
+++ b/desktop-themes/ContrastHigh/gtk-3.0/mate-applications.css
@@ -2,12 +2,6 @@
  * Caja *
  ************/
 
-/* do not flash the desktop with a color during theme switching */
-CajaDesktopWindow FMDesktopIconView .view {
-    background-color: transparent;
-    background-image: none;
-}
-
 .caja-cluebar-label {
     color: @theme_selected_fg_color;
     font: bold;
@@ -33,22 +27,32 @@ CajaWindow .pane-separator {
     border-color: @theme_border_color;
 }
 
-.caja-desktop.caja-canvas-item {
+.caja-canvas-item,
+EelEditableLabel.entry {
+	border-radius: 3px;
+}
+
+EelEditableLabel.entry {
+    text-shadow: none;
+    color: @theme_fg_color;
+}
+
+CajaDesktopWindow.background .caja-canvas-item {
     color: @theme_selected_fg_color;
     text-shadow: 1px 1px black;
 }
 
-.caja-desktop.caja-canvas-item:selected {
+CajaDesktopWindow.background .caja-canvas-item:selected {
     color: @theme_selected_fg_color;
 }
 
-.caja-desktop.caja-canvas-item:backdrop {
+CajaDesktopWindow.background .caja-canvas-item:backdrop {
     background-color: @theme_fg_color;
 }
 
-.caja-desktop.caja-canvas-item:active,
-.caja-desktop.caja-canvas-item:prelight,
-.caja-desktop.caja-canvas-item:selected {
+CajaDesktopWindow.background .caja-canvas-item:active,
+CajaDesktopWindow.background .caja-canvas-item:prelight,
+CajaDesktopWindow.background .caja-canvas-item:selected {
     text-shadow: none;
 }
 

--- a/desktop-themes/ContrastHigh/gtk-3.0/other-applications.css
+++ b/desktop-themes/ContrastHigh/gtk-3.0/other-applications.css
@@ -23,6 +23,22 @@ DConfWindow GtkPaned.horizontal {
     border-width: 0px 1px 0 1px;
 }
 
+DConfKeyView.view .spinbutton .button {
+    border-image: none;
+    border-style: solid;
+    border-width: 0px 0px 0px 3px;
+    border-color: @theme_selected_bg_color;
+    border-radius: 0px;
+    box-shadow: none;
+}
+
+DConfKeyView.view .spinbutton .button:last-child {
+    border-radius: 0 2px 2px 0;
+    border-style: solid;
+    border-width: 0px 0px 0px 3px;
+    border-color: @theme_selected_bg_color;
+}
+
 /********
  * Nemo *
  ********/

--- a/desktop-themes/ContrastHighInverse/gtk-3.0/mate-applications.css
+++ b/desktop-themes/ContrastHighInverse/gtk-3.0/mate-applications.css
@@ -2,10 +2,61 @@
  * Caja *
  ************/
 
-/* do not flash the desktop with a color during theme switching */
-CajaDesktopWindow FMDesktopIconView .view {
-    background-color: transparent;
-    background-image: none;
+.caja-cluebar-label {
+    color: @theme_selected_fg_color;
+    font: bold;
+}
+
+CajaWindow .sidebar .frame {
+    border-style: none;
+}
+
+CajaNotebook.notebook {
+    border-right-width: 0;
+    border-left-width: 0;
+    border-bottom-width: 0;
+}
+
+CajaNotebook .frame {
+    border-width: 0;
+}
+
+CajaWindow .pane-separator {
+    border-width: 0 1px 0 0;
+    border-style: solid;
+    border-color: @theme_border_color;
+}
+
+.caja-canvas-item,
+EelEditableLabel.entry {
+	border-radius: 3px;
+}
+
+EelEditableLabel.entry,
+EelEditableLabel.entry:selected {
+    text-shadow: none;
+    color: @theme_fg_color;
+}
+
+CajaDesktopWindow.background .caja-canvas-item {
+    color: @theme_fg_color;
+    text-shadow: 1px 1px black;
+}
+
+CajaDesktopWindow.background .caja-canvas-item:active,
+CajaDesktopWindow.background .caja-canvas-item:selected {
+    color: @theme_fg_color;
+    background-color: @theme_selected_bg_color;
+}
+
+CajaDesktopWindow.background .caja-canvas-item:backdrop {
+    background-color: @theme_fg_color;
+}
+
+CajaDesktopWindow.background .caja-canvas-item:active,
+CajaDesktopWindow.background .caja-canvas-item:prelight,
+CajaDesktopWindow.background .caja-canvas-item:selected {
+    text-shadow: none;
 }
 
 /**************

--- a/desktop-themes/ContrastHighInverse/gtk-3.0/other-applications.css
+++ b/desktop-themes/ContrastHighInverse/gtk-3.0/other-applications.css
@@ -23,6 +23,22 @@ DConfWindow GtkPaned.horizontal {
     border-width: 0px 1px 0 1px;
 }
 
+DConfKeyView.view .spinbutton .button {
+    border-image: none;
+    border-style: solid;
+    border-width: 0px 0px 0px 3px;
+    border-color: @theme_selected_bg_color;
+    border-radius: 0px;
+    box-shadow: none;
+}
+
+DConfKeyView.view .spinbutton .button:last-child {
+    border-radius: 0 2px 2px 0;
+    border-style: solid;
+    border-width: 0px 0px 0px 3px;
+    border-color: @theme_selected_bg_color;
+}
+
 /********
  * Nemo *
  ********/

--- a/desktop-themes/Green-Submarine/gtk-3.0/gnome-applications.css
+++ b/desktop-themes/Green-Submarine/gtk-3.0/gnome-applications.css
@@ -409,8 +409,8 @@ NautilusTrashBar .button *:hover:checked {
     text-shadow: 0px 1px @theme_shadow_color;
 }
 
-.question .button:insensitive,
-NautilusTrashBar .button:insensitive {
+.question .button:disabled,
+NautilusTrashBar .button:disabled {
 /* .button:hover:active */
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
@@ -424,8 +424,8 @@ NautilusTrashBar .button:insensitive {
                 inset  0px -1px shade(@nautilus_cluebar_color, 0.78);
 }
 
-.question .button *:insensitive,
-NautilusTrashBar .button *:insensitive {
+.question .button *:disabled,
+NautilusTrashBar .button *:disabled {
     color: mix(@nautilus_cluebar_color, @theme_fg_color, 0.50);
     text-shadow: none;
 }
@@ -482,7 +482,7 @@ NautilusView.frame {
 }
 
 NautilusWindow .notebook {
-    -GtkNotebook-initial-gap: 0;
+    /*-GtkNotebook-initial-gap: 0;    deprecated*/
     background-color: @theme_base_color;
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
@@ -561,7 +561,7 @@ NautilusWindow .notebook tab .button GtkImage {
     border-color: transparent;
     border-width: 1px;
     padding: 0;
-    icon-shadow: 1px 1px @theme_shadow_color;
+    -gtk-icon-shadow: 1px 1px @theme_shadow_color;
 }
 
 NautilusWindow .notebook tab .button GtkImage:hover {
@@ -575,7 +575,7 @@ NautilusWindow .notebook tab  .button GtkImage:checked,
 NautilusWindow .notebook tab  .button GtkImage:checked:hover {
     background-color: alpha(black, 0.15); 
     color: shade(@theme_fg_color, 1.00);
-    icon-shadow: 0px 1px @theme_shadow_color;
+    -gtk-icon-shadow: 0px 1px @theme_shadow_color;
     border-color: alpha(black, 0.27) 
                   alpha(black, 0.13) 
                   alpha(black, 0.13) 
@@ -603,7 +603,7 @@ NautilusWindow .notebook tab  .button GtkImage:checked:hover {
 }
 
 .nautilus-desktop.nautilus-canvas-item:active,
-.nautilus-desktop.nautilus-canvas-item:prelight,
+.nautilus-desktop.nautilus-canvas-item:hover,
 .nautilus-desktop.nautilus-canvas-item:selected {
     text-shadow: none;
 }
@@ -712,4 +712,3 @@ Gjs_WeatherWidget.frame.flat .frame.flat.weather-few-clouds-night GtkStack GtkSc
 Gjs_WeatherWidget.frame.flat .frame.flat.weather-overcast GtkStack GtkScrolledWindow .frame {
     color: @osd_button_fg_active;
 }
-

--- a/desktop-themes/Green-Submarine/gtk-3.0/gtk-widgets-assets.css
+++ b/desktop-themes/Green-Submarine/gtk-3.0/gtk-widgets-assets.css
@@ -1,86 +1,97 @@
 /*************************
  * Check and Radio items *
  *************************/
-
-.check,
-.view.cell.check,
-.check row:selected,
-.check row:selected:focus {
+check,
+.view.check,
+.view.cell check,
+check row:selected,
+check row:selected:focus {
     -gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked.png"));
 }
 
-.check:insensitive,
-.check row:selected:insensitive,
-.check row:selected:focus:insensitive {
+check:disabled,
+.view.check:disabled,
+check row:selected:disabled,
+check row:selected:focus:disabled {
     -gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked-insensitive.png"));
     background-color: transparent;
 }
 
-.check:checked,
-.view.cell.check:checked,
-.check row:selected:checked,
-.check row:selected:focus:checked {
+
+check:checked,
+.view.check:checked,
+check row:selected:checked,
+check row:selected:focus:checked {
     -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked.png"));
 
 }
 
-.check:checked:insensitive,
-.check row:selected:checked:insensitive,
-.check row:selected:focus:checked:insensitive {
+check:checked:disabled,
+.view.check:checked:disabled,
+check row:selected:checked:disabled,
+check row:selected:focus:checked:disabled {
     -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked-insensitive.png"));
     background-color: transparent;
 }
 
-.check:inconsistent,
-.check row:selected:inconsistent,
-.check row:selected:focus:inconsistent {
+check:indeterminate,
+.view.check:indeterminate,
+check row:selected:indeterminate,
+check row:selected:focus:indeterminate {
     -gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed.png"));
 
 }
 
-.check:inconsistent:insensitive,
-.check row:selected:inconsistent:insensitive,
-.check row:selected:focus:inconsistent:insensitive {
+check:indeterminate:disabled,
+.view.check:indeterminate:disabled,
+check row:selected:indeterminate:disabled,
+check row:selected:focus:indeterminate:disabled {
     -gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed-insensitive.png"));
 
 }
 
-.radio,
-.view.cell.radio,
-.radio row:selected,
-.radio row:selected:focus {
+radio,
+.view.radio,
+.view.cell radio,
+radio row:selected,
+radio row:selected:focus {
     -gtk-icon-source: -gtk-scaled(url("assets/radio-unselected.png"));
 }
 
-.radio:insensitive,
-.radio row:selected:insensitive,
-.radio row:selected:focus:insensitive {
+radio:disabled,
+.view.radio:disabled,
+radio row:selected:disabled,
+radio row:selected:focus:disabled {
     -gtk-icon-source: -gtk-scaled(url("assets/radio-unselected-insensitive.png"));
 }
 
-.radio:checked,
-.view.cell.radio:checked,
-.radio row:selected:checked,
-.radio row:selected:focus:checked {
+radio:checked,
+.view.radio:checked,
+.view.cell radio:checked,
+radio row:selected:checked,
+radio row:selected:focus:checked {
     -gtk-icon-source: -gtk-scaled(url("assets/radio-selected.png"));
 }
 
-.radio:checked:insensitive,
-.radio row:selected:checked:insensitive,
-.radio row:selected:focus:checked:insensitive {
+radio:checked:disabled,
+.view.radio:checked:disabled,
+radio row:selected:checked:disabled,
+radio row:selected:focus:checked:disabled {
     -gtk-icon-source: -gtk-scaled(url("assets/radio-selected-insensitive.png"));
 }
 
-.radio:inconsistent,
-.radio row:selected:inconsistent,
-.radio row:selected:focus:inconsistent {
+radio:indeterminate,
+.view.radio:indeterminate,
+radio row:selected:indeterminate,
+radio row:selected:focus:indeterminate {
     -gtk-icon-source: -gtk-scaled(url("assets/radio-mixed.png"));
 
 }
 
-.radio:inconsistent:insensitive,
-.radio row:selected:inconsistent:insensitive,
-.radio row:selected:focus:inconsistent:insensitive {
+radio:indeterminate:disabled,
+.view.radio:indeterminate:disabled,
+radio row:selected:indeterminate:disabled,
+radio row:selected:focus:indeterminate:disabled {
     -gtk-icon-source: -gtk-scaled(url("assets/radio-mixed-insensitive.png"));
     background-color: transparent;
 }
@@ -108,122 +119,123 @@
 
 /* Now draw menu check and radio items */
 
-.menuitem.radio:hover,
-.menuitem.radio:insensitive,
-.menuitem.check:hover,
-.menuitem.check:insensitive {
+menuitem.radio:hover,
+menuitem.radio:disabled,
+menuitem.check:hover,
+menuitem.check:disabled {
     background-color: transparent;
     background: none;
     border-style: none;
     border-image: none;
 }
 
-.menuitem.radio {
+menuitem.radio {
     -gtk-icon-source: -gtk-scaled(url("assets/radio-menuitem-unselected.svg"));
 }
 
-.menuitem.radio:checked {
+menuitem.radio:checked {
     -gtk-icon-source: -gtk-scaled(url("assets/radio-menuitem-checked.svg"));
 }
 
-.menuitem.radio:checked:hover {
+menuitem.radio:checked:hover {
     -gtk-icon-source: -gtk-scaled(url("assets/radio-menuitem-checked-prelight.svg"));
 }
 
-.menuitem.radio:checked:insensitive {
+menuitem.radio:checked:disabled {
     -gtk-icon-source: -gtk-scaled(url("assets/radio-menuitem-checked-insensitive.svg"));
 }
 
-.menuitem.radio:inconsistent {
+menuitem.radio:indeterminate {
     -gtk-icon-source: -gtk-scaled(url("assets/radio-menuitem-mixed.svg"));
 }
 
-.menuitem.radio:inconsistent:hover {
+menuitem.radio:indeterminate:hover {
     -gtk-icon-source: -gtk-scaled(url("assets/radio-menuitem-mixed-prelight.svg"));
 }
 
-.menuitem.radio:inconsistent:insensitive {
+menuitem.radio:indeterminate:disabled {
     -gtk-icon-source: -gtk-scaled(url("assets/radio-menuitem-mixed-insensitive.svg"));
 }
 
-.menuitem.check {
+menuitem.check {
     -gtk-icon-source: -gtk-scaled(url("assets/checkbox-menuitem-unchecked.svg"));
 }
 
-.menuitem.check:checked{
+menuitem.check:checked{
     -gtk-icon-source: -gtk-scaled(url("assets/checkbox-menuitem-checked.svg"));
 }
 
-.menuitem.check:checked:hover {
+menuitem.check:checked:hover {
     -gtk-icon-source: -gtk-scaled(url("assets/checkbox-menuitem-checked-prelight.svg"));
 }
 
-.menuitem.check:checked:insensitive {
+menuitem.check:checked:disabled {
     -gtk-icon-source: -gtk-scaled(url("assets/checkbox-menuitem-checked-insensitive.svg"));
 }
 
-.menuitem.check:inconsistent {
+menuitem.check:indeterminate {
     -gtk-icon-source: -gtk-scaled(url("assets/checkbox-menuitem-mixed.svg"));
 }
 
-.menuitem.check:inconsistent:hover {
+menuitem.check:indeterminate:hover {
     -gtk-icon-source: -gtk-scaled(url("assets/checkbox-menuitem-mixed-prelight.svg"));
 }
 
-.menuitem.check:inconsistent:insensitive {
+menuitem.check:indeterminate:disabled {
     -gtk-icon-source: -gtk-scaled(url("assets/checkbox-menuitem-mixed-insensitive.svg"));
 }
 
-GtkScale.slider,
-GtkScale.slider.horizontal,
-GtkScale.slider.horizontal:hover {
+scale slider,
+scale slider.horizontal,
+scale slider.horizontal:hover {
     background-image: url("assets/scale-slider-hor.svg");
 }
 
-GtkScale.slider:insensitive,
-GtkScale.slider.horizontal:insensitive {
+scale slider:disabled,
+scale slider.horizontal:disabled {
     background-image: url("assets/scale-slider-insensitive-hor.svg");
 }
 
-GtkScale.slider.vertical {
+scale slider.vertical {
     background-image: url("assets/scale-slider-ver.svg");
 }
 
-GtkScale.slider.vertical:insensitive {
+scale slider.vertical:disabled {
     background-image: url("assets/scale-slider-insensitive-ver.svg");
 }
 
-GtkScale.scale-has-marks-above.slider.horizontal,
-GtkScale.scale-has-marks-above.slider.horizontal:hover {
+scale.scale-has-marks-above.slider.horizontal,
+scale.scale-has-marks-above.slider.horizontal:hover {
     background-image: url("assets/scale-slider-marks-above-horizontal.svg");
 }
 
-GtkScale.scale-has-marks-above.slider.horizontal:insensitive {
+scale.scale-has-marks-above.slider.horizontal:disabled {
     background-image: url("assets/scale-slider-marks-above-horizontal-insensitive.svg");
 }
 
-GtkScale.scale-has-marks-above.slider.vertical {
+scale.scale-has-marks-above.slider.vertical {
     background-image: url("assets/scale-slider-marks-above-vertical.svg");
 }
 
-GtkScale.scale-has-marks-above.slider.vertical:insensitive {
+scale.scale-has-marks-above.slider.vertical:disabled {
     background-image: url("assets/scale-slider-marks-above-vertical-insensitive.svg");
 }
 
-GtkScale.scale-has-marks-below.slider.horizontal,
-GtkScale.scale-has-marks-below.slider.horizontal:hover {
+scale.scale-has-marks-below.slider.horizontal,
+scale.scale-has-marks-below.slider.horizontal:hover {
     background-image: url("assets/scale-slider-marks-below-horizontal.svg");
 }
 
-GtkScale.scale-has-marks-below.slider.horizontal:insensitive {
+scale.scale-has-marks-below.slider.horizontal:disabled {
     background-image: url("assets/scale-slider-marks-below-horizontal-insensitive.svg");
 }
 
-GtkScale.scale-has-marks-below.slider.vertical {
+scale.scale-has-marks-below.slider.vertical {
     background-image: url("assets/scale-slider-marks-below-vertical.svg");
 }
 
-GtkScale.scale-has-marks-below.slider.vertical:insensitive {
+scale.scale-has-marks-below.slider.vertical:disabled {
     background-image: url("assets/scale-slider-marks-below-vertical-insensitive.svg");
 }
+
 

--- a/desktop-themes/Green-Submarine/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/Green-Submarine/gtk-3.0/gtk-widgets.css
@@ -7,8 +7,8 @@
 * {
     padding: 0;
     background-clip: padding-box;
-    -GtkButton-default-border: 0;
-/*    -GtkButton-child-displacement-x: 1;
+    /*-GtkButton-default-border: 0;
+    -GtkButton-child-displacement-x: 1;
     -GtkButton-child-displacement-y: 1;*/
     -GtkButton-image-spacing: 0;
     -GtkButton-interior-focus: true;
@@ -767,7 +767,7 @@ button {
     transition: all 400ms ease-out;
     -GtkButton-image-spacing: 4;
     -GtkButton-interior-focus: true;
-    -GtkButton-default-border: 0;
+   /* -GtkButton-default-border: 0;*/
     -GtkButton-inner-border: 3;
     -GtkArrow-arrow-scaling: 0.5;
     background-image: -gtk-gradient (linear,

--- a/desktop-themes/Green-Submarine/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/Green-Submarine/gtk-3.0/gtk-widgets.css
@@ -7,9 +7,9 @@
 * {
     padding: 0;
     background-clip: padding-box;
-    -GtkButton-child-displacement-x: 1;
-    -GtkButton-child-displacement-y: 1;
     -GtkButton-default-border: 0;
+/*    -GtkButton-child-displacement-x: 1;
+    -GtkButton-child-displacement-y: 1;*/
     -GtkButton-image-spacing: 0;
     -GtkButton-interior-focus: true;
     -GtkButton-inner-border: 3;
@@ -22,11 +22,9 @@
     -GtkExpander-expander-size: 14;
     -GtkHTML-link-color: @link_color;
     -GtkIMHtml-hyperlink-color: @link_color;
-    -GtkMenu-horizontal-padding: 0;
-    -GtkMenu-vertical-padding: 0;
+/*    -GtkMenu-horizontal-padding: 0;
+    -GtkMenu-vertical-padding: 0;       */
     -GtkMenuBar-internal-padding: 0;
-    -GtkMenuItem-arrow-scaling: 0.7;
-    -GtkNotebook-tab-overlap: 1;
     -GtkPaned-handle-size: 1;
     -GtkProgressBar-min-horizontal-bar-height: 16;
     -GtkProgressBar-min-vertical-bar-width: 16;
@@ -51,22 +49,20 @@
     -GtkTreeView-expander-size: 12; /* arrow size in list/tree views */
     -GtkTreeView-horizontal-separator: 4;
     -GtkTreeView-vertical-separator: 4;
-    -GtkWidget-focus-padding: 2;
-    -GtkWidget-focus-line-width: 0;
     -GtkWindow-resize-grip-default: true;
     -GtkWindow-resize-grip-width: 13;
     -GtkWindow-resize-grip-height: 13;
-    -GtkWidget-separator-width: 2px;
-    -GtkWidget-separator-height: 2px;
-    -GtkWidget-wide-separators: true;
+/*   -GtkWidget-separator-width: 2px;
+     -GtkWidget-separator-height: 2px;
+     -GtkWidget-wide-separators: true;*/
     -WnckTasklist-fade-overlay-rect: 0;
     /* Highlight drag-drop destination */
-    engine: none;
+    /*engine: none; This is now IGNORED */
     outline-color: alpha(@theme_selected_bg_color, 0.3);
     outline-style: dashed;
     outline-offset: -3px; /* 2px */
     outline-width: 0px; /* disable ugly focus-line */
-    outline-radius: 2px;
+    -gtk-outline-radius: 2px;
     -gtk-icon-style: regular; /* no symbolic icons */
 }
 
@@ -74,7 +70,7 @@
  * Base States *
  ***************/
 
-GtkWindow {
+window {
     color: @theme_fg_color;
 }
 
@@ -85,7 +81,7 @@ GtkWindow {
 
 .background:backdrop {
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
 }
 
 /* Ugly hack to fix unexpected background colours (e.g. combo box arrow)
@@ -99,17 +95,17 @@ GtkWindow {
     background-color: alpha(shade(@theme_selected_bg_color, 1.90), 0.015);
 }
 
-*:hover:active:insensitive {
+*:hover:active:disabled {
 }
 
-*:active:insensitive {
+*:active:disabled {
 }
 
 *:hover {
      background-color: alpha(shade(@menu_bg_color, 1.05), 0.0);
 }
 
-*:hover:insensitive {
+*:hover:disabled {
 }
 
 *:selected,
@@ -118,7 +114,7 @@ GtkWindow {
     color: @theme_selected_fg_color;
 }
 
-*:insensitive {
+*:disabled {
     /* inherit the color from parent by default */
     background-color: inherit;
     color: @insensitive_fg_color;
@@ -134,7 +130,7 @@ GtkWindow {
     color: @theme_fg_color;
 }
 
-.gtkstyle-fallback:prelight {
+.gtkstyle-fallback:hover {
     background-color: shade(@theme_bg_color, 1.10);
     color: @theme_fg_color;
 }
@@ -144,7 +140,7 @@ GtkWindow {
     color: @theme_fg_color;
 }
 
-.gtkstyle-fallback:insensitive {
+.gtkstyle-fallback:disabled {
     background-color: @insensitive_bg_color;
     color: @insensitive_fg_color;
 }
@@ -155,16 +151,16 @@ GtkWindow {
 }
 
 /*********
- * label *
+ * GtkLabel *
  *********/
 
-GtkLabel,
-GtkLabel:insensitive {
+label,
+label:disabled {
     background-color: transparent;
 }
 
-.tooltip,
-.tooltip.background {
+tooltip,
+tooltip.background {
     padding: 4px 4px;
     color: shade(@theme_tooltip_fg_color, 0.90);
     border-width: 1px;
@@ -176,16 +172,18 @@ GtkLabel:insensitive {
     box-shadow: 0 1px 5px shade (@theme_selected_bg_color, 1.3);
 }
 
-.tooltip * {
+tooltip * {
     background-color: transparent;
     padding: 4px 4px;
 }
 
-.grip {
+grip {
     background-color: transparent;
     background-image: url("assets/resize-grip.svg");
 }
 
+view.rubberband,
+rubberband,
 .view.rubberband,
 .rubberband {
     background-color: alpha (@theme_selected_bg_color, 0.35);
@@ -199,7 +197,7 @@ GtkLabel:insensitive {
  * separator *
  *************/
 
-.separator {
+separator {
     border-width: 1px;
     border-style: solid;
     border-image: none;
@@ -208,38 +206,37 @@ GtkLabel:insensitive {
     border-right-color:  alpha (shade (@theme_bg_color, 1.26), 0.15);
 }
 
-GtkTreeView.view.separator,
-GtkTreeView.separator,
-GtkTreeView.view.separator:hover,
-GtkTreeView.separator:hover,
-.separator,
-.separator:prelight {
+treeview.view.separator,
+treeview.separator,
+treeview.view.separator:hover,
+treeview.separator:hover,
+separator,
+separator:hover {
     color: shade (@theme_bg_color, 0.92);
     border-color: mix(@theme_fg_color, @theme_bg_color, 0.95);
     border-image: none;
 }
 
-.separator.horizontal {
+separator.horizontal {
     border-width: 1px 0 1px 0;
 }
 
-.separator.vertical {
+separator.vertical {
     border-width: 0 1px 0 1px;
 }
 
-GtkComboBox .separator {
-    -GtkWidget-wide-separators: true;
+combobox .separator {
     -GtkWidget-horizontal-separator: 0;
     -GtkWidget-vertical-separator: 0;
 }
 
-.button .separator,
-.button.separator {
+button separator,
+button.separator {
     border-color: alpha (#000, 0.00);
 }
 
-.button .separator:insensitive,
-.button.separator:insensitive {
+button .separator:disabled,
+button.separator:disabled {
     border-color: alpha (#000, 0.00);
 }
 
@@ -247,23 +244,24 @@ GtkComboBox .separator {
     color: shade (@sidebar_background, 0.95);
 }
 
-.pane-separator:prelight,
+.pane-separator:hover,
 .pane-separator:selected {
     color: shade (@sidebar_background, 0.95);
 }
 
-GtkStatusbar {
-    padding: 5px;
+statusbar {
+    padding: 0px;
     color: @theme_fg_color;
-    -GtkStatusbar-shadow-type: none;
+    -statusbar-shadow-type: none;
     font-size: smaller;
 }
 
-GtkStatusbar .frame {
+statusbar .frame {
     padding: 0px;
     border-width: 0;
 }
 
+dnd,
 .dnd {
     border-width: 1px;
     border-style: solid;
@@ -275,8 +273,8 @@ GtkStatusbar .frame {
  * Text Entries *
  ****************/
 
-.entry,
-.combobox-entry .entry {
+entry,
+combobox-entry entry {
 /* Look out !
 This is the background color of mate-control-center 'too' */
     background-color: @theme_base_color;
@@ -310,14 +308,14 @@ This is the background color of mate-control-center 'too' */
                 inset  0px -1px shade(@button_border, 1.05);
 }
 
-.entry:focus {
+entry:focus {
     box-shadow: inset  0px  1px shade(@selected_bg_color, 1.05),
                 inset  1px  0px shade(@selected_bg_color, 0.97),
                 inset -1px  0px shade(@selected_bg_color, 0.93),
                 inset  0px -1px shade(@selected_bg_color, 0.93);
 }
 
-.entry:insensitive {
+entry:disabled {
     color: @insensitive_fg_color;
     background-image: none;
     background-color: @insensitive_bg_color;
@@ -331,13 +329,13 @@ This is the background color of mate-control-center 'too' */
                 inset  0px -1px @insensitive_border_color;
 }
 
-.entry:selected,
-.entry:selected:focus {
+entry selection,
+entry selection:focus {
     background-color: @theme_selected_bg_color;
     color: @theme_selected_fg_color;
 }
 
-.entry.progressbar {
+entry.progressbar {
     background-color: @theme_selected_bg_color;
     color: @theme_selected_fg_color;
     border-width: 1px;
@@ -348,12 +346,12 @@ This is the background color of mate-control-center 'too' */
  * Symbolic images *
  *******************/
 
-.image {
+image {
     color: @internal_element_color;
 }
 
-.image:prelight {
-    color: @internal_element_prelight;
+image:hover {
+    color: @internal_element_hover;
 }
 
 /****************
@@ -361,13 +359,17 @@ This is the background color of mate-control-center 'too' */
  ****************/
 
 /* progress component */
-.progressbar,
-.toolbar .progressbar,
-.entry.progressbar,
-.progressbar row,
-.progressbar row:hover,
-.progressbar row:selected,
-.progressbar row:selected:focus {
+progressbar progress,
+toolbar progressbar progress,
+entry progressbar,
+progressbar progress,
+progressbar row:hover,
+progressbar row:selected,
+progressbar row:selected:focus {
+	border-width: 1px;    /*set up border FIRST to avoid drawing failure in Synaptic */
+    border-style: solid;
+    border-radius: 3px;
+	min-height: 16px;
     background-image: linear-gradient(to right,
                                       alpha (#000, 0.00),
                                       alpha (#000, 0.00) 48%,
@@ -389,9 +391,6 @@ This is the background color of mate-control-center 'too' */
                 inset  1px  0px alpha(black, 0.03),
                 inset -1px  0px alpha(black, 0.03),
                 inset  0px -1px alpha(white, 0.10);
-    border-width: 1px;
-    border-style: solid;
-    border-radius: 3px;
     border-top-color: shade(@button_border_active, 0.80);
     border-left-color: shade(@button_border_active, 0.85);
     border-right-color: shade(@button_border_active, 0.85);
@@ -401,7 +400,11 @@ This is the background color of mate-control-center 'too' */
     text-shadow: none;
 }
 
-.progressbar.vertical {
+progressbar.vertical progress {
+    border-width: 1px;		 /*set up border FIRST to avoid drawing failure in Synaptic */
+    border-style: solid;
+    border-radius: 3px;
+	min-width: 16px;
     background-image: linear-gradient(to top,
                                       alpha (#000, 0.00),
                                       alpha (#000, 0.00) 48%,
@@ -423,9 +426,6 @@ This is the background color of mate-control-center 'too' */
                 inset  1px  0px alpha(black, 0.03),
                 inset -1px  0px alpha(white, 0.10),
                 inset  0px -1px alpha(black, 0.03);
-    border-width: 1px;
-    border-style: solid;
-    border-radius: 3px;
     border-top-color: shade(@button_border_active, 0.85);
     border-left-color: shade(@button_border_active, 0.80);
     border-right-color: shade(@button_border_active, 1.00);
@@ -435,27 +435,28 @@ This is the background color of mate-control-center 'too' */
     text-shadow: none;
 }
 
-GtkProgressBar {
-    /* FIXME - Not working 3.14 */
-    -GtkProgressBar-min-horizontal-bar-height: 16;
-    -GtkProgressBar-min-vertical-bar-width: 16;
+progressbar {
+    /* Deprecated and ignored in gtk 3.20, use css properties min-width/min-height instead 
+    -progressbar-min-horizontal-bar-height: 16;
+    -progressbar-min-vertical-bar-width: 16; */
     border-radius: 2px;
     padding: 0 0 1px 0;
     text-shadow: none;
 }
 
 /* through component */
-.trough row {
+progressbar trough {
     padding: 0px;
     text-shadow: none;
     border-radius: 2px;
     padding: 0 0 1px 0;
 }
 
-.trough,
-.toolbar .trough,
-.trough row,
-.trough row:hover {
+progressbar trough,
+toolbarprogressbar trough,
+trough row,
+trough row:hover {
+    min-height: 16px;
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (alpha (#000, 0.18)),
@@ -470,7 +471,8 @@ GtkProgressBar {
     text-shadow: none;
 }
 
-.trough.vertical {
+progressbar.vertical trough {
+	min-width: 16px;
     background-image: -gtk-gradient (linear,
                                      left top, right top,
                                      from (alpha (#000, 0.18)),
@@ -481,8 +483,8 @@ GtkProgressBar {
     text-shadow: none;
 }
 
-.trough row:selected,
-.trough row:selected:focus {
+trough row:selected,
+trough row:selected:focus {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (mix (@trough_bg_color_a, @theme_selected_bg_color, 0.25)),
@@ -490,21 +492,21 @@ GtkProgressBar {
 }
 
 /* level bars as used for password quality or remaining power */
-GtkLevelBar {
-    -GtkLevelBar-min-block-width: 34;
-    -GtkLevelBar-min-block-height: 3;
+levelbar {
+    -levelbar-min-block-width: 34;
+    -levelbar-min-block-height: 3;
 }
 
-GtkLevelBar.vertical {
-    -GtkLevelBar-min-block-width: 3;
-    -GtkLevelBar-min-block-height: 34;
+levelbar.vertical {
+    -levelbar-min-block-width: 3;
+    -levelbar-min-block-height: 34;
 }
 
-.level-bar.trough {
+level-bar trough {
     padding: 2px;
 }
 
-.level-bar.fill-block {
+level-bar.fill-block {
     border-width: 1px;
     border-style: solid;
     border-color: @button_border_active;
@@ -516,16 +518,16 @@ GtkLevelBar.vertical {
                                      to (shade (@button_bg_active, 1.20)));
 }
 
-.level-bar.indicator-continuous.fill-block {
+level-bar.indicator-continuous.fill-block {
     padding: 2px;
     border-radius: 2px;
 }
 
-.level-bar.indicator-discrete.fill-block.horizontal {
+level-bar.indicator-discrete.fill-block.horizontal {
     margin: 0 1px;
 }
 
-.level-bar.indicator-discrete.fill-block.vertical {
+level-bar.indicator-discrete.fill-block.vertical {
     margin: 1px 0;
 }
 
@@ -533,24 +535,24 @@ GtkLevelBar.vertical {
    uncomment when :nth-child will be working
    on the widget
 
-.level-bar.indicator-discrete.fill-block.horizontal:first-child {
+ level-bar.indicator-discrete.fill-block.horizontal:first-child {
     border-radius: 2px 0 0 2px;
 }
 
-.level-bar.indicator-discrete.fill-block.horizontal:last-child {
+ level-bar.indicator-discrete.fill-block.horizontal:last-child {
     border-radius: 0 2px 2px 0;
 }
 
-.level-bar.indicator-discrete.fill-block.vertical:first-child {
+ level-bar.indicator-discrete.fill-block.vertical:first-child {
     border-radius: 2px 2px 0 0;
 }
 
-.level-bar.indicator-discrete.fill-block.vertical:last-child {
+ level-bar.indicator-discrete.fill-block.vertical:last-child {
     border-radius: 0 0 2px 2px;
 }
 */
 
-.level-bar.fill-block.level-high {
+level-bar.fill-block.level-high {
     border-color: shade(@success_color, 0.85);
     background-image: linear-gradient(to bottom,
                                       shade(@success_color, 1.2),
@@ -558,7 +560,7 @@ GtkLevelBar.vertical {
                                       shade(@success_color, 0.95));
 }
 
-.level-bar.fill-block.level-low {
+level-bar.fill-block.level-low {
     border-color: shade(@warning_bg_color, 0.80);
     background-image: linear-gradient(to bottom,
                                       shade(@warning_bg_color, 1.3),
@@ -566,13 +568,13 @@ GtkLevelBar.vertical {
                                       shade(@warning_bg_color, 0.90));
 }
 
-.level-bar.fill-block.empty-fill-block {
+level-bar.fill-block.empty-fill-block {
     background-color: transparent;
     background-image: none;
     border-color: alpha(@theme_fg_color, 0.1);
 }
 
-.level-bar.fill-block.empty-fill-block:backdrop {
+level-bar.fill-block.empty-fill-block:backdrop {
     border-color: transparent;
     background-color: transparent;
 }
@@ -581,16 +583,15 @@ GtkLevelBar.vertical {
  * GtkScale *
  ************/
 
-.scale {
+scale {
     -GtkScale-slider-length: 16;
     -GtkRange-slider-width: 16;
     -GtkRange-trough-border: 0;
-    -GtkWidget-focus-line-width: 0;
 }
 
-.scale.slider,
-.scale.slider:hover,
-.scale.slider:insensitive {
+scale slider,
+scale slider:hover,
+scale slider:disabled {
     border-width: 1px;
     border-radius: 8px;
     border-style: none;
@@ -600,17 +601,17 @@ GtkLevelBar.vertical {
     background-position: center;
 }
 
-.scale.slider.fine-tune:active,
-.scale.slider.fine-tune:hover:active,
-.scale.slider.fine-tune.horizontal:active,
-.scale.slider.fine-tune.horizontal:hover:active {
+scale slider.fine-tune:active,
+scale slider.fine-tune:hover:active,
+scale slider.fine-tune.horizontal:active,
+scale slider.fine-tune.horizontal:hover:active {
     background-size: 98%;
     background-repeat: no-repeat;
     background-position: center;
 }
 
-.toolbar .scale.trough,
-.scale.trough {
+toolbar  scale trough,
+scale trough {
     border-radius: 8px;
     border-style: solid;
     border-width: 1px;
@@ -624,35 +625,35 @@ GtkLevelBar.vertical {
                 inset -1px -1px alpha(#000, 0.08);
 }
 
-.scale.trough {
+scale trough {
     margin: 6px 0;
 }
 
-.scale.trough.vertical {
+scale.vertical trough {
     margin: 0 6px;
 }
 
-.scale.trough,
-.scale.trough.vertical {
+scale trough,
+scale.vertical trough {
     border-color: @scale_border_b;
 }
 
-.scale.trough.highlight,
-.scale.trough.highlight.vertical {
+scale trough.highlight,
+scale.vertical trough.highlight {
     border-style: none;
 }
 
-.scale.trough,
-.scale.trough.vertical {
+scale trough,
+scale.vertical trough {
     border-color: @scale_border_b;
 }
 
-.scale.trough.highlight,
-.scale.trough.highlight.vertical {
+scale trough.highlight,
+scale.vertical trough.highlight {
     border-color: @scale_highlight_border;
 }
 
-.scale.trough:insensitive {
+scale trough:disabled {
     background-image: -gtk-gradient (linear,
                                      left top,
                                      left bottom,
@@ -661,24 +662,24 @@ GtkLevelBar.vertical {
     border-style: none;
 }
 
-.scale.progressbar {
+ scale.progressbar {
     background-color: @scale_progress_fill;
     border-width: 1px;
     border-radius: 3px;
     border-style: none;
 }
 
-.scale:insensitive,
-.vertical.scale:insensitive {
+scale:disabled,
+.vertical scale:disabled {
     background-color: transparent;
 }
 
-.scale.mark {
+scale .mark {
     color: mix(@theme_bg_color, @theme_text_color, 0.56);
 }
 
-.menubar .menuitem .scale.highlight.left,
-.scale.highlight.left {
+menubar  menuitem  scale.highlight.left,
+scale.highlight.left {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade (@scale_fill, 0.90)),
@@ -692,8 +693,8 @@ GtkLevelBar.vertical {
     text-shadow: none;
 }
 
-.menubar .menuitem .scale.highlight.bottom,
-.scale.highlight.bottom {
+menubar  menuitem  scale.highlight.bottom,
+scale.highlight.bottom {
     background-image: -gtk-gradient (linear,
                                      left top, right top,
                                      from (shade (@scale_fill, 0.90)),
@@ -707,7 +708,7 @@ GtkLevelBar.vertical {
     text-shadow: none;
 }
 
-.scale.highlight.left:insensitive {
+scale.highlight.left:disabled {
     background-image: -gtk-gradient (linear, left top, left bottom,
                                      from (shade (@theme_bg_color, 0.85)),
                                      to (shade (@theme_bg_color, 0.85)));
@@ -715,7 +716,7 @@ GtkLevelBar.vertical {
                 inset -1px -1px alpha(#000, 0.02);
 }
 
-.scale.highlight.bottom:insensitive {
+scale.highlight.bottom:disabled {
     background-image: -gtk-gradient (linear,  left top, right top,
                                      from (shade (@theme_bg_color, 0.85)),
                                      to (shade (@theme_bg_color, 0.85)));
@@ -726,8 +727,8 @@ GtkLevelBar.vertical {
 /**********
  * Frames *
  **********/
-
-.frame {
+.frame,
+frame {
     padding: 2px;
     border-width: 1px;
     border-radius: 4px;
@@ -740,8 +741,9 @@ GtkLevelBar.vertical {
     color: mix(@theme_selected_bg_color, @theme_fg_color, 0.70);
 }
 
-/* only render frames in a GtkScrolledWindow */
-GtkScrolledWindow.frame {
+/* only render frames in a scrolledwindow */
+scrolledwindow.frame,
+scrolledwindow>frame {
     border-width: 1px;
     border-radius: 0;
     border-style: solid;
@@ -753,15 +755,15 @@ GtkScrolledWindow.frame {
  * Buttons *
  ***********/
 
-.button.menuitem.menubar {
+button menuitem menubar {
     padding: 4px 8px;
 }
 
-.button {
+button {
     padding: 4px;
 }
 
-.button {
+button {
     transition: all 400ms ease-out;
     -GtkButton-image-spacing: 4;
     -GtkButton-interior-focus: true;
@@ -796,14 +798,14 @@ GtkScrolledWindow.frame {
     text-shadow: 0px 1px @theme_shadow_color;
 }
 
-.button.default {
+button.default {
     transition: all 400ms ease-out;
     text-shadow: none;
     color: @theme_fg_color;
 }
 
 /* ie. mate-control-center */
-.button.flat {
+button.flat {
     transition: all 400ms ease-out;
     padding: 0px;
     border-color: transparent;
@@ -811,18 +813,18 @@ GtkScrolledWindow.frame {
     background-image: none;
     box-shadow: inset 0 1px rgba(255,255,255,0), 0 1px rgba(255,255,255,0);
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     border-image: none;
 }
 
 /* ie. controls gnome-mplayer, virtual-manager */
-.button.flat.image-button,
-.button.flat.image-button:hover,
-GtkVolumeButton.button.flat {
+button.flat.image-button,
+button.flat.image-button:hover,
+volumebutton button.flat {
 	padding: 4px;
 }
 
-.button:hover {
+button:hover {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade(@button_gradient1, 1.03)),
@@ -835,11 +837,11 @@ GtkVolumeButton.button.flat {
                 inset  0px -1px shade(@selected_bg_color, 0.93);
 }
 
-.button:hover:active,
-.button:focus:hover:active,
-.button:checked,
-.button:checked:hover,
-.button:checked:hover:active {
+button:hover:active,
+button:focus:hover:active,
+button:checked,
+button:checked:hover,
+button:checked:hover:active {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade (@theme_bg_color, 1.20)),
@@ -853,8 +855,8 @@ GtkVolumeButton.button.flat {
                 inset  0px -1px shade(@selected_bg_color, 0.93);
 }
 
-.button:focus,
-.button.default {
+button:focus,
+button.default {
     border-top-color: alpha(@focused_entry_outer, 0.95);
     border-right-color: alpha(@focused_entry_outer, 1.00);
     border-left-color: alpha(@focused_entry_outer, 1.00);
@@ -865,103 +867,105 @@ GtkVolumeButton.button.flat {
                 inset  0px -1px shade(@selected_bg_color, 0.93);
 }
 
-.button *:hover:active,
-.button *:checked,
-.button *:checked:hover,
-.button *:checked:hover:active {
+button *:hover:active,
+button *:checked,
+button *:checked:hover,
+button *:checked:hover:active {
     color: @theme_selected_fg_color;
     text-shadow: 1px 1px @theme_selected_shadow_color;
 }
 
-.button:insensitive {
+button:disabled {
     background-image: none;
     background-color: @insensitive_bg_color;
-    border-color: alpha (#000, 0.00);
-    border-bottom-color: alpha (#000, 0.00);
+	color: @insensitive_fg_color;
+    border-color: transparent;
+    border-bottom-color: transparent;
     border-image: none;
-    box-shadow: inset  0px  1px @insensitive_border_color,
+   /* Puts borders on Caja toobar buttons, disable */
+   /* box-shadow: inset  0px  1px @insensitive_border_color,
                 inset  1px  0px @insensitive_border_color,
                 inset -1px  0px @insensitive_border_color,
-                inset  0px -1px @insensitive_border_color;
+                inset  0px -1px @insensitive_border_color;*/
 }
 
-.button *:insensitive {
+button *:disabled {
     color: @insensitive_fg_color;
     text-shadow: none;
 }
 
-.toolbar.vertical .image-button.flat.button {
+toolbar.vertical .image-button.flat button {
     padding: 5px;
 }
 
-.button.text-button,
-.button.text-button:hover,
-GtkFileChooserButton .button {
+button.text-button,
+button.text-button:hover,
+GtkFileChooserButton  button {
     padding: 5px 4px;
 }
 
-GtkComboBox GtkToggleButton.button,
-GtkComboBox GtkToggleButton.button:hover {
+combobox GtkToggleButton button,
+combobox GtkToggleButton button:hover {
     padding: 4px;
 }
 
-GtkFontButton.button,
-GtkColorButton.button {
+GtkFontButton button,
+GtkColorButton button {
     padding: 6px 4px;
 }
 
-.path-bar .button,
-.path-bar .button GtkImage,
-.path-bar .button GtkLabel {
+path-bar  button,
+path-bar  button image,
+path-bar  button label {
     padding: 2px;
 }
 
-.path-bar .button {
+path-bar  button {
     border-width: 1px 0px 1px 1px;
 }
 
-.path-bar .button:hover:checked {
+path-bar  button:hover:checked {
     border-left-width: 1px;
 }
 
 /* linked path-bar buttons */
 
-.path-bar.linked .button:dir(ltr),
-.path-bar.linked .button:dir(ltr):hover,
-.path-bar.linked .button:dir(ltr):hover:active,
-.path-bar.linked .button:dir(ltr):checked,
-.path-bar.linked .button:dir(ltr):checked:hover,
-.path-bar.linked .button:dir(ltr):checked:hover:active {
+path-bar.linked  button:dir(ltr),
+path-bar.linked  button:dir(ltr):hover,
+path-bar.linked  button:dir(ltr):hover:active,
+path-bar.linked  button:dir(ltr):checked,
+path-bar.linked  button:dir(ltr):checked:hover,
+path-bar.linked  button:dir(ltr):checked:hover:active {
     border-radius: 0px;
     border-width: 1px 0px 1px 0px;
 }
 
-.path-bar.linked .button:dir(ltr):first-child,
-.path-bar.linked .button:dir(ltr):hover:first-child,
-.path-bar.linked .button:dir(ltr):hover:active:first-child,
-.path-bar.linked .button:dir(ltr):checked:first-child,
-.path-bar.linked .button:dir(ltr):checked:hover:first-child,
-.path-bar.linked .button:dir(ltr):checked:hover:active:first-child {
+path-bar.linked  button:dir(ltr):first-child,
+path-bar.linked  button:dir(ltr):hover:first-child,
+path-bar.linked  button:dir(ltr):hover:active:first-child,
+path-bar.linked  button:dir(ltr):checked:first-child,
+path-bar.linked  button:dir(ltr):checked:hover:first-child,
+path-bar.linked  button:dir(ltr):checked:hover:active:first-child {
     border-radius: 6px 0px 0px 6px;
     border-width: 1px 0px 1px 1px;
 }
 
-.path-bar.linked .button:dir(ltr):last-child,
-.path-bar.linked .button:dir(ltr):hover:last-child,
-.path-bar.linked .button:dir(ltr):hover:active:last-child,
-.path-bar.linked .button:dir(ltr):checked:last-child,
-.path-bar.linked .button:dir(ltr):checked:hover:last-child,
-.path-bar.linked .button:dir(ltr):checked:hover:active:last-child {
+path-bar.linked  button:dir(ltr):last-child,
+path-bar.linked  button:dir(ltr):hover:last-child,
+path-bar.linked  button:dir(ltr):hover:active:last-child,
+path-bar.linked  button:dir(ltr):checked:last-child,
+path-bar.linked  button:dir(ltr):checked:hover:last-child,
+path-bar.linked  button:dir(ltr):checked:hover:active:last-child {
     border-radius: 0px 6px 6px 0px;
     border-width: 1px 1px 1px 0px;
 }
 
-.path-bar.linked .button:dir(ltr):only-child,
-.path-bar.linked .button:dir(ltr):hover:only-child,
-.path-bar.linked .button:dir(ltr):hover:active:only-child,
-.path-bar.linked .button:dir(ltr):checked:only-child,
-.path-bar.linked .button:dir(ltr):checked:hover:only-child,
-.path-bar.linked .button:dir(ltr):checked:hover:active:only-child {
+path-bar.linked  button:dir(ltr):only-child,
+path-bar.linked  button:dir(ltr):hover:only-child,
+path-bar.linked  button:dir(ltr):hover:active:only-child,
+path-bar.linked  button:dir(ltr):checked:only-child,
+path-bar.linked  button:dir(ltr):checked:hover:only-child,
+path-bar.linked  button:dir(ltr):checked:hover:active:only-child {
     border-radius: 6px;
     border-width: 1px;
 }
@@ -969,55 +973,58 @@ GtkColorButton.button {
 /***************************/
 /* Linked toolbars-buttons */
 /***************************/
+/* This puts borders on almost ALL toolbar buttons in GTK 3.20-FIXME or disable
+ when not active of hover*/
 
 /* Middle toolbar-button */
-.toolbar.menubar .linked .button,
-.toolbar.menubar .linked .button:focus,
-.toolbar.menubar .linked .button:hover,
-.toolbar.menubar .linked .button:hover:active,
-.toolbar.menubar .linked .button:checked,
-.toolbar.menubar .linked .button:checked:focus,
-.toolbar.menubar .linked .button:checked:hover,
-.toolbar.menubar .linked .button:checked:hover:active,
-.toolbar.menubar .linked .button:insensitive,
-.toolbar .button.raised.linked,
-.toolbar .button.raised.linked:focus,
-.toolbar .button.raised.linked:hover,
-.toolbar .button.raised.linked:hover:active,
-.toolbar .button.raised.linked:checked,
-.toolbar .button.raised.linked:checked:focus,
-.toolbar .button.raised.linked:checked:hover,
-.toolbar .button.raised.linked:checked:hover:active,
-.toolbar .button.raised.linked:insensitive,
-.toolbar .raised.linked .button,
-.toolbar .raised.linked .button:focus,
-.toolbar .raised.linked .button:hover,
-.toolbar .raised.linked .button:hover:active,
-.toolbar .raised.linked .button:checked,
-.toolbar .raised.linked .button:checked:focus,
-.toolbar .raised.linked .button:checked:hover,
-.toolbar .raised.linked .button:checked:hover:active,
-.toolbar .raised.linked .button:insensitive,
-.primary-toolbar .linked .entry,
-.primary-toolbar .linked .entry:insensitive,
-.primary-toolbar .linked .button,
-.primary-toolbar .linked .button:focus,
-.primary-toolbar .linked .button:hover,
-.primary-toolbar .linked .button:hover:active,
-.primary-toolbar .linked .button:checked,
-.primary-toolbar .linked .button:checked:focus,
-.primary-toolbar .linked .button:checked:hover,
-.primary-toolbar .linked .button:checked:hover:active,
-.primary-toolbar .linked .button:insensitive {
+
+toolbar menubar .linked  button,
+toolbar menubar .linked  button:focus,
+toolbar menubar .linked  button:hover,
+toolbar menubar .linked  button:hover:active,
+toolbar menubar .linked  button:checked,
+toolbar menubar .linked  button:checked:focus,
+toolbar menubar .linked  button:checked:hover,
+toolbar menubar .linked  button:checked:hover:active,
+toolbar menubar .linked  button:disabled,
+toolbar  button.raised.linked,
+toolbar  button.raised.linked:focus,
+toolbar  button.raised.linked:hover,
+toolbar  button.raised.linked:hover:active,
+toolbar  button.raised.linked:checked,
+toolbar  button.raised.linked:checked:focus,
+toolbar  button.raised.linked:checked:hover,
+toolbar  button.raised.linked:checked:hover:active,
+toolbar  button.raised.linked:disabled,
+toolbar .raised.linked  button,
+toolbar .raised.linked  button:focus,
+toolbar .raised.linked  button:hover,
+toolbar .raised.linked  button:hover:active,
+toolbar .raised.linked  button:checked,
+toolbar .raised.linked  button:checked:focus,
+toolbar .raised.linked  button:checked:hover,
+toolbar .raised.linked  button:checked:hover:active,
+toolbar .raised.linked  button:disabled,
+primary-toolbar .linked  entry,
+primary-toolbar .linked  entry:disabled,
+primary-toolbar .linked  button,
+primary-toolbar .linked  button:focus,
+primary-toolbar .linked  button:hover,
+primary-toolbar .linked  button:hover:active,
+primary-toolbar .linked  button:checked,
+primary-toolbar .linked  button:checked:focus,
+primary-toolbar .linked  button:checked:hover,
+primary-toolbar .linked  button:checked:hover:active,
+primary-toolbar .linked  button:disabled {
     padding: 2px 4px 4px 2px;
     border-radius: 0px;
     border-width: 1px 0px 1px 0px;
 }
 
 /* Middle toolbar-button hover */
-.toolbar.menubar .linked .button:hover,
-.toolbar .raised.linked .button:hover,
-.primary-toolbar .linked .button:hover {
+toolbar menubar .linked  button:hover,
+toolbar .raised.linked  button:hover,
+primary-toolbar .linked  button:hover {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade(@menu_bg_dark_color, 2.03)),
@@ -1029,26 +1036,26 @@ GtkColorButton.button {
 }
 
 /* Middle toolbar-button active */
-.toolbar.menubar .linked .button:hover:active,
-.toolbar.menubar .linked .button:checked,
-.toolbar.menubar .linked .button:checked:focus,
-.toolbar.menubar .linked .button:checked:hover,
-.toolbar.menubar .linked .button:checked:hover:active,
-.toolbar .button.raised.linked:hover:active,
-.toolbar .button.raised.linked:checked,
-.toolbar .button.raised.linked:checked:focus,
-.toolbar .button.raised.linked:checked:hover,
-.toolbar .button.raised.linked:checked:hover:active,
-.toolbar .raised.linked .button:hover:active,
-.toolbar .raised.linked .button:checked,
-.toolbar .raised.linked .button:checked:focus,
-.toolbar .raised.linked .button:checked:hover,
-.toolbar .raised.linked .button:checked:hover:active,
-.primary-toolbar .linked .button:hover:active,
-.primary-toolbar .linked .button:checked,
-.primary-toolbar .linked .button:checked:focus,
-.primary-toolbar .linked .button:checked:hover,
-.primary-toolbar .linked .button:checked:hover:active {
+toolbar menubar .linked  button:hover:active,
+toolbar menubar .linked  button:checked,
+toolbar menubar .linked  button:checked:focus,
+toolbar menubar .linked  button:checked:hover,
+toolbar menubar .linked  button:checked:hover:active,
+toolbar  button.raised.linked:hover:active,
+toolbar  button.raised.linked:checked,
+toolbar  button.raised.linked:checked:focus,
+toolbar  button.raised.linked:checked:hover,
+toolbar  button.raised.linked:checked:hover:active,
+toolbar .raised.linked  button:hover:active,
+toolbar .raised.linked  button:checked,
+toolbar .raised.linked  button:checked:focus,
+toolbar .raised.linked  button:checked:hover,
+toolbar .raised.linked  button:checked:hover:active,
+primary-toolbar .linked  button:hover:active,
+primary-toolbar .linked  button:checked,
+primary-toolbar .linked  button:checked:focus,
+primary-toolbar .linked  button:checked:hover,
+primary-toolbar .linked  button:checked:hover:active {
     box-shadow: inset  0px  1px shade(@selected_bg_color, 1.05),
                 inset  1px  0px shade(@selected_bg_color, 0.97),
                 inset -1px  0px shade(@selected_bg_color, 0.93),
@@ -1056,11 +1063,11 @@ GtkColorButton.button {
 }
 
 /* Middle toolbar-button insensitive */
-.toolbar.menubar .linked .button:insensitive,
-.toolbar .button.raised.linked:insensitive,
-.toolbar .raised.linked .button:insensitive,
-.primary-toolbar .linked .button:insensitive,
-.primary-toolbar .linked .entry:insensitive {
+toolbar menubar .linked  button:disabled,
+toolbar  button.raised.linked:disabled,
+toolbar .raised.linked  button:disabled,
+primary-toolbar .linked  button:disabled,
+primary-toolbar .linked  entry:disabled {
      /* remove outer */
     border-color: alpha (#fff, 0.00);
     /* Remove right border */
@@ -1070,53 +1077,54 @@ GtkColorButton.button {
 }
 
 /* Leftmost toolbars-button */
-.toolbar.menubar .linked .button:first-child,
-.toolbar.menubar .linked .button:focus:first-child,
-.toolbar.menubar .linked .button:hover:first-child,
-.toolbar.menubar .linked .button:hover:active:first-child,
-.toolbar.menubar .linked .button:checked:first-child,
-.toolbar.menubar .linked .button:checked:focus:first-child,
-.toolbar.menubar .linked .button:checked:hover:first-child,
-.toolbar.menubar .linked .button:checked:hover:active:first-child,
-.toolbar.menubar .linked .button:insensitive:first-child,
-.toolbar .button.raised.linked:first-child,
-.toolbar .button.raised.linked:focus:first-child,
-.toolbar .button.raised.linked:hover:first-child,
-.toolbar .button.raised.linked:hover:active:first-child,
-.toolbar .button.raised.linked:checked:first-child,
-.toolbar .button.raised.linked:checked:focus:first-child,
-.toolbar .button.raised.linked:checked:hover:first-child,
-.toolbar .button.raised.linked:checked:hover:active:first-child,
-.toolbar .button.raised.linked:insensitive:first-child,
-.toolbar .raised.linked .button:first-child,
-.toolbar .raised.linked .button:focus:first-child,
-.toolbar .raised.linked .button:hover:first-child,
-.toolbar .raised.linked .button:hover:active:first-child,
-.toolbar .raised.linked .button:checked:first-child,
-.toolbar .raised.linked .button:checked:focus:first-child,
-.toolbar .raised.linked .button:checked:hover:first-child,
-.toolbar .raised.linked .button:checked:hover:active:first-child,
-.toolbar .raised.linked .button:insensitive:first-child,
-.primary-toolbar .linked .entry:first-child,
-.primary-toolbar .linked .button:first-child,
-.primary-toolbar .linked .button:focus:first-child,
-.primary-toolbar .linked .button:hover:first-child,
-.primary-toolbar .linked .button:hover:active:first-child,
-.primary-toolbar .linked .button:checked:first-child,
-.primary-toolbar .linked .button:checked:focus:first-child,
-.primary-toolbar .linked .button:checked:hover:first-child,
-.primary-toolbar .linked .button:checked:hover:active:first-child,
-.primary-toolbar .linked .button:insensitive:first-child,
-.primary-toolbar .linked .entry:insensitive:first-child {
+/*
+toolbar menubar .linked  button:first-child,
+toolbar menubar .linked  button:focus:first-child,
+toolbar menubar .linked  button:hover:first-child,
+toolbar menubar .linked  button:hover:active:first-child,
+toolbar menubar .linked  button:checked:first-child,
+toolbar menubar .linked  button:checked:focus:first-child,
+toolbar menubar .linked  button:checked:hover:first-child,
+toolbar menubar .linked  button:checked:hover:active:first-child,
+toolbar menubar .linked  button:disabled:first-child,
+toolbar  button.raised.linked:first-child,
+toolbar  button.raised.linked:focus:first-child,
+toolbar  button.raised.linked:hover:first-child,
+toolbar  button.raised.linked:hover:active:first-child,
+toolbar  button.raised.linked:checked:first-child,
+toolbar  button.raised.linked:checked:focus:first-child,
+toolbar  button.raised.linked:checked:hover:first-child,
+toolbar  button.raised.linked:checked:hover:active:first-child,
+toolbar  button.raised.linked:disabled:first-child,
+toolbar .raised.linked  button:first-child,
+toolbar .raised.linked  button:focus:first-child,
+toolbar .raised.linked  button:hover:first-child,
+toolbar .raised.linked  button:hover:active:first-child,
+toolbar .raised.linked  button:checked:first-child,
+toolbar .raised.linked  button:checked:focus:first-child,
+toolbar .raised.linked  button:checked:hover:first-child,
+toolbar .raised.linked  button:checked:hover:active:first-child,
+toolbar .raised.linked  button:disabled:first-child,
+primary-toolbar .linked  entry:first-child,
+primary-toolbar .linked  button:first-child,
+primary-toolbar .linked  button:focus:first-child,
+primary-toolbar .linked  button:hover:first-child,
+primary-toolbar .linked  button:hover:active:first-child,
+primary-toolbar .linked  button:checked:first-child,
+primary-toolbar .linked  button:checked:focus:first-child,
+primary-toolbar .linked  button:checked:hover:first-child,
+primary-toolbar .linked  button:checked:hover:active:first-child,
+primary-toolbar .linked  button:disabled:first-child,
+primary-toolbar .linked  entry:disabled:first-child {
     padding: 2px 4px 4px 2px;
     border-radius: 6px 0px 0px 6px;
     border-width: 1px 0px 1px 1px;
 }
-
+*/
 /* Leftmost toolbars-button hover */
-.toolbar.menubar .linked .button:hover:first-child,
-.toolbar .raised.linked .button:hover:first-child,
-.primary-toolbar .linked .button:hover:first-child {
+toolbar menubar .linked  button:hover:first-child,
+toolbar .raised.linked  button:hover:first-child,
+primary-toolbar .linked  button:hover:first-child {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade(@menu_bg_dark_color, 2.03)),
@@ -1128,26 +1136,26 @@ GtkColorButton.button {
 }
 
 /* Leftmost toolbars-button active */
-.toolbar.menubar .linked .button:hover:active:first-child,
-.toolbar.menubar .linked .button:checked:first-child,
-.toolbar.menubar .linked .button:checked:focus:first-child,
-.toolbar.menubar .linked .button:checked:hover:first-child,
-.toolbar.menubar .linked .button:checked:hover:active:first-child,
-.toolbar .button.raised.linked:hover:active:first-child,
-.toolbar .button.raised.linked:checked:first-child,
-.toolbar .button.raised.linked:checked:focus:first-child,
-.toolbar .button.raised.linked:checked:hover:first-child,
-.toolbar .button.raised.linked:checked:hover:active:first-child,
-.toolbar .raised.linked .button:hover:active:first-child,
-.toolbar .raised.linked .button:checked:first-child,
-.toolbar .raised.linked .button:checked:focus:first-child,
-.toolbar .raised.linked .button:checked:hover:first-child,
-.toolbar .raised.linked .button:checked:hover:active:first-child,
-.primary-toolbar .linked .button:hover:active:first-child,
-.primary-toolbar .linked .button:checked:first-child,
-.primary-toolbar .linked .button:checked:focus:first-child,
-.primary-toolbar .linked .button:checked:hover:first-child,
-.primary-toolbar .linked .button:checked:hover:active:first-child {
+toolbar menubar .linked  button:hover:active:first-child,
+toolbar menubar .linked  button:checked:first-child,
+toolbar menubar .linked  button:checked:focus:first-child,
+toolbar menubar .linked  button:checked:hover:first-child,
+toolbar menubar .linked  button:checked:hover:active:first-child,
+toolbar button.raised.linked:hover:active:first-child,
+toolbar button.raised.linked:checked:first-child,
+toolbar button.raised.linked:checked:focus:first-child,
+toolbar button.raised.linked:checked:hover:first-child,
+toolbar button.raised.linked:checked:hover:active:first-child,
+toolbar .raised.linked  button:hover:active:first-child,
+toolbar .raised.linked  button:checked:first-child,
+toolbar .raised.linked  button:checked:focus:first-child,
+toolbar .raised.linked  button:checked:hover:first-child,
+toolbar .raised.linked  button:checked:hover:active:first-child,
+primary-toolbar .linked  button:hover:active:first-child,
+primary-toolbar .linked  button:checked:first-child,
+primary-toolbar .linked  button:checked:focus:first-child,
+primary-toolbar .linked  button:checked:hover:first-child,
+primary-toolbar .linked  button:checked:hover:active:first-child {
     box-shadow: inset  0px  1px shade(@selected_bg_color, 1.05),
                 inset  1px  0px shade(@selected_bg_color, 0.97),
                 inset -1px  0px shade(@selected_bg_color, 0.93),
@@ -1155,11 +1163,11 @@ GtkColorButton.button {
 }
 
 /* Leftmost toolbars-button insensitive */
-.toolbar.menubar .linked .button:insensitive:first-child,
-.toolbar .button.raised.linked:insensitive:first-child,
-.toolbar .raised.linked .button:insensitive:first-child,
-.primary-toolbar .linked .button:insensitive:first-child,
-.primary-toolbar .linked .entry:insensitive:first-child {
+toolbar menubar .linked  button:disabled:first-child,
+toolbar  button.raised.linked:disabled:first-child,
+toolbar .raised.linked  button:disabled:first-child,
+primary-toolbar .linked  button:disabled:first-child,
+primary-toolbar .linked  entry:disabled:first-child {
      /* remove outer */
     border-color: alpha (#fff, 0.00);
     /* Remove right border */
@@ -1169,53 +1177,53 @@ GtkColorButton.button {
 }
 
 /* Rightmost toolbar-button */
-.toolbar.menubar .linked .button:last-child,
-.toolbar.menubar .linked .button:focus:last-child,
-.toolbar.menubar .linked .button:hover:last-child,
-.toolbar.menubar .linked .button:hover:active:last-child,
-.toolbar.menubar .linked .button:checked:last-child,
-.toolbar.menubar .linked .button:checked:focus:last-child,
-.toolbar.menubar .linked .button:checked:hover:last-child,
-.toolbar.menubar .linked .button:checked:hover:active:last-child,
-.toolbar.menubar .linked .button:insensitive:last-child,
-.toolbar .button.raised.linked:last-child,
-.toolbar .button.raised.linked:focus:last-child,
-.toolbar .button.raised.linked:hover:last-child,
-.toolbar .button.raised.linked:hover:active:last-child,
-.toolbar .button.raised.linked:checked:last-child,
-.toolbar .button.raised.linked:checked:focus:last-child,
-.toolbar .button.raised.linked:checked:hover:last-child,
-.toolbar .button.raised.linked:checked:hover:active:last-child,
-.toolbar .button.raised.linked:insensitive:last-child,
-.toolbar .raised.linked .button:last-child,
-.toolbar .raised.linked .button:focus:last-child,
-.toolbar .raised.linked .button:hover:last-child,
-.toolbar .raised.linked .button:hover:active:last-child,
-.toolbar .raised.linked .button:checked:last-child,
-.toolbar .raised.linked .button:checked:focus:last-child,
-.toolbar .raised.linked .button:checked:hover:last-child,
-.toolbar .raised.linked .button:checked:hover:active:last-child,
-.toolbar .raised.linked .button:insensitive:last-child,
-.primary-toolbar .linked .entry:last-child,
-.primary-toolbar .linked .button:last-child,
-.primary-toolbar .linked .button:focus:last-child,
-.primary-toolbar .linked .button:hover:last-child,
-.primary-toolbar .linked .button:hover:active:last-child,
-.primary-toolbar .linked .button:checked:last-child,
-.primary-toolbar .linked .button:checked:focus:last-child,
-.primary-toolbar .linked .button:checked:hover:last-child,
-.primary-toolbar .linked .button:checked:hover:active:last-child,
-.primary-toolbar .linked .button:insensitive:last-child,
-.primary-toolbar .linked .entry:insensitive:last-child {
+/*toolbar menubar .linked  button:last-child,*/
+toolbar menubar .linked  button:focus:last-child,
+toolbar menubar .linked  button:hover:last-child,
+toolbar menubar .linked  button:hover:active:last-child,
+toolbar menubar .linked  button:checked:last-child,
+toolbar menubar .linked  button:checked:focus:last-child,
+toolbar menubar .linked  button:checked:hover:last-child,
+toolbar menubar .linked  button:checked:hover:active:last-child,
+toolbar menubar .linked  button:disabled:last-child,
+toolbar  button.raised.linked:last-child,
+toolbar  button.raised.linked:focus:last-child,
+toolbar  button.raised.linked:hover:last-child,
+toolbar  button.raised.linked:hover:active:last-child,
+toolbar  button.raised.linked:checked:last-child,
+toolbar  button.raised.linked:checked:focus:last-child,
+toolbar  button.raised.linked:checked:hover:last-child,
+toolbar  button.raised.linked:checked:hover:active:last-child,
+toolbar  button.raised.linked:disabled:last-child,
+/*toolbar .raised.linked  button:last-child,*/
+toolbar .raised.linked  button:focus:last-child,
+toolbar .raised.linked  button:hover:last-child,
+toolbar .raised.linked  button:hover:active:last-child,
+toolbar .raised.linked  button:checked:last-child,
+toolbar .raised.linked  button:checked:focus:last-child,
+toolbar .raised.linked  button:checked:hover:last-child,
+toolbar .raised.linked  button:checked:hover:active:last-child,
+toolbar .raised.linked  button:disabled:last-child,
+/*primary-toolbar .linked  entry:last-child,*/
+/*primary-toolbar .linked  button:last-child,*/
+primary-toolbar .linked  button:focus:last-child,
+primary-toolbar .linked  button:hover:last-child,
+primary-toolbar .linked  button:hover:active:last-child,
+primary-toolbar .linked  button:checked:last-child,
+primary-toolbar .linked  button:checked:focus:last-child,
+primary-toolbar .linked  button:checked:hover:last-child,
+primary-toolbar .linked  button:checked:hover:active:last-child,
+primary-toolbar .linked  button:disabled:last-child,
+primary-toolbar .linked  entry:disabled:last-child {
     padding: 2px 4px 4px 2px;
     border-radius: 0px 6px 6px  0px;
     border-width: 1px 1px 1px 0px;
 }
 
 /* Rightmost toolbars-button hover */
-.toolbar.menubar .linked .button:hover:last-child,
-.toolbar .raised.linked .button:hover:last-child,
-.primary-toolbar .linked .button:hover:last-child {
+toolbar menubar .linked  button:hover:last-child,
+toolbar .raised.linked  button:hover:last-child,
+primary-toolbar .linked  button:hover:last-child {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade(@menu_bg_dark_color, 2.03)),
@@ -1227,26 +1235,26 @@ GtkColorButton.button {
 }
 
 /* Rightmost toolbar-button active */
-.toolbar.menubar .linked .button:hover:active:last-child,
-.toolbar.menubar .linked .button:checked:last-child,
-.toolbar.menubar .linked .button:checked:focus:last-child,
-.toolbar.menubar .linked .button:checked:hover:last-child,
-.toolbar.menubar .linked .button:checked:hover:active:last-child,
-.toolbar .button.raised.linked:hover:active:last-child,
-.toolbar .button.raised.linked:checked:last-child,
-.toolbar .button.raised.linked:checked:focus:last-child,
-.toolbar .button.raised.linked:checked:hover:last-child,
-.toolbar .button.raised.linked:checked:hover:active:last-child,
-.toolbar .raised.linked .button:hover:active:last-child,
-.toolbar .raised.linked .button:checked:last-child,
-.toolbar .raised.linked .button:checked:focus:last-child,
-.toolbar .raised.linked .button:checked:hover:last-child,
-.toolbar .raised.linked .button:checked:hover:active:last-child,
-.primary-toolbar .linked .button:hover:active:last-child,
-.primary-toolbar .linked .button:checked:last-child,
-.primary-toolbar .linked .button:checked:focus:last-child,
-.primary-toolbar .linked .button:checked:hover:last-child,
-.primary-toolbar .linked .button:checked:hover:active:last-child {
+toolbar menubar .linked  button:hover:active:last-child,
+toolbar menubar .linked  button:checked:last-child,
+toolbar menubar .linked  button:checked:focus:last-child,
+toolbar menubar .linked  button:checked:hover:last-child,
+toolbar menubar .linked  button:checked:hover:active:last-child,
+toolbar  button.raised.linked:hover:active:last-child,
+toolbar  button.raised.linked:checked:last-child,
+toolbar  button.raised.linked:checked:focus:last-child,
+toolbar  button.raised.linked:checked:hover:last-child,
+toolbar  button.raised.linked:checked:hover:active:last-child,
+toolbar .raised.linked  button:hover:active:last-child,
+toolbar .raised.linked  button:checked:last-child,
+toolbar .raised.linked  button:checked:focus:last-child,
+toolbar .raised.linked  button:checked:hover:last-child,
+toolbar .raised.linked  button:checked:hover:active:last-child,
+primary-toolbar .linked  button:hover:active:last-child,
+primary-toolbar .linked  button:checked:last-child,
+primary-toolbar .linked  button:checked:focus:last-child,
+primary-toolbar .linked  button:checked:hover:last-child,
+primary-toolbar .linked  button:checked:hover:active:last-child {
     box-shadow: inset  0px  1px shade(@selected_bg_color, 1.05),
                 inset  1px  0px shade(@selected_bg_color, 0.97),
                 inset -1px  0px shade(@selected_bg_color, 0.93),
@@ -1254,11 +1262,11 @@ GtkColorButton.button {
 }
 
 /* Rightmost toolbar-button insensitive */
-.toolbar.menubar .linked .button:insensitive:last-child,
-.toolbar .button.raised.linked:insensitive:last-child,
-.toolbar .raised.linked .button:insensitive:last-child,
-.primary-toolbar .linked .button:insensitive:last-child,
-.primary-toolbar .linked .entry:insensitive:last-child {
+toolbar menubar .linked  button:disabled:last-child,
+toolbar  button.raised.linked:disabled:last-child,
+toolbar .raised.linked  button:disabled:last-child,
+primary-toolbar .linked  button:disabled:last-child,
+primary-toolbar .linked  entry:disabled:last-child {
     border-color: alpha (#fff, 0.00); /* Quita outer */
     box-shadow: inset  0px  1px shade(@theme_button_border_dark, 1.10),
                 inset  1px  0px shade(@theme_button_border_dark, 1.05),
@@ -1267,49 +1275,50 @@ GtkColorButton.button {
 }
 
 /* Linked single toolbar-button */
-.toolbar.menubar .linked .button:only-child,
-.toolbar.menubar .linked .button:hover:only-child,
-.toolbar.menubar .linked .button:hover:active:only-child,
-.toolbar.menubar .linked .button:checked:only-child,
-.toolbar.menubar .linked .button:checked:focus:only-child,
-.toolbar.menubar .linked .button:checked:hover:only-child,
-.toolbar.menubar .linked .button:checked:hover:active:only-child,
-.toolbar.menubar .linked .button:insensitive:only-child,
-.toolbar .button.raised.linked:only-child,
-.toolbar .button.raised.linked:hover:only-child,
-.toolbar .button.raised.linked:hover:active:only-child,
-.toolbar .button.raised.linked:checked:only-child,
-.toolbar .button.raised.linked:checked:focus:only-child,
-.toolbar .button.raised.linked:checked:hover:only-child,
-.toolbar .button.raised.linked:checked:hover:active:only-child,
-.toolbar .button.raised.linked:insensitive:only-child,
-.toolbar .raised.linked .button:only-child,
-.toolbar .raised.linked .button:hover:only-child,
-.toolbar .raised.linked .button:hover:active:only-child,
-.toolbar .raised.linked .button:checked:only-child,
-.toolbar .raised.linked .button:checked:focus:only-child,
-.toolbar .raised.linked .button:checked:hover:only-child,
-.toolbar .raised.linked .button:checked:hover:active:only-child,
-.toolbar .raised.linked .button:insensitive:only-child,
-.primary-toolbar .linked .entry:only-child,
-.primary-toolbar .linked .button:only-child,
-.primary-toolbar .linked .button:hover:only-child,
-.primary-toolbar .linked .button:hover:active:only-child,
-.primary-toolbar .linked .button:checked:only-child,
-.primary-toolbar .linked .button:checked:focus:only-child,
-.primary-toolbar .linked .button:checked:hover:only-child,
-.primary-toolbar .linked .button:checked:hover:active:only-child,
-.primary-toolbar .linked .entry:insensitive:only-child,
-.primary-toolbar .linked .button:insensitive:only-child {
+
+/*toolbar menubar .linked  button:only-child,*/
+toolbar menubar .linked  button:hover:only-child,
+toolbar menubar .linked  button:hover:active:only-child,
+toolbar menubar .linked  button:checked:only-child,
+toolbar menubar .linked  button:checked:focus:only-child,
+toolbar menubar .linked  button:checked:hover:only-child,
+toolbar menubar .linked  button:checked:hover:active:only-child,
+toolbar menubar .linked  button:disabled:only-child,
+/*toolbar  button.raised.linked:only-child,*/
+toolbar  button.raised.linked:hover:only-child,
+toolbar  button.raised.linked:hover:active:only-child,
+toolbar  button.raised.linked:checked:only-child,
+toolbar  button.raised.linked:checked:focus:only-child,
+toolbar  button.raised.linked:checked:hover:only-child,
+toolbar  button.raised.linked:checked:hover:active:only-child,
+toolbar  button.raised.linked:disabled:only-child,
+toolbar .raised.linked  button:only-child,
+toolbar .raised.linked  button:hover:only-child,
+toolbar .raised.linked  button:hover:active:only-child,
+toolbar .raised.linked  button:checked:only-child,
+toolbar .raised.linked  button:checked:focus:only-child,
+toolbar .raised.linked  button:checked:hover:only-child,
+toolbar .raised.linked  button:checked:hover:active:only-child,
+toolbar .raised.linked  button:disabled:only-child,
+/*primary-toolbar .linked  entry:only-child,  */
+/*primary-toolbar .linked  button:only-child, */
+primary-toolbar .linked  button:hover:only-child,
+primary-toolbar .linked  button:hover:active:only-child,
+primary-toolbar .linked  button:checked:only-child,
+primary-toolbar .linked  button:checked:focus:only-child,
+primary-toolbar .linked  button:checked:hover:only-child,
+primary-toolbar .linked  button:checked:hover:active:only-child,
+primary-toolbar .linked  entry:disabled:only-child,
+primary-toolbar .linked  button:disabled:only-child {
     border-width: 1px;
     border-radius: 6px;
     padding: 2px 4px 4px 2px;
 }
 
 /* Linked single toolbar-button hover */
-.toolbar .raised.linked .button:hover:only-child,
-.toolbar.menubar .linked .button:hover:only-child,
-.primary-toolbar .linked .button:hover:only-child {
+toolbar .raised.linked  button:hover:only-child,
+toolbar menubar .linked  button:hover:only-child,
+primary-toolbar .linked  button:hover:only-child {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade(@menu_bg_dark_color, 2.03)),
@@ -1321,26 +1330,26 @@ GtkColorButton.button {
 }
 
 /* Linked single toolbar-button active */
-.toolbar.menubar .linked .button:hover:active:only-child,
-.toolbar.menubar .linked .button:checked:only-child,
-.toolbar.menubar .linked .button:checked:focus:only-child,
-.toolbar.menubar .linked .button:checked:hover:only-child,
-.toolbar.menubar .linked .button:checked:hover:active:only-child,
-.toolbar .button.raised.linked:hover:active:only-child,
-.toolbar .button.raised.linked:checked:only-child,
-.toolbar .button.raised.linked:checked:focus:only-child,
-.toolbar .button.raised.linked:checked:hover:only-child,
-.toolbar .button.raised.linked:checked:hover:active:only-child,
-.toolbar .raised.linked .button:hover:active:only-child,
-.toolbar .raised.linked .button:checked:only-child,
-.toolbar .raised.linked .button:checked:focus:only-child,
-.toolbar .raised.linked .button:checked:hover:only-child,
-.toolbar .raised.linked .button:checked:hover:active:only-child,
-.primary-toolbar .linked .button:hover:active:only-child,
-.primary-toolbar .linked .button:checked:only-child,
-.primary-toolbar .linked .button:checked:focus:only-child,
-.primary-toolbar .linked .button:checked:hover:only-child,
-.primary-toolbar .linked .button:checked:hover:active:only-child {
+toolbar menubar .linked  button:hover:active:only-child,
+toolbar menubar .linked  button:checked:only-child,
+toolbar menubar .linked  button:checked:focus:only-child,
+toolbar menubar .linked  button:checked:hover:only-child,
+toolbar menubar .linked  button:checked:hover:active:only-child,
+toolbar  button.raised.linked:hover:active:only-child,
+toolbar  button.raised.linked:checked:only-child,
+toolbar  button.raised.linked:checked:focus:only-child,
+toolbar  button.raised.linked:checked:hover:only-child,
+toolbar  button.raised.linked:checked:hover:active:only-child,
+toolbar .raised.linked  button:hover:active:only-child,
+toolbar .raised.linked  button:checked:only-child,
+toolbar .raised.linked  button:checked:focus:only-child,
+toolbar .raised.linked  button:checked:hover:only-child,
+toolbar .raised.linked  button:checked:hover:active:only-child,
+primary-toolbar .linked  button:hover:active:only-child,
+primary-toolbar .linked  button:checked:only-child,
+primary-toolbar .linked  button:checked:focus:only-child,
+primary-toolbar .linked  button:checked:hover:only-child,
+primary-toolbar .linked  button:checked:hover:active:only-child {
     box-shadow: inset  0px  1px shade(@selected_bg_color, 1.05),
                 inset  1px  0px shade(@selected_bg_color, 0.97),
                 inset -1px  0px shade(@selected_bg_color, 0.93),
@@ -1348,11 +1357,11 @@ GtkColorButton.button {
 }
 
 /* Linked single toolbar-button insensitive */
-.toolbar.menubar .linked .button:insensitive:only-child,
-.toolbar .button.raised.linked:insensitive:only-child,
-.toolbar .raised.linked .button:insensitive:only-child,
-.primary-toolbar .linked .entry:insensitive:only-child,
-.primary-toolbar .linked .button:insensitive:only-child {
+toolbar menubar .linked  button:disabled:only-child,
+toolbar  button.raised.linked:disabled:only-child,
+toolbar .raised.linked  button:disabled:only-child,
+primary-toolbar .linked  entry:disabled:only-child,
+primary-toolbar .linked  button:disabled:only-child {
     border-color: alpha (#fff, 0.00); /* Quita outer */
     box-shadow: inset  0px  1px shade(@theme_button_border_dark, 1.10),
                 inset  1px  0px shade(@theme_button_border_dark, 1.05),
@@ -1361,102 +1370,102 @@ GtkColorButton.button {
 }
 
 /* nth-child for linked areas */
-.toolbar .raised.linked.button,
-.toolbar .raised.linked.button:hover:active,
-.toolbar .raised.linked.button:checked,
-.toolbar .raised.linked.button:checked:hover,
-.toolbar .raised.linked.button:checked:hover:active,
-.toolbar .raised.linked .button,
-.toolbar .raised.linked .button:hover:active,
-.toolbar .raised.linked .button:checked,
-.toolbar .raised.linked .button:checked:hover,
-.toolbar .raised.linked .button:checked:hover:active {
+/*toolbar .raised.linked button, */
+toolbar .raised.linked button:hover:active,
+toolbar .raised.linked button:checked,
+toolbar .raised.linked button:checked:hover,
+toolbar .raised.linked button:checked:hover:active,
+toolbar .raised.linked  button,
+toolbar .raised.linked  button:hover:active,
+toolbar .raised.linked  button:checked,
+toolbar .raised.linked  button:checked:hover,
+toolbar .raised.linked  button:checked:hover:active {
 }
 
-.toolbar .raised.linked.button:nth-child(first) ,
-.toolbar .raised.linked.button:hover:active:nth-child(first),
-.toolbar .raised.linked.button:checked:nth-child(first),
-.toolbar .raised.linked.button:checked:hover:nth-child(first),
-.toolbar .raised.linked:nth-child(first) .button,
-.toolbar .raised.linked:nth-child(first) .button:hover:active,
-.toolbar .raised.linked:nth-child(first) .button:checked,
-.toolbar .raised.linked:nth-child(first) .button:checked:hover {
+/*toolbar .raised.linked button:nth-child(first) , */
+toolbar .raised.linked button:hover:active:nth-child(first),
+toolbar .raised.linked button:checked:nth-child(first),
+toolbar .raised.linked button:checked:hover:nth-child(first),
+toolbar .raised.linked:nth-child(first)  button,
+toolbar .raised.linked:nth-child(first)  button:hover:active,
+toolbar .raised.linked:nth-child(first)  button:checked,
+toolbar .raised.linked:nth-child(first)  button:checked:hover {
 }
 
-.toolbar .raised.linked.button:nth-child(last),
-.toolbar .raised.linked.button:hover:active:nth-child(last),
-.toolbar .raised.linked.button:checked:nth-child(last),
-.toolbar .raised.linked.button:checked:hover:nth-child(last),
-.toolbar .raised.linked:nth-child(last) .button,
-.toolbar .raised.linked:nth-child(last) .button:hover:active,
-.toolbar .raised.linked:nth-child(last) .button:checked,
-.toolbar .raised.linked:nth-child(last) .button:checked:hover {
+/*toolbar .raised.linked button:nth-child(last), */
+toolbar .raised.linked button:hover:active:nth-child(last),
+toolbar .raised.linked button:checked:nth-child(last),
+toolbar .raised.linked button:checked:hover:nth-child(last),
+toolbar .raised.linked:nth-child(last)  button,
+toolbar .raised.linked:nth-child(last)  button:hover:active,
+toolbar .raised.linked:nth-child(last)  button:checked,
+toolbar .raised.linked:nth-child(last)  button:checked:hover {
 }
 
 /***************************/
 /* Linked standard buttons */
 /***************************/
 
-.linked .entry,
-.linked > GtkComboBox > .button,
-.linked > GtkComboBox > .button:focus
-.linked > GtkComboBox > .button:checked,
-.linked > GtkComboBox > .button:hover,
-.linked > GtkComboBox > .button:focus:hover,
-.linked > GtkComboBox > .button:insensitive,
-.linked .button,
-.linked .button:focus,
-.linked .button:checked,
-.linked .button:hover,
-.linked .button:focus:hover,
-.linked .button:hover:active,
-.linked .button:checked:hover,
-.linked .button:checked:hover:active,
-.linked .button:insensitive {
+/*.linked  entry,
+.linked > combobox >  button,*/
+.linked > combobox >  button:focus
+.linked > combobox >  button:checked,
+.linked > combobox >  button:hover,
+.linked > combobox >  button:focus:hover,
+.linked > combobox >  button:disabled,
+/*.linked  button,*/
+.linked  button:focus,
+.linked  button:checked,
+.linked  button:hover,
+.linked  button:focus:hover,
+.linked  button:hover:active,
+.linked  button:checked:hover,
+.linked  button:checked:hover:active,
+.linked  button:disabled {
     padding-left:  5px;
     padding-right: 5px;
     border-width: 1px 1px 2px 1px;
     border-radius: 6px;
 }
 
-.linked .entry {
+.linked  entry {
     padding: 5px 4px;
 }
 
-.linked > GtkComboBox > .button,
-.linked > GtkComboBox > .button:focus,
-.linked > GtkComboBox > .button:hover,
-.linked > GtkComboBox > .button:checked,
-.linked > GtkComboBox > .button:focus:hover,
-.linked > GtkComboBox > .button:insensitive {
+.linked > combobox >  button,
+.linked > combobox >  button:focus,
+.linked > combobox >  button:hover,
+.linked > combobox >  button:checked,
+.linked > combobox >  button:focus:hover,
+.linked > combobox >  button:disabled {
     padding: 5px 6px;
 }
 
-.linked .button,
-.linked .button:focus,
-.linked .button:hover,
-.linked .button:checked,
-.linked .button:focus:active,
-.linked .button:focus:hover:active,
-.linked .button:hover:active,
-.linked .button:checked:hover,
-.linked .button:checked:hover:active,
-.linked .button:insensitive {
+.linked  button,
+.linked  button:focus,
+.linked  button:hover,
+.linked  button:checked,
+.linked  button:focus:active,
+.linked  button:focus:hover:active,
+.linked  button:hover:active,
+.linked  button:checked:hover,
+.linked  button:checked:hover:active,
+.linked  button:disabled {
     padding: 4px;
 }
 
-.linked > GtkComboBox > .button:insensitive,
-.linked .button:insensitive {
+.linked > combobox >  button:disabled,
+.linked  button:disabled {
     background-color: @insensitive_bg_color;
     border-color: alpha (#000, 0.00);
     border-bottom-color: alpha (#000, 0.00);
     color: @insensitive_fg_color;
 }
 
-.linked > GtkComboBox > .button,
-.linked > GtkComboBox > .button:focus,
-.linked .button,
-.linked .button:focus {
+.linked > combobox >  button,
+.linked > combobox >  button:focus,
+.linked  button,
+.linked  button:focus {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (@button_gradient1),
@@ -1466,11 +1475,11 @@ GtkColorButton.button {
 
 }
 
-.linked > GtkComboBox > .button:hover,
-.linked > GtkComboBox > .button:focus:hover,
-.linked .button:hover,
-.linked .button:focus:hover,
-.linked .button:checked:hover {
+.linked > combobox >  button:hover,
+.linked > combobox >  button:focus:hover,
+.linked  button:hover,
+.linked  button:focus:hover,
+.linked  button:checked:hover {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade(@button_gradient1, 1.03)),
@@ -1479,10 +1488,10 @@ GtkColorButton.button {
                                      to   (shade(@button_gradient4, 1.01)));
 }
 
-.linked > GtkComboBox > .button:checked,
-.linked > GtkComboBox > .button:checked:hover:active,
-.linked .button:checked,
-.linked .button:checked:hover:active {
+.linked > combobox >  button:checked,
+.linked > combobox >  button:checked:hover:active,
+.linked  button:checked,
+.linked  button:checked:hover:active {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade (@theme_bg_color, 1.20)),
@@ -1492,20 +1501,20 @@ GtkColorButton.button {
 }
 
 /* default button */
-.linked .button.default,
-.linked .button.default:focus,
-.linked .button.default:first-child,
-.linked .button.default:focus:first-child {
+.linked  button.default,
+.linked  button.default:focus,
+.linked  button.default:first-child,
+.linked  button.default:focus:first-child {
     box-shadow: inset  0px  1px shade(@selected_bg_color, 1.3),
                 inset  1px  0px shade(@selected_bg_color, 1.3),
                 inset -1px  0px rgba(255,255,255,0), 0 1px rgba(255,255,255,0),
                 inset  0px -1px shade(@selected_bg_color, 1.3);
 }
 
-.linked .button.default:last-child,
-.linked .button.default:focus:last-child,
-.linked .button.default:only-child,
-.linked .button.default:focus:only-child {
+.linked  button.default:last-child,
+.linked  button.default:focus:last-child,
+.linked  button.default:only-child,
+.linked  button.default:focus:only-child {
     box-shadow: inset  0px  1px shade(@selected_bg_color, 1.05),
                 inset  1px  0px shade(@selected_bg_color, 0.97),
                 inset -1px  0px shade(@selected_bg_color, 0.93),
@@ -1513,11 +1522,12 @@ GtkColorButton.button {
 }
 
 /* Middle button */
-.linked .entry,
-.linked > GtkComboBox > .button:last-child,
-.linked > GtkComboBox > .button:focus:last-child,
-.linked .button,
-.linked .button:focus {
+/*
+.linked  entry,
+.linked > combobox >  button:last-child,
+.linked > combobox >  button:focus:last-child,
+.linked  button,
+.linked  button:focus {
     box-shadow: inset  0px  1px alpha(shade(@button_border, 1.00), 0.70),
                 inset  1px  0px alpha(shade(@button_border, 0.94), 0.80),
                 inset -1px  0px rgba(255,255,255,0), 0 1px rgba(255,255,255,0),
@@ -1526,14 +1536,14 @@ GtkColorButton.button {
     border-left-width: 0px;
     border-radius: 0;
 }
-
+*/
  /* Middle Button active */
-.linked > GtkComboBox > .button:checked:last-child,
-.linked > GtkComboBox > .button:checked:hover:active:last-child,
-.linked .button:focus:active,
-.linked .button:hover:active,
-.linked .button:checked,
-.linked .button:checked:hover:active {
+.linked > combobox >  button:checked:last-child,
+.linked > combobox >  button:checked:hover:active:last-child,
+.linked  button:focus:active,
+.linked  button:hover:active,
+.linked  button:checked,
+.linked  button:checked:hover:active {
     box-shadow: inset  0px  1px shade(@selected_bg_color, 1.05),
                 inset  1px  0px shade(@selected_bg_color, 0.97),
                 inset -1px  0px rgba(255,255,255,0), 0 1px rgba(255,255,255,0),
@@ -1544,10 +1554,10 @@ GtkColorButton.button {
 }
 
 /* Middle button hover */
-.linked > GtkComboBox > .button:hover:last-child,
-.linked > GtkComboBox > .button:focus:hover:last-child,
-.linked .button:hover,
-.linked .button:checked:hover {
+.linked > combobox >  button:hover:last-child,
+.linked > combobox >  button:focus:hover:last-child,
+.linked  button:hover,
+.linked  button:checked:hover {
     box-shadow: inset  0px  1px shade(@selected_bg_color, 1.05),
                 inset  1px  0px shade(@selected_bg_color, 0.97),
                 inset -1px  0px rgba(255,255,255,0), 0 1px rgba(255,255,255,0),
@@ -1558,8 +1568,8 @@ GtkColorButton.button {
 }
 
 /* Middle button insensitive */
-.linked > GtkComboBox > .button:insensitive:last-child,
-.linked .button:insensitive {
+.linked > combobox >  button:disabled:last-child,
+.linked  button:disabled {
     box-shadow: inset  0px  1px @insensitive_border_color,
                 inset  1px  0px @insensitive_border_color,
                 inset -1px  0px rgba(255,255,255,0), 0 1px rgba(255,255,255,0),
@@ -1570,11 +1580,12 @@ GtkColorButton.button {
 }
 
 /* Leftmost button */
-.linked .entry:first-child,
-.linked > GtkComboBox:first-child > .button:last-child,
-.linked > GtkComboBox:first-child > .button:focus:last-child,
-.linked .button:first-child,
-.linked .button:focus:first-child {
+/*
+.linked  entry:first-child,
+.linked > combobox:first-child >  button:last-child,
+.linked > combobox:first-child >  button:focus:last-child,
+.linked  button:first-child,
+.linked  button:focus:first-child {
     box-shadow: inset  0px  1px alpha(shade(@button_border, 1.00), 0.70),
                 inset  1px  0px alpha(shade(@button_border, 0.94), 0.80),
                 inset -1px  0px rgba(255,255,255,0), 0 1px rgba(255,255,255,0),
@@ -1582,14 +1593,14 @@ GtkColorButton.button {
     border-radius: 6px 0 0 6px;
     border-right-width: 0;
 }
-
+*/
 /* Leftmost button active */
-.linked > GtkComboBox:first-child > .button:checked:first-child:last-child,
-.linked > GtkComboBox:first-child > .button:checked:hover:active:last-child,
-.linked .button:focus:active:first-child,
-.linked .button:hover:active:first-child,
-.linked .button:checked:first-child,
-.linked .button:checked:hover:active:first-child {
+.linked > combobox:first-child >  button:checked:first-child:last-child,
+.linked > combobox:first-child >  button:checked:hover:active:last-child,
+.linked  button:focus:active:first-child,
+.linked  button:hover:active:first-child,
+.linked  button:checked:first-child,
+.linked  button:checked:hover:active:first-child {
     box-shadow: inset  0px  1px shade(@selected_bg_color, 1.05),
                 inset  1px  0px shade(@selected_bg_color, 0.97),
                 inset -1px  0px rgba(255,255,255,0), 0 1px rgba(255,255,255,0),
@@ -1599,10 +1610,10 @@ GtkColorButton.button {
 }
 
 /* Leftmost button hover */
-.linked > GtkComboBox:first-child > .button:hover:last-child,
-.linked > GtkComboBox:first-child > .button:hover:focus:last-child,
-.linked .button:hover:first-child,
-.linked .button:checked:hover:first-child {
+.linked > combobox:first-child >  button:hover:last-child,
+.linked > combobox:first-child >  button:hover:focus:last-child,
+.linked  button:hover:first-child,
+.linked  button:checked:hover:first-child {
     box-shadow: inset  0px  1px shade(@selected_bg_color, 1.05),
                 inset  1px  0px shade(@selected_bg_color, 0.97),
                 inset -1px  0px rgba(255,255,255,0), 0 1px rgba(255,255,255,0),
@@ -1612,8 +1623,8 @@ GtkColorButton.button {
 }
 
 /* Leftmost button insensitive */
-.linked > GtkComboBox:first-child > .button:insensitive:last-child,
-.linked .button:insensitive:first-child {
+.linked > combobox:first-child >  button:disabled:last-child,
+.linked  button:disabled:first-child {
     box-shadow: inset  0px  1px @insensitive_border_color,
                 inset  1px  0px @insensitive_border_color,
                 inset -1px  0px rgba(255,255,255,0), 0 1px rgba(255,255,255,0),
@@ -1623,11 +1634,12 @@ GtkColorButton.button {
 }
 
 /* Rightmost button */
-.linked .entry:last-child,
-.linked > GtkComboBox:last-child > .button:last-child,
-.linked > GtkComboBox:last-child > .button:focus:last-child,
-.linked .button:last-child,
-.linked .button:focus:last-child {
+/*
+.linked  entry:last-child,
+.linked > combobox:last-child >  button:last-child,
+.linked > combobox:last-child >  button:focus:last-child,
+.linked  button:last-child,
+.linked  button:focus:last-child {
      box-shadow: inset  0px  1px alpha(shade(@button_border, 1.00), 0.70),
                  inset  1px  0px alpha(shade(@button_border, 0.94), 0.80),
                  inset -1px  0px alpha(shade(@button_border, 0.94), 0.80),
@@ -1635,14 +1647,14 @@ GtkColorButton.button {
     border-radius: 0 6px 6px 0;
     border-left-width: 0;
 }
-
+*/
 /* Rightmost button active */
-.linked > GtkComboBox:last-child > .button:checked:last-child,
-.linked > GtkComboBox:last-child > .button:checked:hover:active:last-child,
-.linked .button:focus:active:last-child,
-.linked .button:hover:active:last-child,
-.linked .button:checked:last-child,
-.linked .button:checked:hover:active:last-child {
+.linked > combobox:last-child >  button:checked:last-child,
+.linked > combobox:last-child >  button:checked:hover:active:last-child,
+.linked  button:focus:active:last-child,
+.linked  button:hover:active:last-child,
+.linked  button:checked:last-child,
+.linked  button:checked:hover:active:last-child {
     box-shadow: inset  0px  1px shade(@selected_bg_color, 1.05),
                 inset  1px  0px shade(@selected_bg_color, 0.97),
                 inset -1px  0px shade(@selected_bg_color, 0.93),
@@ -1652,10 +1664,10 @@ GtkColorButton.button {
 }
 
 /* Rightmost button hover */
-.linked > GtkComboBox:last-child > .button:hover:last-child,
-.linked > GtkComboBox:last-child > .button:hover:focus:last-child,
-.linked .button:hover:last-child,
-.linked .button:checked:hover:last-child {
+.linked > combobox:last-child >  button:hover:last-child,
+.linked > combobox:last-child >  button:hover:focus:last-child,
+.linked  button:hover:last-child,
+.linked  button:checked:hover:last-child {
     box-shadow: inset  0px  1px shade(@selected_bg_color, 1.05),
                 inset  1px  0px shade(@selected_bg_color, 0.97),
                 inset -1px  0px shade(@selected_bg_color, 0.93),
@@ -1665,8 +1677,8 @@ GtkColorButton.button {
 }
 
 /* Rightmost button insensitive */
-.linked > GtkComboBox:last-child > .button:insensitive:last-child,
-.linked .button:insensitive:last-child {
+.linked > combobox:last-child >  button:disabled:last-child,
+.linked  button:disabled:last-child {
     box-shadow: inset  0px  1px @insensitive_border_color,
                 inset  1px  0px @insensitive_border_color,
                 inset -1px  0px @insensitive_border_color,
@@ -1676,23 +1688,23 @@ GtkColorButton.button {
 }
 
 /* Linked single button */
-.linked .entry:only-child,
-.linked > GtkComboBox:only-child > .button:last-child,
-.linked > GtkComboBox:only-child > .button:focus:last-child,
-.linked .button:only-child,
-.linked .button:focus:only-child {
+.linked  entry:only-child,
+.linked > combobox:only-child >  button:last-child,
+.linked > combobox:only-child >  button:focus:last-child,
+.linked  button:only-child,
+.linked  button:focus:only-child {
     border-radius: 6px;
 }
 
-.linked > GtkComboBox:only-child > .button:hover:last-child,
-.linked > GtkComboBox:only-child > .button:checked:last-child,
-.linked > GtkComboBox:only-child > .button:focus:hover:last-child,
-.linked .button:hover:only-child,
-.linked .button:hover:active:only-child,
-.linked .button:focus:active:only-child,
-.linked .button:checked:only-child,
-.linked .button:checked:hover:only-child,
-.linked .button:checked:hover:active:only-child {
+.linked > combobox:only-child >  button:hover:last-child,
+.linked > combobox:only-child >  button:checked:last-child,
+.linked > combobox:only-child >  button:focus:hover:last-child,
+.linked  button:hover:only-child,
+.linked  button:hover:active:only-child,
+.linked  button:focus:active:only-child,
+.linked  button:checked:only-child,
+.linked  button:checked:hover:only-child,
+.linked  button:checked:hover:active:only-child {
     box-shadow: inset  0px  1px shade(@selected_bg_color, 1.05),
                 inset  1px  0px shade(@selected_bg_color, 0.97),
                 inset -1px  0px shade(@selected_bg_color, 0.93),
@@ -1701,8 +1713,8 @@ GtkColorButton.button {
 }
 
 /* Linked single button insensitive */
-.linked > GtkComboBox:only-child > .button:insensitive:last-child,
-.linked .button:insensitive:only-child {
+.linked > combobox:only-child >  button:disabled:last-child,
+.linked  button:disabled:only-child {
     box-shadow: inset  0px  1px @insensitive_border_color,
                 inset  1px  0px @insensitive_border_color,
                 inset -1px  0px @insensitive_border_color,
@@ -1712,10 +1724,10 @@ GtkColorButton.button {
 
 /* vertical */
 /* Middle button */
-.vertical.linked > GtkComboBox > .button:last-child,
-.vertical.linked > GtkComboBox > .button:focus:last-child,
-.vertical.linked .button,
-.vertical.linked .button:focus {
+.vertical.linked > combobox >  button:last-child,
+.vertical.linked > combobox >  button:focus:last-child,
+.vertical.linked  button,
+.vertical.linked  button:focus {
     box-shadow: inset  0px  1px alpha(shade(@button_border, 1.00), 0.90),
                 inset  1px  0px alpha(shade(@button_border, 0.94), 0.90),
                 inset -1px  0px alpha(shade(@button_border, 0.88), 0.90),
@@ -1724,16 +1736,16 @@ GtkColorButton.button {
     border-width: 0px 1px 1px 1px;
 }
 
-.vertical.linked > GtkComboBox > .button:hover:last-child,
-.vertical.linked > GtkComboBox > .button:focus:hover:last-child,
-.vertical.linked > GtkComboBox > .button:checked:last-child,
-.vertical.linked .button:hover,
-.vertical.linked .button:checked,
-.vertical.linked .button:focus:hover,
-.vertical.linked .button:focus:hover:active,
-.vertical.linked .button:hover:active,
-.vertical.linked .button:checked:active,
-.vertical.linked .button:checked:hover:active {
+.vertical.linked > combobox >  button:hover:last-child,
+.vertical.linked > combobox >  button:focus:hover:last-child,
+.vertical.linked > combobox >  button:checked:last-child,
+.vertical.linked  button:hover,
+.vertical.linked  button:checked,
+.vertical.linked  button:focus:hover,
+.vertical.linked  button:focus:hover:active,
+.vertical.linked  button:hover:active,
+.vertical.linked  button:checked:active,
+.vertical.linked  button:checked:hover:active {
     box-shadow: inset  0px  1px shade(@selected_bg_color, 1.05),
                 inset  1px  0px shade(@selected_bg_color, 0.97),
                 inset -1px  0px shade(@selected_bg_color, 0.93),
@@ -1742,8 +1754,8 @@ GtkColorButton.button {
     border-width: 0px 1px 1px 1px;
 }
 
-.vertical.linked > GtkComboBox > .button:insensitive:last-child,
-.vertical.linked .button:insensitive {
+.vertical.linked > combobox >  button:disabled:last-child,
+.vertical.linked  button:disabled {
     box-shadow: inset  0px  1px @insensitive_border_color,
                 inset  1px  0px @insensitive_border_color,
                 inset -1px  0px @insensitive_border_color,
@@ -1754,10 +1766,10 @@ GtkColorButton.button {
 
 /* Top button */
 
-.vertical.linked > GtkComboBox:first-child > .button:last-child,
-.vertical.linked > GtkComboBox:first-child > .button:focus:last-child,
-.vertical.linked .button:first-child,
-.vertical.linked .button:focus:first-child {
+.vertical.linked > combobox:first-child >  button:last-child,
+.vertical.linked > combobox:first-child >  button:focus:last-child,
+.vertical.linked  button:first-child,
+.vertical.linked  button:focus:first-child {
     box-shadow: inset  0px  1px alpha(shade(@button_border, 1.00), 0.70),
                 inset  1px  0px alpha(shade(@button_border, 0.94), 0.90),
                 inset  -1px 0px alpha(shade(@button_border, 0.88), 0.90);
@@ -1765,16 +1777,16 @@ GtkColorButton.button {
     border-width: 1px 1px 1px 1px;
 }
 
-.vertical.linked > GtkComboBox:first-child > .button:hover:last-child,
-.vertical.linked > GtkComboBox:first-child > .button:focus:hover:last-child,
-.vertical.linked > GtkComboBox:first-child > .button:checked:last-child,
-.vertical.linked .button:hover:first-child,
-.vertical.linked .button:checked:first-child,
-.vertical.linked .button:focus:hover:first-child,
-.vertical.linked .button:focus:hover:active:first-child,
-.vertical.linked .button:hover:active:first-child,
-.vertical.linked .button:checked:active:first-child,
-.vertical.linked .button:checked:hover:active:first-child {
+.vertical.linked > combobox:first-child >  button:hover:last-child,
+.vertical.linked > combobox:first-child >  button:focus:hover:last-child,
+.vertical.linked > combobox:first-child >  button:checked:last-child,
+.vertical.linked  button:hover:first-child,
+.vertical.linked  button:checked:first-child,
+.vertical.linked  button:focus:hover:first-child,
+.vertical.linked  button:focus:hover:active:first-child,
+.vertical.linked  button:hover:active:first-child,
+.vertical.linked  button:checked:active:first-child,
+.vertical.linked  button:checked:hover:active:first-child {
     box-shadow: inset  0px  1px shade(@selected_bg_color, 1.3),
                 inset  1px  0px shade(@selected_bg_color, 1.05),
                 inset  -1px 0px shade(@selected_bg_color, 0.93);
@@ -1782,8 +1794,8 @@ GtkColorButton.button {
     border-width: 1px 1px 1px 1px;
 }
 
-.vertical.linked > GtkComboBox:first-child > .button:insensitive:last-child,
-.vertical.linked .button:insensitive:first-child {
+.vertical.linked > combobox:first-child >  button:disabled:last-child,
+.vertical.linked  button:disabled:first-child {
     box-shadow: inset  0px  1px @insensitive_border_color,
                 inset  1px  0px @insensitive_border_color,
                 inset -1px  0px @insensitive_border_color;
@@ -1793,10 +1805,10 @@ GtkColorButton.button {
 
 /* Bottom button */
 
-.vertical.linked > GtkComboBox:last-child > .button:last-child,
-.vertical.linked > GtkComboBox:last-child > .button:focus:last-child,
-.vertical.linked .button:last-child,
-.vertical.linked .button:focus:last-child {
+.vertical.linked > combobox:last-child >  button:last-child,
+.vertical.linked > combobox:last-child >  button:focus:last-child,
+.vertical.linked  button:last-child,
+.vertical.linked  button:focus:last-child {
      box-shadow: inset  1px  0px alpha(shade(@button_border, 0.94), 0.90),
                  inset -1px  0px alpha(shade(@button_border, 0.94), 0.90),
                  inset  0px -1px alpha(shade(@button_border, 0.88), 0.70);
@@ -1804,16 +1816,16 @@ GtkColorButton.button {
     border-width: 0px 1px 1px 1px;
 }
 
-.vertical.linked > GtkComboBox:last-child > .button:hover:last-child,
-.vertical.linked > GtkComboBox:last-child > .button:focus:hover:last-child,
-.vertical.linked > GtkComboBox:last-child > .button:checked:last-child,
-.vertical.linked .button:hover:last-child,
-.vertical.linked .button:checked:last-child,
-.vertical.linked .button:focus:hover:last-child,
-.vertical.linked .button:focus:hover:active:last-child,
-.vertical.linked .button:hover:active:last-child,
-.vertical.linked .button:checked:active:last-child,
-.vertical.linked .button:checked:hover:active:last-child {
+.vertical.linked > combobox:last-child >  button:hover:last-child,
+.vertical.linked > combobox:last-child >  button:focus:hover:last-child,
+.vertical.linked > combobox:last-child >  button:checked:last-child,
+.vertical.linked  button:hover:last-child,
+.vertical.linked  button:checked:last-child,
+.vertical.linked  button:focus:hover:last-child,
+.vertical.linked  button:focus:hover:active:last-child,
+.vertical.linked  button:hover:active:last-child,
+.vertical.linked  button:checked:active:last-child,
+.vertical.linked  button:checked:hover:active:last-child {
     box-shadow: inset  1px  0px shade(@selected_bg_color, 0.97),
                 inset -1px  0px shade(@selected_bg_color, 0.93),
                 inset  0px -1px shade(@selected_bg_color, 0.93);
@@ -1821,8 +1833,8 @@ GtkColorButton.button {
     border-width: 0px 1px 1px 1px;
 }
 
-.vertical.linked > GtkComboBox:last-child > .button:insensitive:last-child,
-.vertical.linked .button:insensitive:last-child {
+.vertical.linked > combobox:last-child >  button:disabled:last-child,
+.vertical.linked  button:disabled:last-child {
     box-shadow: inset  1px  0px @insensitive_border_color,
                 inset -1px  0px @insensitive_border_color,
                 inset  0px -1px @insensitive_border_color;
@@ -1832,10 +1844,10 @@ GtkColorButton.button {
 
 /* Single button */
 
-.vertical.linked > GtkComboBox:only-child > .button:last-child,
-.vertical.linked > GtkComboBox:only-child > .button:focus:last-child,
-.vertical.linked .button:only-child,
-.vertical.linked .button:focus:only-child {
+.vertical.linked > combobox:only-child >  button:last-child,
+.vertical.linked > combobox:only-child >  button:focus:last-child,
+.vertical.linked  button:only-child,
+.vertical.linked  button:focus:only-child {
     box-shadow: inset  0px  1px alpha(shade(@button_border, 0.94), 0.90),
                 inset  1px  0px alpha(shade(@button_border, 0.94), 0.90),
                 inset -1px  0px alpha(shade(@button_border, 0.94), 0.90),
@@ -1844,16 +1856,16 @@ GtkColorButton.button {
     border-width: 1px;
 }
 
-.vertical.linked > GtkComboBox:only-child > .button:hover:last-child,
-.vertical.linked > GtkComboBox:only-child > .button:focus:hover:last-child,
-.vertical.linked > GtkComboBox:only-child > .button:checked:last-child,
-.vertical.linked .button:hover:only-child,
-.vertical.linked .button:checked:only-child,
-.vertical.linked .button:focus:hover:only-child,
-.vertical.linked .button:focus:hover:active:only-child,
-.vertical.linked .button:hover:active:only-child,
-.vertical.linked .button:checked:active:only-child,
-.vertical.linked .button:checked:hover:active:only-child {
+.vertical.linked > combobox:only-child >  button:hover:last-child,
+.vertical.linked > combobox:only-child >  button:focus:hover:last-child,
+.vertical.linked > combobox:only-child >  button:checked:last-child,
+.vertical.linked  button:hover:only-child,
+.vertical.linked  button:checked:only-child,
+.vertical.linked  button:focus:hover:only-child,
+.vertical.linked  button:focus:hover:active:only-child,
+.vertical.linked  button:hover:active:only-child,
+.vertical.linked  button:checked:active:only-child,
+.vertical.linked  button:checked:hover:active:only-child {
     box-shadow: inset  0px  1px shade(@selected_bg_color, 1.05),
                 inset  1px  0px shade(@selected_bg_color, 0.97),
                 inset -1px  0px shade(@selected_bg_color, 0.93),
@@ -1862,8 +1874,8 @@ GtkColorButton.button {
     border-width: 1px;
 }
 
-.vertical.linked > GtkComboBox:only-child > .button:insensitive:last-child,
-.vertical.linked .button:insensitive:only-child {
+.vertical.linked > combobox:only-child >  button:disabled:last-child,
+.vertical.linked  button:disabled:only-child {
     box-shadow: inset  0px  1px @insensitive_border_color,
                 inset  1px  0px @insensitive_border_color,
                 inset -1px  0px @insensitive_border_color,
@@ -1877,12 +1889,12 @@ GtkColorButton.button {
 /*************************/
 
 /* Middle button */
-.inline-toolbar.toolbar .button,
-.inline-toolbar.toolbar .button:checked,
-.inline-toolbar.toolbar .button:insensitive,
-.inline-toolbar.toolbar GtkToolButton > .button,
-.inline-toolbar.toolbar GtkToolButton > .button:checked,
-.inline-toolbar.toolbar GtkToolButton > .button:insensitive {
+.inline-toolbar toolbar  button,
+.inline-toolbar toolbar  button:checked,
+.inline-toolbar toolbar  button:disabled,
+.inline-toolbar toolbar GtkToolButton >  button,
+.inline-toolbar toolbar GtkToolButton >  button:checked,
+.inline-toolbar toolbar GtkToolButton >  button:disabled {
     /* outer */
     border-width: 0px;
     border-right-width: 0px;
@@ -1896,11 +1908,11 @@ GtkColorButton.button {
                 inset  0px -1px alpha(#fff, 0.05);
 }
 
-.inline-toolbar.toolbar .button:hover:active,
-.inline-toolbar.toolbar .button:checked,
-.inline-toolbar.toolbar .button:checked:hover,
-.inline-toolbar.toolbar .button:checked:hover:active,
-.inline-toolbar.toolbar GtkToolButton > .button:checked {
+.inline-toolbar toolbar  button:hover:active,
+.inline-toolbar toolbar  button:checked,
+.inline-toolbar toolbar  button:checked:hover,
+.inline-toolbar toolbar  button:checked:hover:active,
+.inline-toolbar toolbar GtkToolButton >  button:checked {
     background-color: transparent;
     box-shadow: inset  0px  1px alpha(#000, 0.05),
                 inset  2px  0px alpha(#000, 0.03),
@@ -1909,18 +1921,18 @@ GtkColorButton.button {
                 inset  0px -1px alpha(#000, 0.02);
 }
 
-.inline-toolbar.toolbar .button:insensitive,
-.inline-toolbar.toolbar GtkToolButton > .button:insensitive {
+.inline-toolbar toolbar  button:disabled,
+.inline-toolbar toolbar GtkToolButton >  button:disabled {
     box-shadow: inset  1px  0px shade(@button_border, 1.10);
 }
 
 /* Leftmost button */
-.inline-toolbar.toolbar .button:first-child,
-.inline-toolbar.toolbar .button:checked:first-child,
-.inline-toolbar.toolbar .button:insensitive:first-child,
-.inline-toolbar.toolbar GtkToolButton:first-child > .button,
-.inline-toolbar.toolbar GtkToolButton:first-child > .button:checked,
-.inline-toolbar.toolbar GtkToolButton:first-child > .button:insensitive {
+.inline-toolbar toolbar  button:first-child,
+.inline-toolbar toolbar  button:checked:first-child,
+.inline-toolbar toolbar  button:disabled:first-child,
+.inline-toolbar toolbar GtkToolButton:first-child >  button,
+.inline-toolbar toolbar GtkToolButton:first-child >  button:checked,
+.inline-toolbar toolbar GtkToolButton:first-child >  button:disabled {
     border-width: 0px;
     border-radius: 0px;
     box-shadow: inset  0px  1px alpha(#fff, 0.09),
@@ -1929,11 +1941,11 @@ GtkColorButton.button {
                 inset  0px -1px alpha(#fff, 0.05);
 }
 
-.inline-toolbar.toolbar .button:hover:active:first-child,
-.inline-toolbar.toolbar .button:checked:first-child,
-.inline-toolbar.toolbar .button:checked:hover:first-child,
-.inline-toolbar.toolbar .button:checked:hover:active:first-child,
-.inline-toolbar.toolbar GtkToolButton:first-child > .button:checked {
+.inline-toolbar toolbar  button:hover:active:first-child,
+.inline-toolbar toolbar  button:checked:first-child,
+.inline-toolbar toolbar  button:checked:hover:first-child,
+.inline-toolbar toolbar  button:checked:hover:active:first-child,
+.inline-toolbar toolbar GtkToolButton:first-child >  button:checked {
 
     background-color: transparent;
     box-shadow: inset  0px  1px alpha(#000, 0.05),
@@ -1942,18 +1954,18 @@ GtkColorButton.button {
                 inset  0px -1px alpha(#000, 0.02);
 }
 
-.inline-toolbar.toolbar .button:insensitive:first-child,
-.inline-toolbar.toolbar GtkToolButton:first-child > .button:insensitive {
+.inline-toolbar toolbar  button:disabled:first-child,
+.inline-toolbar toolbar GtkToolButton:first-child >  button:disabled {
     box-shadow: none;
 }
 
 /* Rightmost button */
-.inline-toolbar.toolbar .button:last-child,
-.inline-toolbar.toolbar .button:checked:last-child,
-.inline-toolbar.toolbar .button:insensitive:last-child,
-.inline-toolbar.toolbar GtkToolButton:last-child > .button,
-.inline-toolbar.toolbar GtkToolButton:last-child > .button:checked,
-.inline-toolbar.toolbar GtkToolButton:last-child > .button:insensitive {
+.inline-toolbar toolbar  button:last-child,
+.inline-toolbar toolbar  button:checked:last-child,
+.inline-toolbar toolbar  button:disabled:last-child,
+.inline-toolbar toolbar GtkToolButton:last-child >  button,
+.inline-toolbar toolbar GtkToolButton:last-child >  button:checked,
+.inline-toolbar toolbar GtkToolButton:last-child >  button:disabled {
     border-width: 0px;
     border-radius: 0px;
     box-shadow: inset  0px  1px alpha(#fff, 0.09),
@@ -1964,11 +1976,11 @@ GtkColorButton.button {
                 inset  0px -1px alpha(#fff, 0.05);
 }
 
-.inline-toolbar.toolbar .button:hover:active:last-child,
-.inline-toolbar.toolbar .button:checked:last-child,
-.inline-toolbar.toolbar .button:checked:hover:last-child,
-.inline-toolbar.toolbar .button:checked:hover:active:last-child,
-.inline-toolbar.toolbar GtkToolButton:last-child > .button:checked {
+.inline-toolbar toolbar  button:hover:active:last-child,
+.inline-toolbar toolbar  button:checked:last-child,
+.inline-toolbar toolbar  button:checked:hover:last-child,
+.inline-toolbar toolbar  button:checked:hover:active:last-child,
+.inline-toolbar toolbar GtkToolButton:last-child >  button:checked {
     background-color: transparent;
     box-shadow: inset  0px  1px alpha(#000, 0.05),
                 inset  2px  0px alpha(#000, 0.03),
@@ -1978,19 +1990,19 @@ GtkColorButton.button {
                 inset  0px -1px alpha(#000, 0.02);
 }
 
-.inline-toolbar.toolbar .button:insensitive:last-child,
-.inline-toolbar.toolbar GtkToolButton:last-child > .button:insensitive {
+.inline-toolbar toolbar  button:disabled:last-child,
+.inline-toolbar toolbar GtkToolButton:last-child >  button:disabled {
     box-shadow: inset  1px  0px shade(@button_border, 1.10),
                 inset -1px  0px shade(@button_border, 1.10);
 }
 
 /* Single button */
-.inline-toolbar.toolbar .button:only-child,
-.inline-toolbar.toolbar .button:checked:only-child,
-.inline-toolbar.toolbar .button:insensitive:only-child,
-.inline-toolbar.toolbar GtkToolButton:only-child > .button,
-.inline-toolbar.toolbar GtkToolButton:only-child > .button:checked,
-.inline-toolbar.toolbar GtkToolButton:only-child > .button:insensitive {
+.inline-toolbar toolbar  button:only-child,
+.inline-toolbar toolbar  button:checked:only-child,
+.inline-toolbar toolbar  button:disabled:only-child,
+.inline-toolbar toolbar GtkToolButton:only-child >  button,
+.inline-toolbar toolbar GtkToolButton:only-child >  button:checked,
+.inline-toolbar toolbar GtkToolButton:only-child >  button:disabled {
     border-radius:  0px;
     border-width: 0px;
     box-shadow: inset  0px  1px alpha(#fff, 0.09),
@@ -1999,11 +2011,11 @@ GtkColorButton.button {
                 inset  1px  0px shade(@button_border, 1.10);
 }
 
-.inline-toolbar.toolbar .button:hover:active:only-child,
-.inline-toolbar.toolbar .button:checked:only-child,
-.inline-toolbar.toolbar .button:checked:hover:only-child,
-.inline-toolbar.toolbar .button:checked:hover:active:only-child,
-.inline-toolbar.toolbar GtkToolButton:only-child > .button:checked {
+.inline-toolbar toolbar  button:hover:active:only-child,
+.inline-toolbar toolbar  button:checked:only-child,
+.inline-toolbar toolbar  button:checked:hover:only-child,
+.inline-toolbar toolbar  button:checked:hover:active:only-child,
+.inline-toolbar toolbar GtkToolButton:only-child >  button:checked {
     background-color: transparent;
     box-shadow: inset  0px  1px alpha(#000, 0.05),
                 inset -1px  0px alpha(#000, 0.03),
@@ -2011,8 +2023,8 @@ GtkColorButton.button {
                 inset  1px  0px shade(@button_border, 0.80);
 }
 
-.inline-toolbar.toolbar .button:insensitive:only-child,
-.inline-toolbar.toolbar GtkToolButton:only-child > .button:insensitive {
+.inline-toolbar toolbar  button:disabled:only-child,
+.inline-toolbar toolbar GtkToolButton:only-child >  button:disabled {
     box-shadow: inset  1px  0px shade(@button_border, 1.10);
 }
 
@@ -2020,29 +2032,32 @@ GtkColorButton.button {
  * ComboBoxes *
  **************/
 
-GtkComboBox {
+combobox {
     padding: 0px;
-    -GtkWidget-focus-padding: 0;
-    -GtkWidget-focus-line-width: 0;
-    -GtkComboBox-arrow-scaling: 0.5;
-    -GtkComboBox-shadow-type: none;
+    -combobox-arrow-scaling: 0.5;
+    -combobox-shadow-type: none;
 }
 
-GtkComboBox .cell {
+combobox .cell {
     /* color combobox read-only */
     color: @theme_fg_color;
     text-shadow: 0 1px @theme_shadow_color;
 }
 
-GtkComboBox .separator {
+combobox menu .cell {
+    /* light text on dark combobox menu */
+    color: @theme_bg_color;
+    text-shadow: 0 1px @theme_shadow_color;
+}
+
+combobox .separator {
     /* always disable separators */
-    -GtkWidget-wide-separators: true;
     -GtkWidget-horizontal-separator: 0;
     -GtkWidget-vertical-separator: 0;
 }
 
-GtkComboBox .entry,
-GtkComboBox .entry:nth-child(first) {
+combobox  entry,
+combobox  entry:nth-child(first) {
     border-width: 2px 0px 2px 2px; /* remove right-outer */
     border-radius: 4px 0px 0px 4px;
     /* remove right-border */
@@ -2057,7 +2072,7 @@ GtkComboBox .entry:nth-child(first) {
 }
 
 
-GtkComboBox .entry:focus {
+combobox  entry:focus {
     border-width: 2px 0px 2px 2px; /* remove right-outer */
     /* border */
     box-shadow: inset  0px  3px alpha(#000, 0.03),
@@ -2071,35 +2086,35 @@ GtkComboBox .entry:focus {
 }
 
 /* for RTL languages */
-GtkComboBox .entry:nth-child(last) {
+combobox  entry:nth-child(last) {
     border-width: 2px 2px 2px 0px;
     border-radius: 0px 5px 5px 0px;
     border-image-width: 2px 2px 2px 0px;
 }
 
-GtkComboBox .button {
+combobox  button {
     color: @internal_element_color;
     padding: 2px 3px 2px 6px;
 }
 
-GtkComboBox .button *:prelight {
+combobox  button *:hover {
     color: @theme_text_color;
 }
 
-.toolbar GtkComboBox .cell {
+toolbar combobox .cell {
     /* color combobox read-only */
     color: shade(@toolbar_fg_color, 0.94);
     text-shadow: 0 1px @toolbar_shadow_color;
 }
 
-.primary-toolbar GtkComboBox .cell {
+.primary-toolbar combobox .cell {
     /* color combobox read-only */
     color: shade(@theme_fg_dark_color, 0.94);
     text-shadow: 0 1px @theme_shadow_dark_color;
 }
 
-.toolbar GtkComboBox .entry,
-.toolbar GtkComboBox .entry:focus {
+toolbar combobox  entry,
+toolbar combobox  entry:focus {
     border-width: 1px 0px 1px 1px; /* remove rightr */
     border-top-color: shade(@toolbar_gradient_base, 0.60);
     border-left-color: shade(@toolbar_gradient_base, 0.70);
@@ -2111,7 +2126,7 @@ GtkComboBox .button *:prelight {
                 inset -1px  0px alpha(#000, 0.05);
 }
 
-.toolbar GtkComboBox.combobox-entry .button {
+toolbar combobox.combobox-entry  button {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (alpha(#fff, 0.04)),
@@ -2122,7 +2137,7 @@ GtkComboBox .button *:prelight {
     border-bottom-color: alpha (#000, 0.25);
 }
 
-.toolbar GtkComboBox.combobox-entry .button:checked {
+toolbar combobox.combobox-entry  button:checked {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (alpha(#000, 0.20)),
@@ -2140,16 +2155,16 @@ GtkComboBox .button *:prelight {
                 inset  0px -1px alpha(#fff, 0.01);
 }
 
-.toolbar GtkComboBox.combobox-entry .button,
-.toolbar GtkComboBox.combobox-entry .button:hover,
-.toolbar GtkComboBox.combobox-entry .button:checked,
-.toolbar GtkComboBox.combobox-entry .button:insensitive,
-.toolbar GtkComboBox.combobox-entry .button:nth-child(last),
-.primary-toolbar GtkComboBox.combobox-entry .button,
-.primary-toolbar GtkComboBox.combobox-entry .button:hover,
-.primary-toolbar GtkComboBox.combobox-entry .button:checked,
-.primary-toolbar GtkComboBox.combobox-entry .button:insensitive,
-.primary-toolbar GtkComboBox.combobox-entry .button:nth-child(last) {
+toolbar combobox.combobox-entry  button,
+toolbar combobox.combobox-entry  button:hover,
+toolbar combobox.combobox-entry  button:checked,
+toolbar combobox.combobox-entry  button:disabled,
+toolbar combobox.combobox-entry  button:nth-child(last),
+.primary-toolbar combobox.combobox-entry  button,
+.primary-toolbar combobox.combobox-entry  button:hover,
+.primary-toolbar combobox.combobox-entry  button:checked,
+.primary-toolbar combobox.combobox-entry  button:disabled,
+.primary-toolbar combobox.combobox-entry  button:nth-child(last) {
     border-top-left-radius: 0px;
     border-bottom-left-radius: 0px;
     border-top-right-radius: 4px;
@@ -2158,11 +2173,11 @@ GtkComboBox .button *:prelight {
     padding: 2px 3px;
 }
 
-GtkComboBox.combobox-entry .button,
-GtkComboBox.combobox-entry .button:hover,
-GtkComboBox.combobox-entry .button:checked,
-GtkComboBox.combobox-entry .button:insensitive,
-GtkComboBox.combobox-entry .button:nth-child(last) {
+combobox.combobox-entry  button,
+combobox.combobox-entry  button:hover,
+combobox.combobox-entry  button:checked,
+combobox.combobox-entry  button:disabled,
+combobox.combobox-entry  button:nth-child(last) {
     border-color: transparent;
     border-top-left-radius: 0px;
     border-bottom-left-radius: 0px;
@@ -2172,7 +2187,7 @@ GtkComboBox.combobox-entry .button:nth-child(last) {
     padding: 2px 3px;
 }
 
-GtkComboBox.combobox-entry .button:hover {
+combobox.combobox-entry  button:hover {
     border-top-left-radius: 0px;
     border-bottom-left-radius: 0px;
     border-top-right-radius: 5px;
@@ -2186,25 +2201,25 @@ GtkComboBox.combobox-entry .button:hover {
 }
 
 /* for RTL languages */
-GtkComboBox.combobox-entry .button:nth-child(first) {
+combobox.combobox-entry  button:nth-child(first) {
     border-width: 2px 0px 2px 2px;
     border-radius: 4px 0px 0px 4px;
 }
 
-.primary-toolbar GtkComboBox.combobox-entry .button:nth-child(first) {
+.primary-toolbar combobox.combobox-entry  button:nth-child(first) {
     border-width: 1px 0px 1px 1px;
     border-radius: 4px 0px 0px 4px;
 }
 
-GtkComboBox.combobox-entry .button *:checked,
-GtkComboBox.combobox-entry .button *:prelight {
-    color: @internal_element_prelight;
+combobox.combobox-entry  button *:checked,
+combobox.combobox-entry  button *:hover {
+    color: @internal_element_hover;
 }
 
-.toolbar GtkComboBox.combobox-entry .button *:checked,
-.toolbar GtkComboBox.combobox-entry .button *:prelight,
-.primary-toolbar GtkComboBox.combobox-entry .button *:checked,
-.primary-toolbar GtkComboBox.combobox-entry .button *:prelight {
+ toolbar combobox.combobox-entry  button *:checked,
+ toolbar combobox.combobox-entry  button *:hover,
+.primary-toolbar combobox.combobox-entry  button *:checked,
+.primary-toolbar combobox.combobox-entry  button *:hover {
     color: @theme_text_dark_color;
 }
 
@@ -2212,13 +2227,13 @@ GtkComboBox.combobox-entry .button *:prelight {
  * Toolbars *
  ************/
 
-.toolbar * {
+ toolbar * {
     background-image: none;
     background-color: alpha (@theme_base_color, 0.0);
 }
 
 GtkHandleBox,
-.toolbar  {
+ toolbar  {
     padding: 2px 4px;
     background-color: @toolbar_gradient_base;
     background-image: -gtk-gradient (linear,
@@ -2232,7 +2247,7 @@ GtkHandleBox,
     color: @toolbar_fg_color;
 }
 
-.toolbar.vertical {
+ toolbar.vertical {
     border-radius: 4px 0 0 4px;
     padding: 2px;
 }
@@ -2241,7 +2256,7 @@ GtkHandleBox,
  * Menubar Toolbars *
  ********************/
 
-.toolbar.menubar {
+ toolbar menubar {
     padding: 2px 4px 5px 3px;
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
@@ -2265,7 +2280,7 @@ GtkHandleBox,
  * hint on the containing vbox, so we need to handle both these cases here.
  */
 
-.primary-toolbar.toolbar {
+.primary-toolbar toolbar {
    background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade(@theme_bg_dark_color, 1.00)),
@@ -2282,7 +2297,7 @@ GtkHandleBox,
     color: @theme_fg_dark_color;
 }
 
-.primary-toolbar.toolbar:insensitive {
+.primary-toolbar toolbar:disabled {
     background-image: none;
     background-color: shade (@theme_bg_dark_color, 0.97);
     border-image: none;
@@ -2291,24 +2306,24 @@ GtkHandleBox,
 }
 
 /* primary toolbar buttons */
-.toolbar .button,
-.primary-toolbar.toolbar .button {
-    -GtkWidget-focus-line-width: 0;
+ toolbar  button,
+.primary-toolbar toolbar  button {
     border-image: none;
     border-style: solid;
     border-radius: 6px;
+	border-width: 1px;
     border-color: transparent;
     box-shadow: none;
     background-image: none;
     background-color: alpha (@theme_base_color, 0.0);
 }
 
-.toolbar .button {
+toolbar  button label{
     color: shade(@toolbar_fg_color, 1.00);
     text-shadow: 0px 1px @toolbar_shadow_color;
 }
 
-.toolbar GtkComboBox .button {
+toolbar combobox  button {
     /* color combobox read-only */
     color: shade(@toolbar_fg_color, 1.00);
     text-shadow: 0px 1px @toolbar_shadow_color;
@@ -2326,38 +2341,37 @@ GtkHandleBox,
                 inset  0px -1px alpha(shade(@button_border, 0.88), 0.90);
 }
 
-.toolbar GtkComboBox .button:hover {
+ toolbar combobox  button:hover {
     border-radius: 5px
 }
 
-.primary-toolbar.toolbar .button {
+.primary-toolbar toolbar  button {
     color: @theme_fg_dark_color;
     text-shadow: 0px 1px @theme_shadow_dark_color;
 }
 
-.primary-toolbar .linked .button:focus {
+.primary-toolbar .linked  button:focus {
    box-shadow: none;
 }
 
-.toolbar .button:insensitive,
-.primary-toolbar.toolbar .button:insensitive {
+ toolbar  button:disabled,
+.primary-toolbar toolbar  button:disabled {
     background-image: none;
     background-color: alpha (@theme_base_color, 0.0);
     border-color: transparent;
-    /* -GtkWidget-focus-line-width: 0; */
 }
 
-.toolbar .button *:insensitive {
+ toolbar  button *:disabled {
     color: mix(@toolbar_gradient_base, @toolbar_fg_color, 0.60);
     text-shadow: none;
 }
 
-.primary-toolbar.toolbar .button *:insensitive {
+.primary-toolbar toolbar  button *:disabled {
     color: mix(@theme_bg_dark_color, @theme_fg_dark_color, 0.60);
     text-shadow: none;
 }
 
-.toolbar .button:hover {
+ toolbar  button:hover {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade(@menu_bg_dark_color, 2.03)),
@@ -2368,11 +2382,11 @@ GtkHandleBox,
                 inset  0px -1px shade(@selected_bg_color, 0.93);
 }
 
-.toolbar .button:hover:active,
-.toolbar .button:checked,
-.toolbar .button:checked:focus,
-.toolbar .button:checked:hover,
-.toolbar .button:checked:hover:active {
+ toolbar  button:hover:active,
+ toolbar  button:checked,
+ toolbar  button:checked:focus,
+ toolbar  button:checked:hover,
+ toolbar  button:checked:hover:active {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade(@menu_bg_dark_color, 2.03)),
@@ -2386,12 +2400,12 @@ GtkHandleBox,
                 inset  0px -1px shade(@selected_bg_color, 0.93);
 }
 
-.primary-toolbar.toolbar .button:hover,
-.primary-toolbar.toolbar .button:hover:active,
-.primary-toolbar.toolbar .button:checked,
-.primary-toolbar.toolbar .button:checked:focus,
-.primary-toolbar.toolbar .button:checked:hover,
-.primary-toolbar.toolbar .button:checked:hover:active {
+.primary-toolbar toolbar  button:hover,
+.primary-toolbar toolbar  button:hover:active,
+.primary-toolbar toolbar  button:checked,
+.primary-toolbar toolbar  button:checked:focus,
+.primary-toolbar toolbar  button:checked:hover,
+.primary-toolbar toolbar  button:checked:hover:active {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade(@menu_bg_dark_color, 2.03)),
@@ -2405,50 +2419,50 @@ GtkHandleBox,
                 inset  0px -1px shade(@selected_bg_color, 0.93);
 }
 
-.toolbar .button *:hover,
-.toolbar .button *:active,
-.toolbar .button *:checked {
+ toolbar  button *:hover,
+ toolbar  button *:active,
+ toolbar  button *:checked {
 /* edge */
     color: shade(@toolbar_fg_color, 0.90);
     text-shadow: 0px 1px @toolbar_shadow_color;
 }
 
-/* arrangement epiphany (toolbar.menubar) */
-.primary-toolbar.toolbar .button *:hover,
-.primary-toolbar.toolbar .button *:active,
-.primary-toolbar.toolbar .button *:hover:active,
-.primary-toolbar.toolbar .button *:active:active,
-.primary-toolbar.toolbar .button *:checked,
-.primary-toolbar.toolbar .button *:checked:hover,
-.primary-toolbar.toolbar .button *:checked:checked {
+/* arrangement epiphany (toolbar menubar) */
+.primary-toolbar toolbar  button *:hover,
+.primary-toolbar toolbar  button *:active,
+.primary-toolbar toolbar  button *:hover:active,
+.primary-toolbar toolbar  button *:active:active,
+.primary-toolbar toolbar  button *:checked,
+.primary-toolbar toolbar  button *:checked:hover,
+.primary-toolbar toolbar  button *:checked:checked {
     color: @theme_text_dark_color;
     text-shadow: 0px 1px @theme_shadow_dark_color;
 }
 
-.toolbar .button:active:insensitive,
-.toolbar .button:checked:insensitive,
-.primary-toolbar.toolbar .button:checked:insensitive {
+ toolbar  button:active:disabled,
+ toolbar  button:checked:disabled,
+.primary-toolbar toolbar  button:checked:disabled {
     background-image: none;
     background-color: alpha (@theme_base_color, 0.0);
     border-color: transparent;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     text-shadow: none;
 }
 
-.toolbar GtkLabel {
+ toolbar label {
     color: shade(@theme_fg_color, 1.10);
     text-shadow: 0px 1px @theme_shadow_color;
 }
 
-.toolbar.menubar GtkLabel,
-.primary-toolbar.toolbar GtkLabel {
+ toolbar menubar label,
+.primary-toolbar toolbar label {
     color: @theme_fg_dark_color;
     text-shadow: 0px 1px @theme_shadow_dark_color;
 }
 
-.toolbar GtkSeparatorToolItem,
-.toolbar .separator,
-.toolbar .separator:insensitive {
+ toolbar GtkSeparatorToolItem,
+ toolbar .separator,
+ toolbar .separator:disabled {
     border-color: alpha (#000, 0.24);
     border-bottom-color: alpha (#fff, 0.08);
     border-right-color: alpha (#fff, 0.08);
@@ -2458,26 +2472,26 @@ GtkHandleBox,
     primary toolbar raised buttons
 *************************************/
 
-.toolbar .raised .button,
-.toolbar .raised.button {
+ toolbar .raised  button,
+ toolbar .raised button {
     padding: 2px;
 }
 
-.toolbar.menubar .button {
+ toolbar menubar  button {
     padding: 2px 2px;
 }
 
-.toolbar.menubar .linked .button {
+ toolbar menubar .linked  button {
     padding: 3px 4px;
 }
 
-.toolbar.menubar .button {
+ toolbar menubar  button {
     padding: 2px 4px;
 }
 
-.toolbar.menubar .button,
-.toolbar .raised .button,
-.toolbar .raised.button {
+ toolbar menubar  button,
+ toolbar .raised  button,
+ toolbar .raised button {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (@button_raised_gradient_color_a),
@@ -2486,25 +2500,24 @@ GtkHandleBox,
     /* outer */
     border-color: transparent;
     /* border and inset */
-    -GtkWidget-focus-line-width: 0;
     color: shade(@theme_fg_dark_color, 1.00);
 }
 
-.toolbar .button.raised.linked:insensitive,
-.toolbar .raised.linked .button:insensitive,
-.toolbar .button.raised.linked:insensitive:active,
-.toolbar .raised.linked .button:insensitive:active,
-.toolbar .button.raised.linked:insensitive:checked,
-.toolbar .raised.linked .button:insensitive:checked,
-.toolbar.menubar .button:insensitive,
-.toolbar.menubar .button:insensitive:active,
-.toolbar.menubar .button:insensitive:checked,
-.toolbar .raised .button:insensitive,
-.toolbar .raised.button:insensitive,
-.toolbar .raised .button:insensitive:active,
-.toolbar .raised.button:insensitive:active,
-.toolbar .raised .button:insensitive:checked,
-.toolbar .raised.button:insensitive:checked {
+toolbar  button.raised.linked:disabled,
+toolbar .raised.linked  button:disabled,
+toolbar  button.raised.linked:disabled:active,
+toolbar .raised.linked  button:disabled:active,
+toolbar  button.raised.linked:disabled:checked,
+toolbar .raised.linked  button:disabled:checked,
+toolbar menubar  button:disabled,
+toolbar menubar  button:disabled:active,
+toolbar menubar  button:disabled:checked,
+toolbar .raised  button:disabled,
+toolbar .raised button:disabled,
+toolbar .raised  button:disabled:active,
+toolbar .raised button:disabled:active,
+toolbar .raised  button:disabled:checked,
+toolbar .raised button:disabled:checked {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade(@button_raised_gradient_color_a, 0.88)),
@@ -2514,9 +2527,9 @@ GtkHandleBox,
     color: mix(@theme_bg_dark_color, @theme_fg_dark_color, 0.50);
 }
 
-.toolbar.menubar .button:hover,
-.toolbar .raised .button:hover,
-.toolbar .raised.button:hover {
+ toolbar menubar  button:hover,
+ toolbar .raised  button:hover,
+ toolbar .raised button:hover {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade(@menu_bg_dark_color, 2.03)),
@@ -2532,13 +2545,13 @@ GtkHandleBox,
     color: shade(@theme_fg_dark_color, 1.00);
 }
 
-.toolbar .raised .button:hover:active,
-.toolbar .raised.button:hover:active,
-.toolbar.menubar .button:checked,
-.toolbar .raised .button:checked,
-.toolbar .raised .button:checked:hover,
-.toolbar .raised.button:checked:hover,
-.toolbar .raised.button:checked {
+toolbar .raised  button:hover:active,
+toolbar .raised button:hover:active,
+toolbar menubar  button:checked,
+toolbar .raised  button:checked,
+toolbar .raised  button:checked:hover,
+toolbar .raised button:checked:hover,
+toolbar .raised button:checked {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade(@menu_bg_dark_color, 2.03)),
@@ -2554,40 +2567,40 @@ GtkHandleBox,
 }
 
 /* setup shadows */
-.toolbar .raised .button GtkLabel,
-.toolbar .raised.button GtkLabel {
+toolbar .raised  button label,
+toolbar .raised button label {
     color: @theme_fg_dark_color;
     text-shadow: 0px 1px @theme_shadow_dark_color;
 }
 
-.toolbar .raised .button,
-.toolbar .raised.button {
-    icon-shadow:  1px  1px @theme_shadow_dark_color;
+toolbar .raised  button,
+toolbar .raised button {
+    -gtk-icon-shadow:  1px  1px @theme_shadow_dark_color;
 }
 
-.toolbar.menubar .button *:hover,
-.toolbar .raised .button *:hover,
-.toolbar .raised.button *:hover,
-.toolbar .raised .button *:hover:active,
-.toolbar .raised.button *:hover:active,
-.toolbar.menubar .button *:checked,
-.toolbar .raised .button *:checked,
-.toolbar .raised.button *:checked,
-.toolbar .raised .button *:checked:hover,
-.toolbar .raised.button *:checked:hover {
+toolbar menubar  button *:hover,
+toolbar .raised  button *:hover,
+toolbar .raised button *:hover,
+toolbar .raised  button *:hover:active,
+toolbar .raised button *:hover:active,
+toolbar menubar  button *:checked,
+toolbar .raised  button *:checked,
+toolbar .raised button *:checked,
+toolbar .raised  button *:checked:hover,
+toolbar .raised button *:checked:hover {
     color: @theme_text_dark_color;
     text-shadow: 0px 1px @theme_shadow_dark_color;
 }
 
-.toolbar.menubar .button *:insensitive,
-.toolbar .raised .button *:insensitive,
-.toolbar .raised.button *:insensitive {
-    icon-shadow: none;
+toolbar menubar  button *:disabled,
+toolbar .raised  button *:disabled,
+toolbar .raised button *:disabled {
+    -gtk-icon-shadow: none;
     text-shadow: none;
     color: mix(@theme_bg_dark_color, @theme_fg_dark_color, 0.50);
 }
 
-.toolbar .entry {
+toolbar  entry {
     padding: 4px 4px 4px 6px;
     color: shade(@toolbar_fg_color, 1.0);
     background-image: -gtk-gradient (linear,
@@ -2597,12 +2610,12 @@ GtkHandleBox,
                                      to   (shade(@toolbar_gradient_base, 1.15)));
 }
 
-.toolbar .entry,
-.toolbar.menubar .entry,
-.toolbar .raised .entry,
-.toolbar .raised.entry,
-.primary-toolbar .toolbar .entry,
-.primary-toolbar.toolbar .entry {
+toolbar  entry,
+toolbar menubar  entry,
+toolbar .raised  entry,
+toolbar .raised entry,
+primary-toolbar  toolbar  entry,
+primary-toolbar toolbar  entry {
     padding: 4px 4px 4px 6px;
     color: @entry_text_dark_color;
     background-image: -gtk-gradient (linear,
@@ -2630,11 +2643,11 @@ GtkHandleBox,
                 inset  0px -1px shade(@theme_entry_border_dark, 1.10);
 }
 
-.toolbar .entry:focus,
-.toolbar.menubar .entry:focus,
-.toolbar .raised .entry:focus,
-.toolbar .raised.entry:focus,
-.primary-toolbar.toolbar .entry:focus {
+toolbar  entry:focus,
+toolbar menubar  entry:focus,
+toolbar .raised  entry:focus,
+toolbar .raised entry:focus,
+primary-toolbar toolbar  entry:focus {
     /* outer */
     border-top-color: @focused_dark_entry_outer;
     border-right-color: alpha(@focused_dark_entry_outer, 0.90);
@@ -2652,17 +2665,17 @@ GtkHandleBox,
                 inset  0px -1px shade(@focused_dark_entry_border, 1.00);
 }
 
-.toolbar .entry:selected,
-.toolbar.menubar .entry:selected,
-.toolbar .raised .entry:selected,
-.toolbar .raised.entry:selected,
-.primary-toolbar.toolbar .entry:selected {
+toolbar  entry selection,
+toolbar menubar  entry selection,
+toolbar .raised  entry selection,
+toolbar .raised entry selection,
+primary-toolbar toolbar  entry selection {
     background-color: @theme_selected_bg_color;
     color: @theme_selected_fg_color;
 }
 
 /* progressbars on primary toolbar entries are special */
-.primary-toolbar.toolbar .entry.progressbar {
+primary-toolbar toolbar  entry progressbar progress {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade (@button_bg_active, 1.35)),
@@ -2682,7 +2695,7 @@ GtkHandleBox,
  * Buttons + dialog open *
  ****************************/
 
-.inline-toolbar.toolbar {
+.inline-toolbar toolbar {
     -GtkToolbar-button-relief: normal;
     padding: 0px;
     background-color: alpha(@button_base, 0.0);
@@ -2706,7 +2719,7 @@ GtkHandleBox,
                 inset  0px -1px alpha(#fff, 0.05);
 }
 
-.inline-toolbar.toolbar .button {
+.inline-toolbar toolbar  button {
     padding: 2px 6px;
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
@@ -2720,13 +2733,13 @@ GtkHandleBox,
     box-shadow:  none;
     color:       @theme_fg_color;
     text-shadow: 0 1px @theme_shadow_color;
-    icon-shadow: 1px 1px @theme_shadow_color;
+    -gtk-icon-shadow: 1px 1px @theme_shadow_color;
 }
 
-.inline-toolbar.toolbar .button:hover:active,
-.inline-toolbar.toolbar .button:checked,
-.inline-toolbar.toolbar .button:checked:hover,
-.inline-toolbar.toolbar .button:checked:hover:active {
+.inline-toolbar toolbar  button:hover:active,
+.inline-toolbar toolbar  button:checked,
+.inline-toolbar toolbar  button:checked:hover,
+.inline-toolbar toolbar  button:checked:hover:active {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade(@button_base, 0.50)),
@@ -2740,7 +2753,7 @@ GtkHandleBox,
                 inset  0px -1px shade(@button_border, 0.78);
 }
 
-.inline-toolbar.toolbar .button:hover {
+.inline-toolbar toolbar  button:hover {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade(@button_base, 1.03)),
@@ -2750,60 +2763,60 @@ GtkHandleBox,
     color: @theme_text_color;
 }
 
-.inline-toolbar.toolbar .button:insensitive {
+.inline-toolbar toolbar  button:disabled {
     box-shadow: none;
     background-color: mix(@button_base, @theme_fg_color, 0.10);
     background-image: none;
 }
 
-.inline-toolbar.toolbar .button *:insensitive {
+.inline-toolbar toolbar  button *:disabled {
     color: @insensitive_fg_color;
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
 }
 
-.inline-toolbar.toolbar .button *:hover {
+.inline-toolbar toolbar  button *:hover {
     color: @theme_text_color;
     text-shadow: 0 1px @theme_shadow_color;
-    icon-shadow: 1px 1px @theme_shadow_color;
+    -gtk-icon-shadow: 1px 1px @theme_shadow_color;
 }
 
-.inline-toolbar.toolbar .button *:active,
-.inline-toolbar.toolbar .button *:checked {
+.inline-toolbar toolbar  button *:active,
+.inline-toolbar toolbar  button *:checked {
     color: @theme_selected_fg_color;
     text-shadow: 0 1px @theme_selected_shadow_color;
-    icon-shadow: 1px 1px @theme_selected_shadow_color;
+    -gtk-icon-shadow: 1px 1px @theme_selected_shadow_color;
 }
 
 /* Stack switcher */
-.stack-switcher > .button > GtkLabel,
-.header-bar .stack-switcher > .button.titlebutton > GtkLabel,
-.titlebar .stack-switcher > .button.titlebutton > GtkLabel,
-GtkCalendar.header .stack-switcher > .button.titlebutton > GtkLabel {
+.stack-switcher >  button > label,
+ headerbar .stack-switcher >  button.titlebutton > label,
+.titlebar .stack-switcher >  button.titlebutton > label,
+calendar.header .stack-switcher >  button.titlebutton > label {
     padding-left: 6px;
     padding-right: 6px;
 }
 
-.stack-switcher > .button > GtkImage,
-.header-bar .stack-switcher > .button.titlebutton > GtkImage,
-.titlebar .stack-switcher > .button.titlebutton > GtkImage,
-GtkCalendar.header .stack-switcher > .button.titlebutton > GtkImage {
+stack-switcher >  button > image,
+header-bar stack-switcher >  button.titlebutton > image,
+titlebar stack-switcher >  button.titlebutton > image,
+calendar.header .stack-switcher >  button.titlebutton > image {
     padding-left: 6px;
     padding-right: 6px;
     padding-top: 3px;
     padding-bottom: 3px;
 }
 
-.stack-switcher > .button.text-button,
-.stack-switcher > .button.image-button,
-.header-bar .stack-switcher > .titlebutton.button,
-.titlebar .stack-switcher > .titlebutton.button,
-GtkCalendar.header .stack-switcher > .titlebutton.button {
+.stack-switcher >  button.text-button,
+.stack-switcher >  button.image-button,
+ headerbar .stack-switcher > .titlebutton button,
+.titlebar .stack-switcher > .titlebutton button,
+calendar.header .stack-switcher > .titlebutton button {
     padding: 4px 2px;
 }
 
-.stack-switcher > .button.needs-attention > GtkLabel,
-.stack-switcher > .button.needs-attention > GtkImage {
+.stack-switcher >  button.needs-attention > label,
+.stack-switcher >  button.needs-attention > image {
     animation: needs_attention 150ms ease-in;
     background-color: @theme_bg_color; /* FIXME: ? */
     background-size: 6px 6px, 6px 6px;
@@ -2811,18 +2824,18 @@ GtkCalendar.header .stack-switcher > .titlebutton.button {
     background-position: right 3px, right 4px;
 }
 
-.stack-switcher > .button.needs-attention > GtkLabel:backdrop,
-.stack-switcher > .button.needs-attention > GtkImage:backdrop {
+.stack-switcher >  button.needs-attention > label:backdrop,
+.stack-switcher >  button.needs-attention > image:backdrop {
     background-size: 6px 6px, 0 0;
 }
 
-.stack-switcher > .button.needs-attention > GtkLabel:dir(rtl),
-.stack-switcher > .button.needs-attention > GtkImage:dir(rtl) {
+.stack-switcher >  button.needs-attention > label:dir(rtl),
+.stack-switcher >  button.needs-attention > image:dir(rtl) {
     background-position: left 3px, left 4px;
 }
 
-.stack-switcher > .button.needs-attention:checked > GtkLabel,
-.stack-switcher > .button.needs-attention:checked > GtkImage {
+.stack-switcher >  button.needs-attention:checked > label,
+.stack-switcher >  button.needs-attention:checked > image {
     animation: none;
     background-image: none;
 }
@@ -2831,11 +2844,11 @@ GtkCalendar.header .stack-switcher > .titlebutton.button {
  * GtkActionBar *
  ****************/
 
-GtkActionBar .frame.action-bar .horizontal.linked.stack-switcher .button.image-button {
+actionbar .frame.action-bar .horizontal.linked.stack-switcher  button.image-button {
     padding: 4px 2px;
 }
 
-GtkActionBar .frame.action-bar .button.image-button {
+actionbar .frame.action-bar  button.image-button {
     padding: 8px;
 }
 
@@ -2843,11 +2856,11 @@ GtkActionBar .frame.action-bar .button.image-button {
  * GtkSpinButton *
  *****************/
 
-.horizontal.entry.spinbutton {
+.horizontal entry spinbutton {
    padding: 4px 5px;
 }
 
-.spinbutton .button {
+spinbutton  button {
     color: @internal_element_color;
     border-width: 0;
     border-radius: 0;
@@ -2857,31 +2870,31 @@ GtkActionBar .frame.action-bar .button.image-button {
     background-image: none;
 }
 
-.spinbutton .button:insensitive,
-.spinbutton .button:insensitive:last-child,
-.spinbutton .button:insensitive:first-child,
-.spinbutton .button:insensitive:only-child,
-.spinbutton .vertical .button:insensitive,
-.spinbutton .vertical .button:insensitive:last-child,
-.spinbutton .vertical .button:insensitive:first-child,
-.spinbutton .vertical .button:insensitive:only-child {
+spinbutton  button:disabled,
+spinbutton  button:disabled:last-child,
+spinbutton  button:disabled:first-child,
+spinbutton  button:disabled:only-child,
+spinbutton .vertical  button:disabled,
+spinbutton .vertical  button:disabled:last-child,
+spinbutton .vertical  button:disabled:first-child,
+spinbutton .vertical  button:disabled:only-child {
     color: @internal_element_insensitive;
     box-shadow: inset  1px  0px shade(@insensitive_border_color, 0.97);
     border-color: @insensitive_border_color;
 }
 
-.spinbutton .button,
-.spinbutton .button:hover,
-.spinbutton .button:focus,
-.spinbutton .button:checked {
+spinbutton  button,
+spinbutton  button:hover,
+spinbutton  button:focus,
+spinbutton  button:checked {
     border-radius: 0px 0px 0px 0px;
-    color: @internal_element_prelight;
+    color: @internal_element_hover;
     box-shadow: inset  0px  1px shade(@selected_bg_color, 1.05),
                 inset  1px  0px shade(@selected_bg_color, 0.97),
                 inset  0px -1px shade(@selected_bg_color, 0.93);
 }
 
-.spinbutton .button:hover {
+spinbutton  button:hover {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade(@button_gradient1, 1.03)),
@@ -2890,7 +2903,7 @@ GtkActionBar .frame.action-bar .button.image-button {
                                      to   (shade(@button_gradient4, 1.01)));
 }
 
-.spinbutton .button:checked {
+spinbutton  button:checked {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade (@theme_bg_color, 1.20)),
@@ -2899,81 +2912,81 @@ GtkActionBar .frame.action-bar .button.image-button {
                                      to (shade (@theme_bg_color, 0.80)));
 }
 
-.spinbutton .button,
-.spinbutton .button:hover,
-.spinbutton .button:checked,
-.spinbutton .button:insensitive {
+spinbutton  button,
+spinbutton  button:hover,
+spinbutton  button:checked,
+spinbutton  button:disabled {
     border-radius: 0px 0 0 0px;
     border-image: none;
     padding: 6px 3px;
 }
 
-.spinbutton .button:first-child,
-.spinbutton .button:hover:first-child,
-.spinbutton .button:checked:first-child {
+spinbutton  button:first-child,
+spinbutton  button:hover:first-child,
+spinbutton  button:checked:first-child {
     border-radius: 3px 0 0 3px;
     border-image: none;
     padding: 6px 3px;
 }
 
-.spinbutton .button:last-child,
-.spinbutton .button:hover:last-child,
-.spinbutton .button:checked:last-child {
+spinbutton  button:last-child,
+spinbutton  button:hover:last-child,
+spinbutton  button:checked:last-child {
     border-radius: 0 3px 3px 0;
     border-image: none;
     padding: 6px 3px;
 }
 
-.spinbutton .button:first-child,
-.spinbutton .button:hover:first-child,
-.spinbutton .button:checked:first-child,
-.spinbutton .button:last-child,
-.spinbutton .button:hover:last-child,
-.spinbutton .button:checked:last-child {
+spinbutton  button:first-child,
+spinbutton  button:hover:first-child,
+spinbutton  button:checked:first-child,
+spinbutton  button:last-child,
+spinbutton  button:hover:last-child,
+spinbutton  button:checked:last-child {
     box-shadow: inset  0px  1px shade(@selected_bg_color, 1.05),
                 inset  1px  0px shade(@selected_bg_color, 0.97),
                 inset -1px  0px shade(@selected_bg_color, 0.93),
                 inset  0px -1px shade(@selected_bg_color, 0.93);
 }
 
-.spinbutton .button:dir(rtl) {
+spinbutton  button:dir(rtl) {
     box-shadow: inset -1px 0 @inset_dark_color;
 }
 
-.spinbutton.vertical .button {
+spinbutton.vertical  button {
     padding: 4px;
-    icon-shadow: 0 1px @button_text_shadow;
+    -gtk-icon-shadow: 0 1px @button_text_shadow;
 }
 
-.spinbutton.vertical .button,
-.spinbutton.vertical .button:hover {
+spinbutton.vertical  button,
+spinbutton.vertical  button:hover {
     color: @theme_fg_color;
 }
 
-.spinbutton.vertical .button:insensitive {
+spinbutton.vertical  button:disabled {
     color: @insensitive_fg_color;
 }
 
-.spinbutton.vertical .button:checked {
+spinbutton.vertical  button:checked {
     color: @theme_fg_color;
-    icon-shadow: 0 1px @button_active_text_shadow;
+    -gtk-icon-shadow: 0 1px @button_active_text_shadow;
 }
 
-/* :insensitive:insensitive to override the dark overriden style for
+/* :disabled:disabled to override the dark overriden style for
    normal spinbutton buttons, yeah we lack !important */
-.spinbutton.vertical .button:insensitive:insensitive {
-    icon-shadow: none;
+spinbutton.vertical  button:disabled:disabled {
+    -gtk-icon-shadow: none;
 }
 
 /* :active:active to override the dark overriden style for
    normal spinbutton buttons, yeah we lack !important */
-.spinbutton.vertical .button,
-.spinbutton.vertical .button:active:active,
-.spinbutton.vertical .button:checked:checked {
+spinbutton.vertical  button,
+spinbutton.vertical  button:active:active,
+spinbutton.vertical  button:checked:checked {
     box-shadow: none;
 }
 
-.spinbutton.vertical .button:first-child {
+spinbutton.vertical  button:first-child {
     padding: 6px 4px;
     border-image-width: 3px 3px 0 3px;
     border-width: 1px 1px 0 1px;
@@ -2988,18 +3001,18 @@ GtkActionBar .frame.action-bar .button.image-button {
                 inset  0px -1px alpha(shade(@button_border, 0.88), 0.90);
 }
 
-.spinbutton.vertical .button:hover:first-child,
-.spinbutton.vertical .button:checked:first-child {
+spinbutton.vertical  button:hover:first-child,
+spinbutton.vertical  button:checked:first-child {
     border-radius: 4px 4px 0px 0;
     border-image: none;
-    color: @internal_element_prelight;
+    color: @internal_element_hover;
     box-shadow: inset  0px  1px shade(@selected_bg_color, 1.05),
                 inset  1px  0px shade(@selected_bg_color, 0.97),
                 inset -1px  0px shade(@selected_bg_color, 0.93),
                 inset  0px -1px shade(@selected_bg_color, 0.93);
 }
 
-.spinbutton.vertical .button:last-child {
+spinbutton.vertical  button:last-child {
     padding: 6px 4px;
     border-image-width: 0 3px 4px 3px;
     border-width: 0px 1px 1px 1px;
@@ -3014,18 +3027,18 @@ GtkActionBar .frame.action-bar .button.image-button {
                 inset  0px -1px alpha(shade(@button_border, 0.88), 0.90);
 }
 
-.spinbutton.vertical .button:hover:last-child,
-.spinbutton.vertical .button:checked:last-child {
+spinbutton.vertical  button:hover:last-child,
+spinbutton.vertical  button:checked:last-child {
     border-radius: 0px 0px 4px 4px;
     border-image: none;
-    color: @internal_element_prelight;
+    color: @internal_element_hover;
     box-shadow: inset  0px  1px shade(@selected_bg_color, 1.05),
                 inset  1px  0px shade(@selected_bg_color, 0.97),
                 inset -1px  0px shade(@selected_bg_color, 0.93),
                 inset  0px -1px shade(@selected_bg_color, 0.93);
 }
 
-.spinbutton.vertical.entry {
+spinbutton.vertical entry {
     border-image: none;
     border-color: alpha(@borders, 0.1);
     border-width: 0 0px 0 0px;
@@ -3040,43 +3053,43 @@ GtkActionBar .frame.action-bar .button.image-button {
                 inset -1px  0px alpha(shade(@button_border, 0.94), 0.80);
 }
 
-.spinbutton.vertical.entry:insensitive {
+spinbutton.vertical entry:disabled {
     padding: 4px 1px 4px 1px;
     border-color: alpha(@borders, 0.1);
     box-shadow: inset 1px  0px alpha(@borders, 0.4),
                 inset -1px 0px alpha(@borders, 0.4);
 }
 
-.spinbutton.vertical.entry:focus {
+spinbutton.vertical entry:focus {
     border-color: alpha(@borders, 0.1);
     box-shadow: inset 1px 0 0 0 @theme_selected_bg_color,
                 inset -1px 0 0 0 @theme_selected_bg_color;
 }
 
 /* volume button */
-GtkGrid .button,
-GtkGrid .button.flat {
+grid button,
+grid button.flat {
     transition: all 600ms ease-out;
 }
 
-GtkGrid .button,
-GtkGrid .button.flat,
-GtkGrid .button:hover,
-GtkGrid .button:insensitive,
-GtkGrid .button.flat:hover,
-GtkGrid .button.flat:insensitive {
+grid button,
+grid button.flat,
+grid button:hover,
+grid button:disabled,
+grid button.flat:hover,
+grid button.flat:disabled {
     padding: 5px 4px;
     border-radius: 6px;
     border-color: transparent;
     background-color: transparent;
 }
 
-GtkFlowBox .grid-child {
+flowbox .grid-child {
     padding: 3px;
     border-radius: 3px;
 }
 
-GtkFlowBox .grid-child:selected {
+flowbox .grid-child:selected {
     outline-offset: -2px;
 }
 
@@ -3087,10 +3100,10 @@ GtkFlowBox .grid-child:selected {
   color: @link_color;
 }
 
-GtkLinkButton,
-GtkLinkButton:hover,
-GtkLinkButton.button.flat,
-GtkLinkButton.button.flat:hover {
+linkbutton,
+linkbutton:hover,
+linkbutton button.flat,
+linkbutton button.flat:hover {
      padding: 4px;
      border-color: transparent;
 }
@@ -3100,132 +3113,129 @@ GtkLinkButton.button.flat:hover {
  * tabs          *
  *****************/
 
-.notebook {
+notebook {
     padding: 0;
     background-clip: border-box;
     background-color: shade (@theme_bg_color, 1.1);
     border-style: solid;
     border-color: @notebook_border;
     border-width: 1px;
-    -GtkNotebook-initial-gap: 0;
+  /*  -GtkNotebook-initial-gap: 0;
     -GtkNotebook-arrow-spacing: 0;
     -GtkNotebook-tab-curvature: 0;
-    -GtkNotebook-tab-overlap: 1;
-    -GtkNotebook-has-tab-gap: false;
+    -GtkNotebook-has-tab-gap: false;*/
     /* FIXME, why this doesn't work? */
-	-GtkNotebook-arrow-scaling: 0.3;
-    -GtkWidget-focus-padding: 0;
-    -GtkWidget-focus-line-width: 0;
+	/*-GtkNotebook-arrow-scaling: 0.3; it's deprecated for sure */
 }
 
-.notebook :hover {
-    -gtk-image-effect: highlight;
+notebook:hover {
+    /*-gtk-image-effect: highlight; INVALID*/
     color: @theme_fg_color;
 }
 
-.notebook.frame.top {
+notebook.frame.top {
     border-top: 0px;
     border-radius: 0px 0px 4px 4px;
 }
 
-.notebook.frame.bottom {
+notebook.frame.bottom {
     border-bottom: 0px;
     border-radius: 4px 4px 0px 0px;
 }
 
-.notebook.frame.left {
+notebook.frame.left {
     border-left: 0px;
     border-radius: 0px 4px 4px 0px;
 }
 
-.notebook.frame.right {
+notebook.frame.right {
     border-right: 0px;
     border-radius: 4px 0px 0px 4px;
 }
 
-.notebook.header {
+notebook header {
     background-image: linear-gradient(to bottom,
                                       shade(@theme_bg_color, 0.86),
                                       shade(@theme_bg_color, 1.05));
     border-radius: 0px;
 }
 
-.notebook.header.top {
+notebook header.top {
     border-width: 0px 0px 1px 0px;
 }
 
-.notebook.header.bottom {
+notebook header.bottom {
     border-width: 1px 0px 0px 0px;
 }
 
-.notebook.header.left {
+notebook header.left {
     border-width: 1px 1px 0px 0px;
 }
 
-.notebook.header.right {
+notebook header.right {
     border-width: 0px 0px 0px 1px;
 }
 
 /* tabs in view areas, ie. pluma-, caja-tabs */
-GtkPaned.horizontal .notebook.header.top {
+paned.horizontal  notebook header.top {
     border-width: 0px;
 }
 
-.notebook.header.frame.top {
+notebook header.frame.top {
     border-radius: 4px 4px 0px 0px;
 }
 
-.notebook.header.frame.bottom {
+notebook header.frame.bottom {
     border-radius: 0px 0px 4px 4px;
 }
 
-.notebook.header.frame.left {
+notebook header.frame.left {
     border-radius: 4px 0px 0px 4px;
 }
 
-.notebook.header.frame.right {
+notebook header.frame.right {
     border-radius: 0px 4px 4px 0px;
 }
 
-.notebook tab {
+notebook tab {
+	border-style:solid; /*keep tabs from jumping on hover */
     border-color: transparent;
-    border-width: 0px;
+    border-width: 1px;
     background-image: none;
     background-color: transparent;
 }
 
-.notebook tab GtkLabel {
+notebook tab label {
     color: mix (@theme_fg_color, @theme_bg_color, 0.40);
     font-weight: normal;
 }
-
-.notebook .prelight-page,
-.notebook .prelight-page GtkLabel {
+notebook .hover-page,
+notebook .hover-page label {
     color: mix (@theme_fg_color, @theme_bg_color, 0.15);
 }
 
-.notebook .active-page,
-.notebook tab .active-page GtkLabel {
+notebook .active-page,
+notebook tab .active-page label {
     color: @theme_fg_color;
 }
 
 /* horizontal tabs */
 
-.notebook tab.top,
-.notebook tab.bottom {
+notebook header.top tab,
+notebook header.bottom tab{
     padding: 5px 20px 6px;
 }
 
-GtkPaned.horizontal .notebook tab.top {
+paned.horizontal  notebook header.top tab {
     padding: 5px 4px;
 }
 
-.notebook tab.top {
+notebook header.top tab {
     border-width: 1px 1px 0 1px;
 }
 
-.notebook tab.top:active,
-.notebook tab.top:active:hover {
+notebook header.top tab:active,
+notebook header.top tab:active:hover {
     background-image: linear-gradient(to bottom,
                                       shade(@theme_bg_color, 1.18),
                                       shade(@theme_bg_color, 1.1));
@@ -3236,7 +3246,7 @@ GtkPaned.horizontal .notebook tab.top {
     box-shadow: none;
 }
 
-.notebook tab.top:hover {
+notebook header.top tab:hover {
     background-image: linear-gradient(to bottom,
                                       alpha(@theme_base_color, 0.0),
                                       alpha(@theme_base_color, 0.3));
@@ -3247,12 +3257,12 @@ GtkPaned.horizontal .notebook tab.top {
     box-shadow: none;
 }
 
-.notebook tab.top:active {
+notebook header.top tab:active {
     border-bottom-color: @notebook_active_tab_border;
 }
 
-.notebook tab.bottom:active,
-.notebook tab.bottom:hover:active {
+notebook header.bottom tab:active,
+notebook header.bottom tab:hover:active {
     background-image: linear-gradient(to top,
                                       shade(@theme_bg_color, 1.18),
                                       shade(@theme_bg_color, 1.1));
@@ -3263,7 +3273,7 @@ GtkPaned.horizontal .notebook tab.top {
     box-shadow: none;
 }
 
-.notebook tab.bottom:hover {
+notebook header.bottom tab:hover {
     background-image: linear-gradient(to top,
                                       alpha(@theme_base_color, 0.0),
                                       alpha(@theme_base_color, 0.3));
@@ -3276,13 +3286,13 @@ GtkPaned.horizontal .notebook tab.top {
 
 /* vertical tabs */
 
-.notebook tab.left,
-.notebook tab.right {
+notebook header.left tab,
+notebook header.right tab{
     padding: 5px 20px;
 }
 
-.notebook tab.left:active,
-.notebook tab.left:hover:active {
+notebook header.left tab:active,
+notebook header.left tab:hover:active {
     background-image: linear-gradient(to right,
                                       shade(@theme_bg_color, 1.18),
                                       shade(@theme_bg_color, 1.1));
@@ -3292,7 +3302,7 @@ GtkPaned.horizontal .notebook tab.top {
     border-radius: 4px 0px 0px 4px;
 }
 
-.notebook tab.left:hover {
+notebook header.left tab:hover {
     background-image: linear-gradient(to right,
                                       alpha(@theme_base_color, 0.0),
                                       alpha(@theme_base_color, 0.3));
@@ -3301,9 +3311,9 @@ GtkPaned.horizontal .notebook tab.top {
     border-color: @notebook_border;
     border-radius: 4px 0px 0px 4px;
 }
-
-.notebook tab.right:active,
-.notebook tab.right:hover:active {
+ 
+notebook header.right tab:active,
+notebook header.right tab:hover:active {
     background-image: linear-gradient(to left,
                                       shade(@theme_bg_color, 1.18),
                                       shade(@theme_bg_color, 1.1));
@@ -3313,7 +3323,7 @@ GtkPaned.horizontal .notebook tab.top {
     border-radius: 0px 4px 4px 0px;
 }
 
-.notebook tab.right:hover {
+notebook header.right tab:hover {
     background-image: linear-gradient(to left,
                                       alpha(@theme_base_color, 0.0),
                                       alpha(@theme_base_color, 0.3));
@@ -3323,7 +3333,7 @@ GtkPaned.horizontal .notebook tab.top {
     border-radius: 0px 4px 4px 0px;
 }
 
-.notebook tab.reorderable-page:hover {
+notebook tab.reorderable-page:hover {
     background-image: linear-gradient(to bottom,
                                       alpha(@theme_base_color, 0.0),
                                       alpha(@theme_base_color, 0.3));
@@ -3332,7 +3342,7 @@ GtkPaned.horizontal .notebook tab.top {
     border-style: none;
 }
 
-.notebook tab.reorderable-page:active {
+notebook tab.reorderable-page:active {
     background-image: linear-gradient(to bottom,
                                       shade(@theme_bg_color, 1.18),
                                       shade(@theme_bg_color, 1.1));
@@ -3343,7 +3353,7 @@ GtkPaned.horizontal .notebook tab.top {
 
 /* close button styling */
 
-.notebook tab .button {
+notebook tab  button {
     color: mix (@theme_fg_color, @theme_bg_color, 0.85);
     border-image: none;
     background-image: none;
@@ -3353,28 +3363,28 @@ GtkPaned.horizontal .notebook tab.top {
     border-color: transparent;
     border-width: 1px;
     padding: 1px;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
 }
 
-.notebook .prelight-page .button,
-.notebook tab.prelight-page .button,
-.notebook .active-page .button,
-.notebook tab.active-page .button {
+notebook .hover-page  button,
+notebook tab.hover-page  button,
+notebook .active-page  button,
+notebook tab.active-page  button {
 	color: mix(@theme_fg_color, @theme_base_color, 0.6);
-	icon-shadow: 0 1px @button_text_shadow;
+	-gtk-icon-shadow: 0 1px @button_text_shadow;
 }
 
-.notebook tab .button:hover {
+notebook tab  button:hover {
 	color: @theme_fg_color;
 	border-color: alpha(black, 0.1);
 }
 
-.notebook tab .button:active,
-.notebook tab .button:hover:active {
+notebook tab  button:active,
+notebook tab  button:hover:active {
 	color:  @button_active_text;
 	background-color: alpha(black, 0.08);
 	box-shadow: inset 0 1px alpha(black, 0.05);
-	icon-shadow: 0 1px @button_active_text_shadow;
+	-gtk-icon-shadow: 0 1px @button_active_text_shadow;
 
 	border-color: alpha(black, 0.27)
 		alpha(black, 0.13)
@@ -3382,53 +3392,54 @@ GtkPaned.horizontal .notebook tab.top {
 		alpha(black, 0.13);
 }
 
-.notebook.arrow {
+notebook arrow {
     color: @theme_fg_color;
 }
 
-.notebook.arrow:hover,
-.notebook.arrow:active {
+notebook arrow:hover,
+notebook arrow:active {
     color: @theme_selected_bg_color;
 }
 
-.notebook.arrow:insensitive {
+notebook arrow:disabled {
     color: rgba(141, 144, 145, 0.3);
 }
 
-.notebook.arrow:backdrop {
+notebook arrow:backdrop {
     color: rgba(84, 89, 90, 0.4);
 }
 
-.notebook.arrow:backdrop:insensitive {
+notebook arrow:backdrop:disabled {
     color: #c7c7c7;
 }
 
 /*************************
  * Check and Radio items *
  *************************/
-
+check, 
+radio,
 .check,
 .radio,
-.check:insensitive,
-.radio:insensitive {
+.check:disabled,
+.radio:disabled {
     background-color: transparent;
     border-style: none;
 }
 
-GtkCheckButton,
-GtkCheckButton:hover,
-GtkCheckButton:focus,
-GtkCheckButton:focus:hover,
-GtkCheckButton:focus:hover:active,
-GtkCheckButton:checked,
-GtkCheckButton:checked:hover,
-GtkCheckButton:checked:focus,
-GtkCheckButton:checked:focus:hover,
-GtkCheckButton:checked:focus:hover:active {
+checkbutton,
+checkbutton:hover,
+checkbutton:focus,
+checkbutton:focus:hover,
+checkbutton:focus:hover:active,
+checkbutton:checked,
+checkbutton:checked:hover,
+checkbutton:checked:focus,
+checkbutton:checked:focus:hover,
+checkbutton:checked:focus:hover:active {
     background-color: transparent;
 }
 
-GtkCheckButton.text-button, GtkRadioButton.text-button {
+checkbutton.text-button, GtkRadioButton.text-button {
   padding: 1px;
   outline-offset: 0; }
 
@@ -3436,7 +3447,7 @@ GtkCheckButton.text-button, GtkRadioButton.text-button {
  * Header bars *
  ***************/
 
-.header-bar {
+headerbar {
     border-width: 0 0 1px;
     border-style: solid;
     border-color: shade(@borders, 0.90);
@@ -3446,7 +3457,7 @@ GtkCheckButton.text-button, GtkRadioButton.text-button {
     padding: 6px 6px 5px 6px;
 }
 
-.header-bar:backdrop {
+headerbar:backdrop {
     border-image: linear-gradient(to top,
                                   @unfocused_borders,
                                   @unfocused_borders 1px,
@@ -3455,19 +3466,19 @@ GtkCheckButton.text-button, GtkRadioButton.text-button {
     background-color: @theme_bg_dark_color;
 }
 
-.header-bar .button,
-.header-bar .button:last-child,
-.header-bar .button:first-child,
-.header-bar .button:only-child {
+headerbar  button,
+headerbar  button:last-child,
+headerbar  button:first-child,
+headerbar  button:only-child {
     background-image: none;
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     color: @theme_fg_dark_color;
     border-width: 1px;
     border-radius: 5px;
 }
 
-.header-bar:backdrop .button {
+headerbar:backdrop  button {
     border-width: 1px;
     border-radius: 5px;
     padding-left:  4px;
@@ -3479,21 +3490,21 @@ GtkCheckButton.text-button, GtkRadioButton.text-button {
                                      to   (shade(@theme_unfocused_bg_color, 0.85)));
 }
 
-.header-bar .button:hover:first-child,
-.header-bar .button:checked:first-child,
-.header-bar .button:hover:active:first-child,
-.header-bar .button:checked:hover:first-child,
-.header-bar .button:checked:hover:active:first-child,
-.header-bar .button:hover:last-child,
-.header-bar .button:checked:last-child,
-.header-bar .button:hover:active:last-child,
-.header-bar .button:checked:hover:last-child,
-.header-bar .button:checked:hover:active:last-child,
-.header-bar .button:hover:only-child,
-.header-bar .button:checked:only-child,
-.header-bar .button:hover:active:last-child,
-.header-bar .button:checked:hover:only-child,
-.header-bar .button:checked:hover:active:only-child {
+headerbar  button:hover:first-child,
+headerbar  button:checked:first-child,
+headerbar  button:hover:active:first-child,
+headerbar  button:checked:hover:first-child,
+headerbar  button:checked:hover:active:first-child,
+headerbar  button:hover:last-child,
+headerbar  button:checked:last-child,
+headerbar  button:hover:active:last-child,
+headerbar  button:checked:hover:last-child,
+headerbar  button:checked:hover:active:last-child,
+headerbar  button:hover:only-child,
+headerbar  button:checked:only-child,
+headerbar  button:hover:active:last-child,
+headerbar  button:checked:hover:only-child,
+headerbar  button:checked:hover:active:only-child {
     border-width: 1px;
     border-radius: 5px;
     background-image: -gtk-gradient (linear,
@@ -3510,61 +3521,61 @@ GtkCheckButton.text-button, GtkRadioButton.text-button {
                 inset  0px -1px shade(@selected_bg_color, 0.93);
 }
 
-.header-bar .button:insensitive,
-.header-bar .button:insensitive:last-child,
-.header-bar .button:insensitive:first-child {
+headerbar  button:disabled,
+headerbar  button:disabled:last-child,
+headerbar  button:disabled:first-child {
     color: @theme_text_dark_color;
     background-image: none;
     background-color: @theme_bg_dark_color;
     border-color: @theme_button_border_dark;
     box-shadow: none;
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
 }
 
-.header-bar .button *:insensitive {
+headerbar  button *:disabled {
     background-color: transparent;
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
 }
 
-.header-bar .button.text-button {
+headerbar  button.text-button {
     padding: 2px 6px;
 }
  
-.header-bar .button.image-button {
+headerbar  button.image-button {
     padding: 5px 5px 6px 5px;
 }
  
-.header-bar .title {
+headerbar .title {
     font: Bold 11;
     color: @theme_text_dark_color;
 }
  
-.header-bar .subtitle {
+headerbar .subtitle {
     font: 9;
     color: @theme_text_dark_color;
 }
 
-.header-bar GtkSeparatorToolItem,
-.header-bar .separator,
-.header-bar .separator:insensitive,
-.header-bar .pane-separator {
+headerbar GtkSeparatorToolItem,
+headerbar .separator,
+headerbar .separator:disabled,
+headerbar .pane-separator {
     border-color: alpha (shade(@theme_bg_dark_color, 0.2), 0.24);
     border-bottom-color: @theme_bg_dark_color;
     border-right-color: @theme_bg_dark_color;
 }
 
 /****************
- * GtkAssistant *
+ * assistant *
  ****************/
 
-GtkAssistant .sidebar .highlight {
+assistant .sidebar .highlight {
     color: @theme_text_color;
     font: bold;
 }
 
-GtkAssistant .sidebar {
+assistant .sidebar {
     padding: 5px;
     background-color: shade (@theme_bg_color, 0.97);
     border-width: 0px 1px 0px 0px;
@@ -3578,9 +3589,9 @@ GtkAssistant .sidebar {
  * Switch *
  **********/
 
-GtkSwitch {
+switch {
     padding: 8px; /* 8px to avoid padding list-row issue if active */
-    -GtkSwitch-slider-width: 45px;
+    -switch-slider-width: 45px;
     font-weight: bold;
     font-size: smaller;
     box-shadow: inset  0px  2px alpha(#fff, 0.11),
@@ -3593,8 +3604,8 @@ GtkSwitch {
                 inset  0px -1px alpha(shade(@button_border, 0.88), 0.90);
 }
 
-GtkSwitch.trough,
-GtkSwitch.trough:backdrop {
+switch trough,
+switch trough:backdrop {
     border: 1px solid ;
     border-radius: 6px;
     color: @theme_fg_color;
@@ -3616,16 +3627,16 @@ GtkSwitch.trough:backdrop {
     text-shadow: 0 1px rgba(0, 0, 0, 0.1);
 }
 
-GtkSwitch.trough:active,
-GtkSwitch.trough:backdrop:active {
+switch trough:active,
+switch trough:backdrop:active {
     background-image: linear-gradient(to bottom,
                                       @theme_selected_bg_color 2px,
                                       shade(@theme_selected_bg_color, 1.2));
     color: white;
 }
 
-GtkSwitch.trough:insensitive,
-GtkSwitch.trough:backdrop:insensitive {
+switch trough:disabled,
+switch trough:backdrop:disabled {
     color: @insensitive_fg_color;
     border-color: @insensitive_border_color;
     background-image: none;
@@ -3637,8 +3648,8 @@ GtkSwitch.trough:backdrop:insensitive {
     text-shadow: none;
 }
 
-GtkSwitch.slider,
-GtkSwitch.slider:backdrop {
+switch slider,
+switch slider:backdrop {
     border: 1px solid;
     border-radius: 6px;
     color: @theme_fg_color;
@@ -3663,8 +3674,8 @@ GtkSwitch.slider:backdrop {
     padding: 2px 4px 2px 2px;
 }
 
-GtkSwitch.slider:active,
-GtkSwitch.slider:backdrop:active {
+switch slider:active,
+switch slider:backdrop:active {
     color: @theme_fg_color;
     border-color: transparent;
     border-radius: 6px;
@@ -3681,8 +3692,8 @@ GtkSwitch.slider:backdrop:active {
     padding: 1px 3px 1px 1px;
 }
 
-GtkSwitch.slider:insensitive,
-GtkSwitch.slider:backdrop:insensitive {
+switch slider:disabled,
+switch slider:backdrop:disabled {
     background-image: none;
     background-color: @insensitive_bg_color;
     border-color: alpha (#000, 0.00);
@@ -3694,29 +3705,29 @@ GtkSwitch.slider:backdrop:insensitive {
                 inset  0px -1px @insensitive_border_color;
 }
 
-GtkSwitch.slider:insensitive > GtkLabel,
-GtkSwitch.slider:backdrop:insensitive > GtkLabel {
+switch slider:disabled > label,
+switch slider:backdrop:disabled > label {
     color: inherit;
 }
 
-.list-row GtkSwitch,
-.list-row GtkSwitch:backdrop,
-.list-row:selected GtkSwitch,
-.list-row:selected GtkSwitch:backdrop {
+list-row switch,
+list-row switch:backdrop,
+list-row:selected switch,
+list-row:selected switch:backdrop {
     box-shadow: none;
     border-color: shade(@theme_selected_bg_color, 0.4);
 }
 
-.list-row:selected GtkSwitch.slider:dir(rtl) {
+list-row:selected switch slider:dir(rtl) {
     border-left-color: @borders;
 }
 
-.list-row:selected GtkSwitch.slider:dir(ltr) {
+ list-row:selected switch slider:dir(ltr) {
     border-right-color: @borders;
 }
 
-.list-row:selected GtkSwitch.slider,
-.list-row:selected GtkSwitch.slider:active {
+ list-row:selected switch slider,
+ list-row:selected switch slider:active {
     border-color: shade(@theme_selected_bg_color, 0.4);
 }
 
@@ -3724,8 +3735,8 @@ GtkSwitch.slider:backdrop:insensitive > GtkLabel {
  * image *
  *********/
 
-GtkImage,
-GtkImage:insensitive {
+image,
+image:disabled {
     background-color: transparent;
 }
 
@@ -3737,14 +3748,14 @@ GtkImage:insensitive {
  * viewport *
  ************/
 
-GtkViewport {
+viewport {
     border-width: 0px;
     border-style: none;
     /* Background color and system config gnome-tweak-tools */
     background-color: shade(@theme_bg_color, 1.00);
 }
 
-GtkViewport.frame {
+viewport.frame {
     border-width: 0px;
     border-style: none;
     padding: 0px;
@@ -3754,31 +3765,31 @@ GdMainIconView.content-view {
     -GdMainIconView-icon-size: 40;
 }
 
-GtkIconView.content-view.check {
+iconview.content-view.check {
     background-image: url("assets/grid-selection-unchecked.svg");
     background-color: transparent;
 }
 
-GtkIconView.content-view.check:active {
+iconview.content-view.check:active {
     background-image: url("assets/grid-selection-checked.svg");
     background-color: transparent;
 }
 
-GtkIconView,
-GtkViewport {
+iconview,
+viewport {
     /* avoid resizing theme thumbnails in mate-appearance-properties */
     padding: 0px;
 }
 
-GtkIconView {
+iconview {
     border-width: 0px;
     border-style: none;
     /* background view mate-appearance-properties */
     background-color: @base_color;
 }
 
-GtkIconView.view.cell:selected,
-GtkIconView.view.cell:selected:focus {
+iconview.view.cell:selected,
+iconview.view.cell:selected:focus {
     /* eg. Configuration center */
     background-color: alpha(@theme_selected_bg_color, 0.90);    
     background-image: -gtk-gradient (linear,
@@ -3799,26 +3810,39 @@ GtkIconView.view.cell:selected:focus {
                 inset  1px  0px alpha(#fff, 0.07),
                 inset -1px  0px alpha(#fff, 0.07),
                 inset  0px -1px alpha(#fff, 0.06);
-    -GtkWidget-focus-line-width: 0;
     text-shadow: 0px 1px @theme_selected_shadow_color;
 }
 
-GtkIconView.view.cell:hover,
-GtkIconView.view.cell:hover:focus {
+iconview.view.cell:hover,
+iconview.view.cell:hover:focus {
     background-color: alpha(@theme_selected_bg_color, 0.10);
     border-style: none;
     border-radius: 4px;
 }
 
-.view {
+view,
+.view, 
+view text,
+.view text,
+iconview text,
+textview text{
     background-color: @theme_base_color;
     color: @theme_fg_color;
     text-shadow: 0px 1px @theme_shadow_color;
 }
 
+
+
+view,
+view:selected,
+view:selected:focus, 
 .view:selected,
-.view:selected:focus {
-    background-color: shade(@theme_selected_bg_color, 1.10);
+.view:selected:focus, 
+view text selection,
+.view text selection,
+view text selection:focus,
+.view text selection:focus{
+    background-color: shade(@theme_selected_bg_color, 1.10); 
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade(@theme_selected_bg_color, 1.0)),
@@ -3827,26 +3851,27 @@ GtkIconView.view.cell:hover:focus {
     text-shadow: 0px 1px @theme_selected_shadow_color;
     text-shadow: none;
 }
-
+.view text selection:focus,
 .view:selected:focus {
     text-shadow: 0px 1px @theme_selected_shadow_color;
 }
 
-GtkTreeView {
-    -GtkWidget-focus-line-width: 0;
-    -GtkWidget-focus-padding: 1;
+treeview {
 }
 
-GtkTreeView.dnd {
+treeview.dnd {
     border-color: @internal_element_color;
     border-radius: 2px;
     border-width: 1px;
     border-style: solid;
 }
 
-GtkTreeView row:nth-child(odd):selected:hover,
-GtkTreeView row:nth-child(even):selected:hover,
-.notebook GtkContainer GtkTreeView row:selected {
+
+treeview:selected:hover,
+/*does not work in recent GTK versions
+treeview row:nth-child(odd):selected:hover,
+treeview row:nth-child(even):selected:hover,*/
+notebook container treeview:selected {
     background-image: -gtk-gradient (linear,
                                      left top,
                                      left bottom,
@@ -3856,16 +3881,18 @@ GtkTreeView row:nth-child(even):selected:hover,
     color:  @theme_selected_fg_color;
 }
 
-GtkTreeView.view row,
-GtkTreeView.view row:focus {
+treeview.view,
+treeview.view:focus {
     background-color: @theme_base_color;
     border-style: none;
 }
 
 .view row:hover,
-GtkTreeView row:nth-child(odd):hover,
-GtkTreeView row:nth-child(even):hover,
-.notebook GtkContainer GtkTreeView row:hover {
+/*does not work in recent GTK versions
+treeview row:nth-child(odd):hover,
+treeview row:nth-child(even):hover,*/
+treeview:hover,
+notebook container treeview:hover {
     background-image: -gtk-gradient (linear,
                                     left top,
                                     left bottom,
@@ -3876,14 +3903,18 @@ GtkTreeView row:nth-child(even):hover,
     text-shadow: none;
 }
 
+/*Keep treeviews from jumping, separators drawn at 0 by default until hovered*/
+treeview.view.separator {
+    min-height: 2px; 
+}
+
 column-header {
     padding: 0px 2px;
 }
 
-column-header .button,
-column-header .button:focus {
+column-header  button,
+column-header  button:focus {
     padding: 0px 4px 1px;
-    -GtkWidget-focus-line-width: 0; 
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade(@button_base, 1.00)),
@@ -3904,7 +3935,7 @@ column-header .button:focus {
                 inset  0px -1px alpha(#fff, 0.05);
 }
 
-column-header .button:hover {
+column-header  button:hover {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade(@button_gradient1, 1.03)),
@@ -3924,7 +3955,7 @@ column-header .button:hover {
                 inset  0px -1px shade(@selected_bg_color, 0.93);
 }
 
-column-header .button:focus:hover:active {
+column-header  button:focus:hover:active {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade (@theme_bg_color, 1.20)),
@@ -3935,7 +3966,7 @@ column-header .button:focus:hover:active {
     box-shadow: none;
 }
 
-column-header .button:insensitive {
+column-header  button:disabled {
     background-image: none;
     background-color: @insensitive_bg_color;
     border-color: @insensitive_border_color;
@@ -3943,15 +3974,15 @@ column-header .button:insensitive {
     box-shadow: none;
 }
 
-column-header .button GtkArrow {
+column-header  button GtkArrow {
     color: @internal_element_color;
 }
 
-column-header:nth-child(last) .button {
+column-header:nth-child(last)  button {
     border-width: 0px 0px 1px 0px;
 }
 
-row:insensitive {
+row:disabled {
     border-width: 0px;
 }
 
@@ -4004,14 +4035,14 @@ row:selected:focus:backdrop {
     background-image: none;
 }
 
-.app-notification .button,
-.app-notification .header-bar .button.titlebutton,
-.header-bar .app-notification .button.titlebutton,
-.app-notification .titlebar .button.titlebutton,
-.titlebar .app-notification .button.titlebutton,
-.app-notification GtkCalendar.header .button.titlebutton,
-GtkCalendar.header .app-notification .button.titlebutton,
-.app-notification.frame .button {
+.app-notification  button,
+.app-notification  headerbar  button.titlebutton,
+ headerbar .app-notification  button.titlebutton,
+.app-notification .titlebar  button.titlebutton,
+.titlebar .app-notification  button.titlebutton,
+.app-notification calendar.header  button.titlebutton,
+calendar.header .app-notification  button.titlebutton,
+.app-notification.frame  button {
     color: @theme_dark_fg_color;
     border-color: rgba(114, 180, 157, 0.7);
     background-image: linear-gradient(to bottom,
@@ -4019,32 +4050,32 @@ GtkCalendar.header .app-notification .button.titlebutton,
     background-clip: padding-box;
     box-shadow: inset 0 1px rgba(255, 255, 255, 0.1);
     text-shadow: none;
-    icon-shadow: 0 1px black;
+    -gtk-icon-shadow: 0 1px black;
     outline-color: rgba(238, 238, 236, 0.3);
     border-radius: 3px;
     padding: 0 0px 2px 0px;
 }
 
-.app-notification .button.flat,
-.app-notification .header-bar .titlebutton.button,
-.header-bar .app-notification .titlebutton.button,
-.app-notification .titlebar .titlebutton.button,
-.titlebar .app-notification .titlebutton.button,
-.app-notification GtkCalendar.header .titlebutton.button,
-GtkCalendar.header .app-notification .titlebutton.button,
-.app-notification.frame .button.flat,
-.app-notification.frame .header-bar .titlebutton.button,
-.header-bar .app-notification.frame .titlebutton.button,
-.app-notification.frame .titlebar .titlebutton.button,
-.titlebar .app-notification.frame .titlebutton.button,
-.app-notification.frame GtkCalendar.header .titlebutton.button,
-GtkCalendar.header .app-notification.frame .titlebutton.button {
-    icon-shadow: 0 1px black;
+.app-notification  button.flat,
+.app-notification  headerbar .titlebutton button,
+ headerbar .app-notification .titlebutton button,
+.app-notification .titlebar .titlebutton button,
+.titlebar .app-notification .titlebutton button,
+.app-notification calendar.header .titlebutton button,
+calendar.header .app-notification .titlebutton button,
+.app-notification.frame  button.flat,
+.app-notification.frame  headerbar .titlebutton button,
+ headerbar .app-notification.frame .titlebutton button,
+.app-notification.frame .titlebar .titlebutton button,
+.titlebar .app-notification.frame .titlebutton button,
+.app-notification.frame calendar.header .titlebutton button,
+calendar.header .app-notification.frame .titlebutton button {
+    -gtk-icon-shadow: 0 1px black;
     text-shadow: 0 1px black;
 }
 
-.app-notification .button:hover,
-.app-notification.frame .button:hover {
+.app-notification  button:hover,
+.app-notification.frame  button:hover {
     color: black;
     border-color: rgba(0, 0, 0, 0.7);
     background-image: linear-gradient(to bottom,
@@ -4052,16 +4083,16 @@ GtkCalendar.header .app-notification.frame .titlebutton.button {
     background-clip: padding-box;
     box-shadow: inset 0 1px rgba(255, 255, 255, 0.1);
     text-shadow: none;
-    icon-shadow: 0 1px black;
+    -gtk-icon-shadow: 0 1px black;
     outline-color: rgba(238, 238, 236, 0.3);
     border-radius: 3px;
     padding: 0 0px 2px 0px;
 }
 
-.app-notification .button:checked,
-.app-notification .button:backdrop:checked,
-.app-notification.frame .button:checked,
-.app-notification.frame .button:backdrop:active {
+.app-notification  button:checked,
+.app-notification  button:backdrop:checked,
+.app-notification.frame  button:checked,
+.app-notification.frame  button:backdrop:active {
     color: white;
     border-color: rgba(0, 0, 0, 0.7);
     background-image: linear-gradient(to bottom,
@@ -4069,15 +4100,15 @@ GtkCalendar.header .app-notification.frame .titlebutton.button {
     background-clip: padding-box;
     box-shadow: none;
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     outline-color: rgba(238, 238, 236, 0.3);
     border-radius: 3px;
 }
 
-.app-notification .button:insensitive,
-.app-notification .button:backdrop:insensitive,
-.app-notification.frame .button:insensitive,
-.app-notification.frame .button:backdrop:insensitive {
+.app-notification  button:disabled,
+.app-notification  button:backdrop:disabled,
+.app-notification.frame  button:disabled,
+.app-notification.frame  button:backdrop:disabled {
     color: #878989;
     border-color: rgba(0, 0, 0, 0.7);
     background-image: linear-gradient(to bottom,
@@ -4085,13 +4116,13 @@ GtkCalendar.header .app-notification.frame .titlebutton.button {
     background-clip: padding-box;
     box-shadow: none;
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     border-radius: 3px;
     padding: 0px;
 }
 
-.app-notification .button:backdrop,
-.app-notification.frame .button:backdrop {
+.app-notification  button:backdrop,
+.app-notification.frame  button:backdrop {
     color: #eeeeec;
     border-color: rgba(0, 0, 0, 0.7);
     background-image: linear-gradient(to bottom,
@@ -4099,7 +4130,7 @@ GtkCalendar.header .app-notification.frame .titlebutton.button {
     background-clip: padding-box;
     box-shadow: none;
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     border-radius: 3px;
     padding: 0px;
 }
@@ -4108,67 +4139,73 @@ GtkCalendar.header .app-notification.frame .titlebutton.button {
  * Expanders *
  *************/
 
-GtkTreeView.view.expander {
+treeview.view.expander {
     -gtk-icon-source: -gtk-icontheme("pan-end-symbolic");
     color: @theme_fg_color;
 }
 
- GtkTreeView.view.expander:dir(rtl) {
+treeview.view.expander:dir(rtl) {
      -gtk-icon-source: -gtk-icontheme("pan-end-symbolic-rtl");
 }
 
-GtkTreeView.view.expander:checked {
+treeview.view.expander:checked {
     -gtk-icon-source: -gtk-icontheme("pan-down-symbolic");
  }
 
-GtkTreeView.view.expander:hover {
+treeview.view.expander:hover {
     color: @theme_selected_bg_color;
 }
 
-GtkTreeView.view.expander:selected,
-GtkTreeView.view.expander:selected:hover {
+treeview.view.expander:selected,
+treeview.view.expander:selected:hover {
     color: @theme_selected_fg_color;
 }
 
-GtkExpander {
+expander arrow{
     -gtk-icon-source: -gtk-icontheme("pan-end-symbolic");
 }
 
-GtkExpander:dir(rtl) {
+
+expander arrow:dir(rtl) {
     -gtk-icon-source: -gtk-icontheme("pan-end-symbolic-rtl");
 }
 
-GtkExpander:hover {
+expander arrow:hover {
     color: @internal_element_color;
 }
 
-GtkExpander:checked {
+expander arrow:checked {
     -gtk-icon-source: -gtk-icontheme("pan-down-symbolic");
 }
 
 /* why this weird padding, possible issue with gtk+-3.18 ? */
-GtkExpander {
-    -GtkExpander-expander-size: 14;
+expander {
+    -expander-expander-size: 14;
     padding: 0px 4px 0px 0px;
 }
 
+expander,
 .expander {
     color: @theme_fg_color;
     border-color: @theme_fg_color;
 }
 
+expander:checked,
 .expander:checked {
     color: @theme_selected_bg_color;
     border-color: @theme_selected_bg_color;
 }
 
+expander:hover,
 .expander:hover {
     color: @internal_element_color;
     border-color: @internal_element_color;
 }
 
-.expander row:selected,
-.expander row:selected:focus {
+expander title:selected,
+expander title:selected:focus,
+.expander title:selected,
+.expander title:selected:focus {
     border-style: solid;
     border-width: 1px;
     border-color: @expander_row_selected_color;
@@ -4176,8 +4213,10 @@ GtkExpander {
     background-color: @theme_selected_bg_color;
 }
 
-.expander row:selected:hover,
-.expander row:selected:focus:hover {
+expander title:selected:hover,
+expander title:selected:focus:hover,
+.expander title:selected:hover,
+.expander title:selected:focus:hover {
     color: @theme_selected_fg_color;
     border-color: @theme_selected_fg_color;
 }
@@ -4186,23 +4225,23 @@ GtkExpander {
  * List boxes *
  **************/
 
-.list {
+list {
     background-color: @list_box_bg;
 }
 
-.list .separator.horizontal {
+list .separator.horizontal {
     background-color: @theme_base_color;
     border-width: 0px;
 }
 
-.list-row {
+list-row {
     padding: 2px;
     transition: all 200ms ease-in;
     background-image: none;
     background-color: @theme_base_color;
 }
 
-.list-row:hover {
+list-row:hover {
     border-color: shade (@theme_selected_bg_color, 1.6);
     background-image: -gtk-gradient (linear,
                                      left top,
@@ -4215,15 +4254,15 @@ GtkExpander {
                 inset -1px  0px shade(@selected_bg_color, 0.93),
                 inset  0px -1px shade(@selected_bg_color, 0.93);
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     border-image: none;
     border-radius: 6px;
     border-style: solid;
 }
 
-.list-row:selected,
-.list-row:selected:hover,
-.list-row:selected:hover:active {
+list-row:selected,
+list-row:selected:hover,
+list-row:selected:hover:active {
     border-width: 0;
     border-radius: 0px;
     border-style: none;
@@ -4235,8 +4274,8 @@ GtkExpander {
     color: @theme_selected_fg_color;
 }
 
-.list-row:selected:backdrop,
-.list-row:selected:backdrop:hover {
+list-row:selected:backdrop,
+list-row:selected:backdrop:hover {
     border-width: 0;
     border-style: solid;
     border-color: shade (@theme_bg_color, 0.85);
@@ -4252,20 +4291,20 @@ GtkExpander {
  * Calendar   *
  **************/
 
-GtkCalendar {
+calendar {
     border-radius: 3px;
     border-color: shade (@theme_fg_color, 0.8);
     padding: 1px 1px 3px 1px;
 }
 
-GtkCalendar.view {
+calendar.view {
     border-radius: 3px;
     border-style: solid;
     border-width: 1px;
     padding: 2px;
 }
 
-GtkCalendar.header {
+calendar.header {
     border-radius: 3px 3px 0px 0px;
     background-image: linear-gradient(to bottom,
                                       shade(@theme_bg_color, 1.04),
@@ -4273,10 +4312,10 @@ GtkCalendar.header {
     border-width: 0;
 }
 
-GtkCalendar.expander,
-GtkCalendar.button,
-GtkCalendar.button.flat,
-GtkCalendar.button:insensitive {
+calendar.expander,
+calendar button,
+calendar button.flat,
+calendar button:disabled {
     border-color: transparent;
     background-image: none;
     background-color: transparent;
@@ -4285,15 +4324,15 @@ GtkCalendar.button:insensitive {
 }
 
 /* disable shadows and button background on arrows */
-GtkCalendar.button:first-child,
-GtkCalendar.button:last-child {
+calendar button:first-child,
+calendar button:last-child {
     box-shadow: none;
     background-image: none;
 }
 
 /* disable button background on arrows */
-GtkCalendar.button:hover:first-child,
-GtkCalendar.button:hover:last-child {
+calendar button:hover:first-child,
+calendar button:hover:last-child {
     background-image: none;
     border-radius: 3px;
     box-shadow: inset  0px  1px shade(@selected_bg_color, 1.05),
@@ -4303,7 +4342,7 @@ GtkCalendar.button:hover:last-child {
 }
 
 .highlight,
-GtkCalendar.highlight {
+calendar.highlight {
     background-color: @theme_selected_bg_color;
     color: @theme_selected_fg_color;
     border-radius: 0px;
@@ -4312,10 +4351,10 @@ GtkCalendar.highlight {
     border-color: transparent;
 }
 
-.menuitem GtkCalendar,
-.menuitem GtkCalendar.button,
-.menuitem GtkCalendar.header,
-.menuitem GtkCalendar.view {
+menuitem calendar,
+menuitem calendar button,
+menuitem calendar.header,
+menuitem calendar.view {
     background-color: shade(@theme_bg_dark_color, 0.82);
     background-image: none;
     border-radius: 0px;
@@ -4325,7 +4364,7 @@ GtkCalendar.highlight {
     color: @theme_base_color;
 }
 
-.menuitem GtkCalendar {
+menuitem calendar {
     background-color: shade (@menu_bg_color, 1.3);
     background-image: none;
 }
@@ -4334,7 +4373,7 @@ GtkCalendar.highlight {
  * GtkInfoBar *
  **************/
 
-GtkInfoBar {
+infobar {
     border-width: 0;
     border-style: none;
 }
@@ -4353,54 +4392,54 @@ GtkInfoBar {
     color: @warning_fg_color;
 }
 
-.info .button.close,
-.warning .button.close,
-.question .button.close,
-.error .button.close {
+.info  button.close,
+.warning  button.close,
+.question  button.close,
+.error  button.close {
     color: @theme_fg_color;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
 }
 
-.info .button.close:hover,
-.warning .button.close:hover,
-.question .button.close:hover,
-.error .button.close:hover {
+.info  button.close:hover,
+.warning  button.close:hover,
+.question  button.close:hover,
+.error  button.close:hover {
     background-image: linear-gradient(to bottom,
                                       alpha(white, 0.3),
                                       alpha(white, 0.2) 30%,
                                       alpha(black, 0.02));
 }
 
-.info .button.close:checked,
-.warning .button.close:checked,
-.question .button.close:checked,
-.error .button.close:checked {
+.info  button.close:checked,
+.warning  button.close:checked,
+.question  button.close:checked,
+.error  button.close:checked {
     color: @infobar_fg_color;
     background-image: linear-gradient(to bottom,
                                       alpha(black, 0.1),
                                       transparent);
 }
 
-.info .entry,
-.info .entry:focus,
-.info .button,
-.info .button:insensitive,
-.info .button:checked,
-.warning .entry,
-.warning .entry:focus,
-.warning .button,
-.warning .button:insensitive,
-.warning .button:checked,
-.error .entry,
-.error .entry:focus,
-.error .button,
-.error .button:insensitive,
-.error .button:checked,
-.question .entry,
-.question .entry:focus,
-.question .button,
-.question .button:insensitive,
-.question .button:checked {
+.info  entry,
+.info  entry:focus,
+.info  button,
+.info  button:disabled,
+.info  button:checked,
+.warning  entry,
+.warning  entry:focus,
+.warning  button,
+.warning  button:disabled,
+.warning  button:checked,
+.error  entry,
+.error  entry:focus,
+.error  button,
+.error  button:disabled,
+.error  button:checked,
+.question  entry,
+.question  entry:focus,
+.question  button,
+.question  button:disabled,
+.question  button:checked {
     color: @theme_fg_color;
     border-color: darker(@info_bg_color);
     border-style: solid;
@@ -4408,7 +4447,7 @@ GtkInfoBar {
 }
 
 /* Warning Bar */
-GtkInfoBar.horizontal.error {
+infobar.horizontal.error {
     background-color: @error_bg_color;
     color: @error_fg_color;
     border-color: darker(@error_bg_color);
@@ -4417,14 +4456,14 @@ GtkInfoBar.horizontal.error {
 }
 
 /* Question Bar */
-GtkInfoBar.horizontal.info .horizontal {
+infobar.horizontal.info .horizontal {
     background-color: @question_bg_color;
     color: @question_fg_color;
 }
 
-GtkInfoBar.horizontal.info .horizontal .button.flat.raised.close,
-GtkInfoBar.horizontal.info .horizontal .button.flat.raised.close:hover,
-GtkInfoBar.horizontal.info .horizontal .button.flat.raised.close:checked {
+infobar.horizontal.info .horizontal  button.flat.raised.close,
+infobar.horizontal.info .horizontal  button.flat.raised.close:hover,
+infobar.horizontal.info .horizontal  button.flat.raised.close:checked {
     border-radius: 3px;
     box-shadow: none;
 }
@@ -4434,7 +4473,7 @@ GtkInfoBar.horizontal.info .horizontal .button.flat.raised.close:checked {
  ***************/
 
 .prompt,
-GtkMessageDialog {
+messagedialog {
     -GtkDialog-content-area-border: 0;
     -GtkDialog-action-area-border: 12;
     -GtkDialog-button-spacing: 0;
@@ -4443,18 +4482,18 @@ GtkMessageDialog {
 }
 
 /* ie. mate-keyboard-properties option window */
-GtkDialog GtkScrolledWindow.frame {
+dialog scrolledwindow.frame {
     border-color: @notebook_border;
     border-style: solid;
     border-width: 1px;
     border-radius: 2px;
 }
 
-GtkDialog GtkScrolledWindow.frame GtkViewport .vertical {
+dialog scrolledwindow.frame viewport .vertical {
     background-color: shade (@theme_bg_color, 1.10);
 }
 
-GtkDialog GtkScrolledWindow.frame GtkViewport .vertical GtkExpander .vertical {
+dialog scrolledwindow.frame viewport .vertical expander .vertical {
     background-color: @theme_base_color;
     border-radius: 3px;
     border-color: @notebook_border;
@@ -4463,71 +4502,71 @@ GtkDialog GtkScrolledWindow.frame GtkViewport .vertical GtkExpander .vertical {
 }
 
 /* middle buttons */
-.dialog-action-area.linked .button,
-.dialog-action-area.linked .button:focus,
-.dialog-action-area.linked .button:hover,
-.dialog-action-area.linked .button:focus:hover,
-.dialog-action-area.linked .button:focus:hover:active,
-.dialog-action-area.linked .button:checked,
-.dialog-action-area.linked .button:checked:hover,
-.dialog-action-area.linked .button:checked:hover:active,
-.dialog-action-area.linked .button:insensitive {
+.dialog-action-area.linked  button,
+.dialog-action-area.linked  button:focus,
+.dialog-action-area.linked  button:hover,
+.dialog-action-area.linked  button:focus:hover,
+.dialog-action-area.linked  button:focus:hover:active,
+.dialog-action-area.linked  button:checked,
+.dialog-action-area.linked  button:checked:hover,
+.dialog-action-area.linked  button:checked:hover:active,
+.dialog-action-area.linked  button:disabled {
     border-right-width: 0px;
     border-left-width:  0px;
     border-width: 1px 0;
     border-radius: 0;
-    padding: 1px 2px;
+    padding: 6px 2px; /*this looks about right on the Caja run/display dialog*/
 }
 
 /* left button */
-.dialog-action-area.linked .button:first-child,
-.dialog-action-area.linked .button:focus:first-child,
-.dialog-action-area.linked .button:hover:first-child,
-.dialog-action-area.linked .button:focus:hover:first-child,
-.dialog-action-area.linked .button:focus:hover:active:first-child,
-.dialog-action-area.linked .button:checked:first-child,
-.dialog-action-area.linked .button:checked:hover:first-child,
-.dialog-action-area.linked .button:checked:hover:active:first-child,
-.dialog-action-area.linked .button:insensitive:first-child {
+.dialog-action-area.linked  button:first-child,
+.dialog-action-area.linked  button:focus:first-child,
+.dialog-action-area.linked  button:hover:first-child,
+.dialog-action-area.linked  button:focus:hover:first-child,
+.dialog-action-area.linked  button:focus:hover:active:first-child,
+.dialog-action-area.linked  button:checked:first-child,
+.dialog-action-area.linked  button:checked:hover:first-child,
+.dialog-action-area.linked  button:checked:hover:active:first-child,
+.dialog-action-area.linked  button:disabled:first-child {
     border-radius: 6px 0 0 6px;
     border-width: 1px;
     border-right-width: 0;
-    padding: 1px 2px;
+    padding: 6px 2px;
 }
 
 /* right button */
-.dialog-action-area.linked .button:last-child,
-.dialog-action-area.linked .button:focus:last-child,
-.dialog-action-area.linked .button:hover:last-child,
-.dialog-action-area.linked .button:focus:hover:last-child,
-.dialog-action-area.linked .button:focus:hover:active:last-child,
-.dialog-action-area.linked .button:checked:last-child,
-.dialog-action-area.linked .button:checked:hover:last-child,
-.dialog-action-area.linked .button:checked:hover:active:last-child,
-.dialog-action-area.linked .button:insensitive:last-child {
+.dialog-action-area.linked  button:last-child,
+.dialog-action-area.linked  button:focus:last-child,
+.dialog-action-area.linked  button:hover:last-child,
+.dialog-action-area.linked  button:focus:hover:last-child,
+.dialog-action-area.linked  button:focus:hover:active:last-child,
+.dialog-action-area.linked  button:checked:last-child,
+.dialog-action-area.linked  button:checked:hover:last-child,
+.dialog-action-area.linked  button:checked:hover:active:last-child,
+.dialog-action-area.linked  button:disabled:last-child {
     border-width: 1px;
     border-radius: 0 6px 6px 0;
     border-left-width: 0;
-    padding: 1px 2px;
+    padding: 6px 2px;
 }
 
 /* single button */
-.dialog-action-area.linked .button:only-child,
-.dialog-action-area.linked .button:focus:only-child,
-.dialog-action-area.linked .button:hover:only-child,
-.dialog-action-area.linked .button:focus:hover:only-child,
-.dialog-action-area.linked .button:focus:hover:active:only-child,
-.dialog-action-area.linked .button:checked:only-child,
-.dialog-action-area.linked .button:checked:hover:only-child,
-.dialog-action-area.linked .button:checked:hover:active:only-child,
-.dialog-action-area.linked .button:insensitive:last-child {
+.dialog-action-area.linked  button:only-child,
+.dialog-action-area.linked  button:focus:only-child,
+.dialog-action-area.linked  button:hover:only-child,
+.dialog-action-area.linked  button:focus:hover:only-child,
+.dialog-action-area.linked  button:focus:hover:active:only-child,
+.dialog-action-area.linked  button:checked:only-child,
+.dialog-action-area.linked  button:checked:hover:only-child,
+.dialog-action-area.linked  button:checked:hover:active:only-child,
+.dialog-action-area.linked  button:disabled:last-child {
     padding-left: 6px;
     padding-right: 6px;
     border-width: 1px;
     border-radius: 6px;
 }
 
-.dialog-action-area.linked .button:only-child {
+.dialog-action-area.linked  button:only-child {
     border-width: 0px;
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
@@ -4545,14 +4584,14 @@ GtkDialog GtkScrolledWindow.frame GtkViewport .vertical GtkExpander .vertical {
                 inset  0px -1px alpha(shade(@button_border, 0.88), 0.90);
 }
 
-.dialog-action-area.linked .button:focus:only-child {
+.dialog-action-area.linked  button:focus:only-child {
     box-shadow: inset  0px  1px shade(@selected_bg_color, 1.05),
                 inset  1px  0px shade(@selected_bg_color, 0.97),
                 inset -1px  0px shade(@selected_bg_color, 0.93),
                 inset  0px -1px shade(@selected_bg_color, 0.93);
 }
 
-.dialog-action-area.linked .button:hover:only-child {
+.dialog-action-area.linked  button:hover:only-child {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade(@button_gradient1, 1.03)),
@@ -4561,7 +4600,7 @@ GtkDialog GtkScrolledWindow.frame GtkViewport .vertical GtkExpander .vertical {
                                      to   (shade(@button_gradient4, 1.01)));
 }
 
-.dialog-action-area.linked .button:active:only-child {
+.dialog-action-area.linked  button:active:only-child {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade (@theme_bg_color, 1.20)),
@@ -4570,10 +4609,10 @@ GtkDialog GtkScrolledWindow.frame GtkViewport .vertical GtkExpander .vertical {
                                      to (shade (@theme_bg_color, 0.80)));
 }
 
-.dialog-action-area.linked .button.suggested-action,
-.dialog-action-area.linked .button.suggested-action:active,
-.dialog-action-area.linked .button.suggested-action:checked,
-.dialog-action-area.linked .button.suggested-action:insensitive {
+.dialog-action-area.linked  button.suggested-action,
+.dialog-action-area.linked  button.suggested-action:active,
+.dialog-action-area.linked  button.suggested-action:checked,
+.dialog-action-area.linked  button.suggested-action:disabled {
     box-shadow: none;
 }
 
@@ -4612,7 +4651,7 @@ GtkDialog GtkScrolledWindow.frame GtkViewport .vertical GtkExpander .vertical {
     background-color: alpha(shade(@theme_selected_bg_color, 1.0), 0.4);
 }
 
-GtkOverlay.osd {
+overlay.osd {
     background-color: transparent;
 }
 
@@ -4621,15 +4660,15 @@ GtkOverlay.osd {
     background-origin: border-box;
 }
 
-.osd.button:focus,
-.osd.button:checked,
-.osd.button:hover:active,
-.osd.button:focus:hover:active,
-.osd .button,
-.osd .button:focus,
-.osd .button:checked,
-.osd .button:hover:active,
-.osd .button:focus:hover:active {
+.osd button:focus,
+.osd button:checked,
+.osd button:hover:active,
+.osd button:focus:hover:active,
+.osd  button,
+.osd  button:focus,
+.osd  button:checked,
+.osd  button:hover:active,
+.osd  button:focus:hover:active {
     border-width: 1px;
     border-style: solid;
     border-image: none;
@@ -4638,23 +4677,23 @@ GtkOverlay.osd {
     box-shadow: none;
 }
 
-.osd.button,
-.osd.button:hover,
-.osd.button:checked {
+.osd button,
+.osd button:hover,
+.osd button:checked {
     background-color: shade(@osd_bg, 1.10);
     border-radius: 5px;
     border-color: @osd_button_border;
 }
 
-.osd .button,
-.osd .button:hover,
-.osd .button:checked {
+.osd  button,
+.osd  button:hover,
+.osd  button:checked {
     background-color: transparent;
     box-shadow: none;
 }
 
-.osd.button:insensitive,
-.osd .button:insensitive {
+.osd button:disabled,
+.osd  button:disabled {
     background-image: none;
     border-color: @osd_button_bg_insensitive;
     background-color: transparent;
@@ -4662,17 +4701,17 @@ GtkOverlay.osd {
     color: @osd_button_fg_insensitive;
 }
 
-.osd.button:checked:insensitive,
-.osd .button:checked:insensitive {
+.osd button:checked:disabled,
+.osd  button:checked:disabled {
     background-image: none;
     background-color: @osd_button_bg_insensitive_active;
     color: @osd_button_fg_insensitive;
 }
 
-.osd.button,
-.osd.button:focus,
-.osd .button,
-.osd .button:focus {
+.osd button,
+.osd button:focus,
+.osd  button,
+.osd  button:focus {
     padding: 4px;
     background-image: linear-gradient(to bottom,
                                       @osd_button_bg_a,
@@ -4680,12 +4719,12 @@ GtkOverlay.osd {
                                       @osd_button_bg_c);
     color: @osd_button_fg;
     text-shadow: 0 -1px @osd_button_shadow;
-    icon-shadow: 0 -1px @osd_button_shadow;
+    -gtk-icon-shadow: 0 -1px @osd_button_shadow;
 }
 
-.osd.button:hover,
-.osd .button:hover,
-.osd .linked .button:hover {
+.osd button:hover,
+.osd  button:hover,
+.osd .linked  button:hover {
     background-image: linear-gradient(to bottom,
                                       @osd_button_bg_hover_a,
                                       @osd_button_bg_hover_b 68%,
@@ -4693,17 +4732,17 @@ GtkOverlay.osd {
     color: @osd_button_fg_hover;
 }
 
-.osd.button:checked,
-.osd.button:checked:hover,
-.osd.button:checked:hover:active,
-.osd.button:hover:active,
-.osd.button:focus:hover:active,
-.osd .button:checked,
-.osd .button:checked:hover,
-.osd .button:checked:hover:active,
-.osd .button:hover:active,
-.osd .button:focus:hover:active,
-.osd GtkMenuButton.button:checked {
+.osd button:checked,
+.osd button:checked:hover,
+.osd button:checked:hover:active,
+.osd button:hover:active,
+.osd button:focus:hover:active,
+.osd  button:checked,
+.osd  button:checked:hover,
+.osd  button:checked:hover:active,
+.osd  button:hover:active,
+.osd  button:focus:hover:active,
+.osd GtkMenuButton button:checked {
     background-image: linear-gradient(to bottom,
                                       @osd_button_bg_active_a,
                                       @osd_button_bg_active_b 68%,
@@ -4712,13 +4751,13 @@ GtkOverlay.osd {
     text-shadow: 0 -1px @osd_button_shadow;
 }
 
-.osd GtkMenuButton.button:checked {
+.osd GtkMenuButton button:checked {
     background-color: transparent;
     border-color: @osd_button_border;
 }
 
 /* gnome-weather */
-.linked.stack-switcher.osd .button {
+.linked.stack-switcher.osd  button {
     background-image: linear-gradient(to bottom,
                                       alpha(shade(@theme_selected_bg_color, 1.2), 0.1),
                                       alpha(shade(@theme_selected_bg_color, 0.95), 0.1));
@@ -4726,7 +4765,7 @@ GtkOverlay.osd {
     box-shadow: none;
 }
 
-.linked.stack-switcher.osd .button:hover {
+.linked.stack-switcher.osd  button:hover {
     background-image: linear-gradient(to bottom,
                                       alpha(shade(@theme_selected_bg_color, 1.2), 0.4),
                                       alpha(shade(@theme_selected_bg_color, 0.95), 0.4));
@@ -4734,30 +4773,30 @@ GtkOverlay.osd {
 
 }
 
-.linked.stack-switcher.osd .button {
+.linked.stack-switcher.osd  button {
     border-width: 1px 0 1px 0px;
     border-color: shade (@theme_selected_bg_color, 0.8);
 }
 
-.linked.stack-switcher.osd .button:first-child {
+.linked.stack-switcher.osd  button:first-child {
     border-width: 1px 1px 1px 1px;
 }
 
-.linked.stack-switcher.osd .button:last-child {
+.linked.stack-switcher.osd  button:last-child {
     border-width: 1px 1px 1px 0px;
 }
 
-.linked.stack-switcher.osd .button:only-child {
+.linked.stack-switcher.osd  button:only-child {
     border-width: 1px;
 }
 
 /* ie. parole media-player */
 /* previous/play/next */
-.osd .horizontal .horizontal .button {
+.osd .horizontal .horizontal  button {
     padding: 5px 8px;
 }
 
-.osd .horizontal .horizontal .button:insensitive {
+.osd .horizontal .horizontal  button:disabled {
     border-color: @osd_button_bg_insensitive;
 }
 
@@ -4775,12 +4814,12 @@ GtkOverlay.osd {
 }
 
 /* ie. volume button */
-.osd .horizontal .button,
-.osd .horizontal .button:hover {
+.osd .horizontal  button,
+.osd .horizontal  button:hover {
     padding: 5px 8px;
 }
 
-.osd.toolbar {
+.osd toolbar {
     color: @osd_fg;
     text-shadow: 0 1px @osd_text_shadow;
     padding: 10px;
@@ -4795,41 +4834,41 @@ GtkOverlay.osd {
     -GtkToolbar-button-relief: normal;
 }
 
-.osd.toolbar .button,
-.osd.toolbar .button:hover,
-.osd.toolbar .linked .button {
+.osd toolbar  button,
+.osd toolbar  button:hover,
+.osd toolbar .linked  button {
     padding: 6px;
     border-width: 1px;
     border-radius: 5px;
 }
 
-.osd.toolbar .button:first-child,
-.osd.toolbar .linked .button:first-child {
+.osd toolbar  button:first-child,
+.osd toolbar .linked  button:first-child {
     border-radius: 5px 0 0 5px;
     border-width: 1px 0 1px 1px;
     box-shadow: inset -1px 0 @osd_button_inset;
 }
 
-.osd.toolbar .button:last-child,
-.osd.toolbar .linked .button:last-child {
+.osd toolbar  button:last-child,
+.osd toolbar .linked  button:last-child {
     box-shadow: none;
     border-radius: 0 5px 5px 0;
     border-width: 1px 1px 1px 0;
 }
 
-.osd.toolbar .button:only-child,
-.osd.toolbar .linked .button:only-child,
-.osd.toolbar GtkToolButton .button,
-.osd.toolbar GtkToolButton:only-child .button,
-.osd.toolbar GtkToolButton:last-child .button,
-.osd.toolbar GtkToolButton:first-child .button {
+.osd toolbar  button:only-child,
+.osd toolbar .linked  button:only-child,
+.osd toolbar GtkToolButton  button,
+.osd toolbar GtkToolButton:only-child  button,
+.osd toolbar GtkToolButton:last-child  button,
+.osd toolbar GtkToolButton:first-child  button {
     border-width: 1px;
     border-radius: 5px;
     border-style: solid;
     box-shadow: none;
 }
 
-.osd.toolbar .separator {
+.osd toolbar .separator {
     color: shade(@osd_lowlight, 0.80);
 }
 
@@ -4844,13 +4883,13 @@ GtkOverlay.osd {
     background-color: @osd_fg;
 }
 
-.osd .scale.trough:insensitive,
-.osd .scale.trough.highlight:insensitive {
+.osd  scale trough:disabled,
+.osd  scale trough.highlight:disabled {
     background-image: none;
     background-color: transparent;
 }
 
-.osd .scale-popup.popover.background {
+.osd  scale-popup popover.background {
     color: @osd_fg;
     border-style: solid;
     border-width: 1px;
@@ -4862,7 +4901,7 @@ GtkOverlay.osd {
     background-color: alpha(shade(@theme_selected_bg_color, 1.0), 0.4);
 }
 
-.osd .popover.scale-popup .flat.button.image-button {
+.osd  popover scale-popup .flat button.image-button {
     background-image: linear-gradient(to bottom,
                                       @osd_button_bg_a,
                                       @osd_button_bg_b 68%,
@@ -4874,16 +4913,16 @@ GtkOverlay.osd {
     padding: 2px;
 }
 
-.osd .popover.scale-popup .flat.button.image-button:hover {
+.osd  popover scale-popup .flat button.image-button:hover {
     background-image: linear-gradient(to bottom,
                                       @osd_button_bg_hover_a,
                                       @osd_button_bg_hover_b 68%,
                                       @osd_button_bg_hover_c);
     border-color: alpha(shade(@theme_selected_bg_color, 2.2), 0.8);
-    -gtk-image-effect: highlight;
+    /*-gtk-image-effect: highlight; INVALID */
 }
 
-.osd .popover.scale-popup .flat.button.image-button:insensitive {
+.osd  popover scale-popup .flat button.image-button:disabled {
     background-image: none;
     background-color: transparent;
     border-image: none;
@@ -4891,16 +4930,16 @@ GtkOverlay.osd {
     box-shadow: none;
 }
 
-.osd GtkProgressBar,
-GtkProgressBar.osd {
+.osd progressbar,
+progressbar.osd {
     padding: 0;
-    -GtkProgressBar-xspacing: 0;
-    -GtkProgressBar-yspacing: 3px;
-    -GtkProgressBar-min-horizontal-bar-height: 3px;
+    -progressbar-xspacing: 0;
+    -progressbar-yspacing: 3px;
+    min-height: 3px;
 }
 
-.osd GtkProgressBar.trough,
-GtkProgressBar.osd.trough {
+.osd progressbar trough,
+progressbar.osd trough {
     padding: 0;
     border-image: none;
     border-style: none;
@@ -4910,8 +4949,8 @@ GtkProgressBar.osd.trough {
     border-radius: 0;
 }
 
-.osd GtkProgressBar.progressbar,
-GtkProgressBar.osd.progressbar {
+.osd progressbar.progressbar,
+progressbar.osd.progressbar {
     border-style: none;
     background-color: @theme_selected_bg_color;
     background-image: none;
@@ -4932,15 +4971,15 @@ GtkProgressBar.osd.progressbar {
 }
 
 .osd .scrollbar.slider:hover {
-    background-color: @osd_scrollbar_slider_prelight;
+    background-color: @osd_scrollbar_slider_hover;
 }
 
 .osd .scrollbar.slider:active {
     background-color: @osd_scrollbar_slider_active;
 }
 
-.osd GtkIconView.cell:selected,
-.osd GtkIconView.cell:selected:focus {
+.osd iconview.cell:selected,
+.osd iconview.cell:selected:focus {
     background-color: transparent;
     border-style: solid;
     border-radius: 15px;
@@ -4962,7 +5001,7 @@ GtkProgressBar.osd.progressbar {
  * Popovers *
  *************/
 
-.popover {
+popover {
     background-clip: initial;
     margin: 10px;
     padding: 2px;
@@ -4973,42 +5012,42 @@ GtkProgressBar.osd.progressbar {
     background-color: @bg_dark_color;
     box-shadow: 0 1px 5px @wm_shadow;
     text-shadow: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
 }
 
-.popover > .list,
-.popover > .view,
-.popover > .toolbar .popover.osd > .toolbar,
-.popover > .inline-toolbar .popover.osd > .toolbar,
-.popover > .search-bar .popover.osd > .toolbar,
-.popover > .location-bar .popover.osd > .toolbar,
-.popover > .toolbar .popover.osd > .inline-toolbar,
-.popover > .inline-toolbar .popover.osd > .inline-toolbar,
-.popover > .search-bar .popover.osd > .inline-toolbar,
-.popover > .location-bar .popover.osd > .inline-toolbar,
-.popover > .toolbar .popover.osd > .search-bar,
-.popover > .inline-toolbar .popover.osd > .search-bar,
-.popover > .search-bar .popover.osd > .search-bar,
-.popover > .location-bar .popover.osd > .search-bar,
-.popover > .toolbar .popover.osd > .location-bar,
-.popover > .inline-toolbar .popover.osd > .location-bar,
-.popover > .search-bar .popover.osd > .location-bar,
-.popover > .location-bar .popover.osd > .location-bar {
+popover >  list,
+popover > .view,
+popover >  toolbar  popover.osd >  toolbar,
+popover > .inline-toolbar  popover.osd >  toolbar,
+popover > .search-bar  popover.osd >  toolbar,
+popover > .location-bar  popover.osd >  toolbar,
+popover >  toolbar  popover.osd > .inline-toolbar,
+popover > .inline-toolbar  popover.osd > .inline-toolbar,
+popover > .search-bar  popover.osd > .inline-toolbar,
+popover > .location-bar  popover.osd > .inline-toolbar,
+popover >  toolbar  popover.osd > .search-bar,
+popover > .inline-toolbar  popover.osd > .search-bar,
+popover > .search-bar  popover.osd > .search-bar,
+popover > .location-bar  popover.osd > .search-bar,
+popover >  toolbar  popover.osd > .location-bar,
+popover > .inline-toolbar  popover.osd > .location-bar,
+popover > .search-bar  popover.osd > .location-bar,
+popover > .location-bar  popover.osd > .location-bar {
     border-style: none;
     background-color: transparent;
 }
 
-.popover .separator {
+popover .separator {
     font-size: 80%;
     font-weight: bold;
     color: alpha(@theme_fg_dark_color,0.6);
     text-shadow: none;
     background-color: transparent;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
     border: 0;
 }
 
-.popover.osd {
+popover.osd {
     background-image: none;
     background-color: alpha(shade(#3D3E40, 0.85), 0.75);
     border: 1px solid black;
@@ -5016,27 +5055,27 @@ GtkProgressBar.osd.progressbar {
     color: @theme_selected_fg_color;
 }
 
-.popover.osd .toolbar {
+popover.osd  toolbar {
     background-image: none;
     background-color: transparent;
     border: none;
     box-shadow: none;
 }
 
-.popover.osd .button {
+popover.osd  button {
     text-shadow: 0 -1px @osd_text_shadow;
-    icon-shadow: 0 -1px @osd_text_shadow;
+    -gtk-icon-shadow: 0 -1px @osd_text_shadow;
 }
 
-.popover.osd .button:checked {
+popover.osd  button:checked {
     box-shadow: none;
 }
 
-.popover.osd .button:insensitive {
+popover.osd  button:disabled {
     color: alpha(@theme_selected_fg_color, 0.4);
 }
 
-.popover.scale-popup .flat.button.image-button:insensitive {
+popover scale-popup .flat button.image-button:disabled {
     background-image: none;
     background-color: transparent;
     border-image: none;
@@ -5044,7 +5083,7 @@ GtkProgressBar.osd.progressbar {
     box-shadow: none;
 }
 
-.popover.scale-popup .flat.button.image-button {
+popover scale-popup .flat button.image-button {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade(@menu_bg_dark_color, 2.03)),
@@ -5056,29 +5095,29 @@ GtkProgressBar.osd.progressbar {
                 inset  0px -1px shade(@selected_bg_color, 0.93);
 }
 
-.popover.scale-popup .flat.button.image-button:hover {
-    -gtk-image-effect: highlight;
+popover scale-popup .flat button.image-button:hover {
+   /* -gtk-image-effect: highlight; INVALID*/
 }
 
-.popover.scale-popup .scale .trough,
-.popover.scale-popup .scale .trough.vertical {
+popover scale-popup  scale .trough,
+popover scale-popup  scale .trough.vertical {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade (@scale_border_a, 1.10)),
                                      to (shade (@scale_border_a, 1.51)));
 }
 
-.popover.scale-popup .scale .trough.highlight,
-.popover.scale-popup .scale .trough.highlight.vertical {
+popover scale-popup  scale .trough.highlight,
+popover scale-popup  scale .trough.highlight.vertical {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade (@theme_selected_bg_color, 1.31)),
                                      to (shade (@theme_selected_bg_color, 1.00)));
 }
 
-/* needs to be here to avoid a override by .popover.scale-popup */
-.osd .scale.trough,
-.osd .scale-popup.popover .scale.trough {
+/* needs to be here to avoid a override by  popover scale-popup */
+.osd  scale trough,
+.osd  scale-popup popover  scale trough {
     border-color: @osd_scale_border;
     border-image: none;
     background-image: linear-gradient(to bottom,
@@ -5087,19 +5126,19 @@ GtkProgressBar.osd.progressbar {
     background-color: transparent;
 }
 
-.osd .scale.trough.highlight,
-.osd .scale-popup.popover .scale.trough.highlight {
+.osd  scale trough.highlight,
+.osd  scale-popup popover  scale trough.highlight {
     background-image: none;
     background-color: @theme_selected_bg_color;
     border-color: @scale_highlight_border;
 }
 
-.popover .list {
+popover  list {
     background-color: @theme_base_color;
 }
 
 /* more/less volume button */
-.popover .image-button:hover {
+popover .image-button:hover {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade(@menu_bg_dark_color, 2.03)),
@@ -5110,7 +5149,7 @@ GtkProgressBar.osd.progressbar {
                 inset  0px -1px shade(@selected_bg_color, 0.93);
 }
 
-.popover .image-button:insensitive {
+popover .image-button:disabled {
     background-image: none;
     background-color: transparent;
     box-shadow: inset  0px  1px @insensitive_border_color,
@@ -5119,45 +5158,45 @@ GtkProgressBar.osd.progressbar {
                 inset  0px -1px @insensitive_border_color;
 }
 
-GtkModelButton.button,
-GtkModelButton.button:first-child,
-GtkModelButton.button:last-child,
-GtkModelButton.button:only-child {
+modelbutton button,
+modelbutton button:first-child,
+modelbutton button:last-child,
+modelbutton button:only-child {
     background-image: none;
     color: @theme_fg_dark_color;
     border-radius: 3px;
 }
 
-GtkModelButton.button:checked,
-GtkModelButton.button:insensitive,
-GtkModelButton.button:checked:insensitive,
-GtkModelButton.button,
-GtkModelButton.button:focus,
-GtkModelButton.button:checked:focus,
-GtkModelButton.button:checked:first-child,
-GtkModelButton.button:insensitive:first-child,
-GtkModelButton.button:checked:insensitive:first-child,
-GtkModelButton.button:first-child,
-GtkModelButton.button:focus:first-child,
-GtkModelButton.button:checked:focus:first-child,
-GtkModelButton.button:checked:last-child,
-GtkModelButton.button:insensitive:last-child,
-GtkModelButton.button:checked:insensitive:last-child,
-GtkModelButton.button:last-child,
-GtkModelButton.button:focus:last-child,
-GtkModelButton.button:checked:focus:last-child,
-GtkModelButton.button:checked:only-child,
-GtkModelButton.button:insensitive:only-child,
-GtkModelButton.button:checked:insensitive:only-child,
-GtkModelButton.button:only-child,
-GtkModelButton.button:focus:only-child,
-GtkModelButton.button:checked:focus:only-child,
-.linked GtkModelButton.button,
-.linked GtkModelButton.button:focus,
-.linked GtkModelButton.button:first-child,
-.linked GtkModelButton.button:focus:first-child,
-.linked GtkModelButton.button:last-child,
-.linked GtkModelButton.button:focus:last-child {
+modelbutton button:checked,
+modelbutton button:disabled,
+modelbutton button:checked:disabled,
+modelbutton button,
+modelbutton button:focus,
+modelbutton button:checked:focus,
+modelbutton button:checked:first-child,
+modelbutton button:disabled:first-child,
+modelbutton button:checked:disabled:first-child,
+modelbutton button:first-child,
+modelbutton button:focus:first-child,
+modelbutton button:checked:focus:first-child,
+modelbutton button:checked:last-child,
+modelbutton button:disabled:last-child,
+modelbutton button:checked:disabled:last-child,
+modelbutton button:last-child,
+modelbutton button:focus:last-child,
+modelbutton button:checked:focus:last-child,
+modelbutton button:checked:only-child,
+modelbutton button:disabled:only-child,
+modelbutton button:checked:disabled:only-child,
+modelbutton button:only-child,
+modelbutton button:focus:only-child,
+modelbutton button:checked:focus:only-child,
+.linked modelbutton button,
+.linked modelbutton button:focus,
+.linked modelbutton button:first-child,
+.linked modelbutton button:focus:first-child,
+.linked modelbutton button:last-child,
+.linked modelbutton button:focus:last-child {
     background-color: shade (@theme_bg_dark_color, 1.0);
     background-image: none;
     border-color: transparent;
@@ -5167,42 +5206,42 @@ GtkModelButton.button:checked:focus:only-child,
     border-radius: 3px;
 }
 
-GtkModelButton.button:checked:hover:only-child,
-GtkModelButton.button:checked:hover:active:only-child,
-GtkModelButton.button:focus:hover:active:only-child,
-GtkModelButton.button:hover:active:only-child,
-GtkModelButton.button:hover:only-child,
-GtkModelButton.button:selected:only-child,
-GtkModelButton.button:checked:hover:first-child,
-GtkModelButton.button:checked:hover:active:first-child,
-GtkModelButton.button:focus:hover:active:first-child,
-GtkModelButton.button:hover:active:first-child,
-GtkModelButton.button:hover:first-child,
-GtkModelButton.button:selected:first-child,
-GtkModelButton.button:checked:hover:last-child,
-GtkModelButton.button:checked:hover:active:last-child,
-GtkModelButton.button:focus:hover:active:last-child,
-GtkModelButton.button:hover:active:last-child,
-GtkModelButton.button:hover:last-child,
-GtkModelButton.button:selected:last-child,
-GtkModelButton.button:checked:hover,
-GtkModelButton.button:checked:hover:active,
-GtkModelButton.button:focus:hover:active,
-GtkModelButton.button:hover:active,
-GtkModelButton.button:hover,
-GtkModelButton.button:selected,
-.linked GtkModelButton.button:hover,
-.linked GtkModelButton.button:hover:active,
-.linked GtkModelButton.button:checked:hover,
-.linked GtkModelButton.button:checked:hover:active,
-.linked GtkModelButton.button:hover:first-child,
-.linked GtkModelButton.button:hover:active:first-child,
-.linked GtkModelButton.button:checked:hover:first-child,
-.linked GtkModelButton.button:checked:hover:active:first-child,
-.linked GtkModelButton.button:hover:last-child,
-.linked GtkModelButton.button:hover:active:last-child,
-.linked GtkModelButton.button:checked:hover:last-child,
-.linked GtkModelButton.button:checked:hover:active:last-child {
+modelbutton button:checked:hover:only-child,
+modelbutton button:checked:hover:active:only-child,
+modelbutton button:focus:hover:active:only-child,
+modelbutton button:hover:active:only-child,
+modelbutton button:hover:only-child,
+modelbutton button:selected:only-child,
+modelbutton button:checked:hover:first-child,
+modelbutton button:checked:hover:active:first-child,
+modelbutton button:focus:hover:active:first-child,
+modelbutton button:hover:active:first-child,
+modelbutton button:hover:first-child,
+modelbutton button:selected:first-child,
+modelbutton button:checked:hover:last-child,
+modelbutton button:checked:hover:active:last-child,
+modelbutton button:focus:hover:active:last-child,
+modelbutton button:hover:active:last-child,
+modelbutton button:hover:last-child,
+modelbutton button:selected:last-child,
+modelbutton button:checked:hover,
+modelbutton button:checked:hover:active,
+modelbutton button:focus:hover:active,
+modelbutton button:hover:active,
+modelbutton button:hover,
+modelbutton button:selected,
+.linked modelbutton button:hover,
+.linked modelbutton button:hover:active,
+.linked modelbutton button:checked:hover,
+.linked modelbutton button:checked:hover:active,
+.linked modelbutton button:hover:first-child,
+.linked modelbutton button:hover:active:first-child,
+.linked modelbutton button:checked:hover:first-child,
+.linked modelbutton button:checked:hover:active:first-child,
+.linked modelbutton button:hover:last-child,
+.linked modelbutton button:hover:active:last-child,
+.linked modelbutton button:checked:hover:last-child,
+.linked modelbutton button:checked:hover:active:last-child {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade(@menu_bg_dark_color, 2.03)),
@@ -5219,11 +5258,11 @@ GtkModelButton.button:selected,
                 inset  0px -1px shade(@selected_bg_color, 0.93);
 }
 
-.csd .popover .linked GtkModelButton.button:checked,
-.csd .popover .linked GtkModelButton.button:hover,
-.csd .popover .linked GtkModelButton.button:hover:active,
-.csd .popover .linked GtkModelButton.button:checked:hover,
-.csd .popover .linked GtkModelButton.button:checked:hover:active {
+.csd  popover .linked modelbutton button:checked,
+.csd  popover .linked modelbutton button:hover,
+.csd  popover .linked modelbutton button:hover:active,
+.csd  popover .linked modelbutton button:checked:hover,
+.csd  popover .linked modelbutton button:checked:hover:active {
     color: @fg_dark_color;
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
@@ -5236,36 +5275,36 @@ GtkModelButton.button:selected,
 }
 
 /* middle button*/
-.linked GtkModelButton.button:hover,
-.linked GtkModelButton.button:hover:active,
-.linked GtkModelButton.button:checked:hover,
-.linked GtkModelButton.button:checked:hover:active {
+.linked modelbutton button:hover,
+.linked modelbutton button:hover:active,
+.linked modelbutton button:checked:hover,
+.linked modelbutton button:checked:hover:active {
     border-right-width: 0px;
     border-left-width:  0px;
     border-radius: 0;
 }
 
 /* left button*/
-.linked GtkModelButton.button:hover:first-child,
-.linked GtkModelButton.button:hover:active:first-child,
-.linked GtkModelButton.button:checked:hover:first-child,
-.linked GtkModelButton.button:checked:hover:active:first-child {
+.linked modelbutton button:hover:first-child,
+.linked modelbutton button:hover:active:first-child,
+.linked modelbutton button:checked:hover:first-child,
+.linked modelbutton button:checked:hover:active:first-child {
     border-right-width: 0px;
     border-radius: 6px 0 0 6px;
 }
 
 /* right button*/
-.linked GtkModelButton.button:hover:last-child,
-.linked GtkModelButton.button:hover:active:last-child,
-.linked GtkModelButton.button:checked:hover:last-child,
-.linked GtkModelButton.button:checked:hover:active:last-child {
+.linked modelbutton button:hover:last-child,
+.linked modelbutton button:hover:active:last-child,
+.linked modelbutton button:checked:hover:last-child,
+.linked modelbutton button:checked:hover:active:last-child {
     border-left-width:  0px;
     border-radius: 0 6px 6px 0;
 }
 
-.popover .button.default.text-button.suggested-action {
+popover button.default.text-button.suggested-action {
     background-image: none;
-    color: @theme_fg_dark_color;
+    color: @theme_fg_color;
     text-shadow: none;
     border-width: 0;
     border-color: transparent;
@@ -5273,7 +5312,7 @@ GtkModelButton.button:selected,
     padding: 5px 4px;
 }
 
-.popover .button.default.text-button.suggested-action:hover {
+popover button.default.text-button.suggested-action:hover {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade(@menu_bg_dark_color, 2.03)),
@@ -5290,7 +5329,7 @@ GtkModelButton.button:selected,
                 inset  0px -1px shade(@selected_bg_color, 0.93);
 }
 
-.entry.cursor-handle,
+entry.cursor-handle,
 .cursor-handle {
     background-color: transparent;
     background-image: none;
@@ -5298,12 +5337,12 @@ GtkModelButton.button:selected,
     border-style: none;
 }
 
-.entry.cursor-handle.top,
+entry.cursor-handle.top,
 .cursor-handle.top {
     -gtk-icon-source: -gtk-icontheme("selection-start-symbolic");
 }
 
-.entry.cursor-handle.bottom,
+entry.cursor-handle.bottom,
 .cursor-handle.bottom {
     -gtk-icon-source: -gtk-icontheme("selection-end-symbolic");
 }
@@ -5311,6 +5350,14 @@ GtkModelButton.button:selected,
 /*******
  * CSD *
  *******/
+
+decoration{
+    border-radius: 7px 7px 0px 0px;
+    border-width: 0px;
+    box-shadow: 0 0 0 2px @wm_csd_border_color, 0 2px 8px 3px @wm_shadow;
+    /* this is used for the resize cursor area */
+   margin: 10px;
+}
 
 .titlebar {
     text-shadow: 0 1px @wm_title_shadow;
@@ -5350,11 +5397,11 @@ GtkModelButton.button:selected,
     background-color: @theme_bg_dark_color;
 }
 
-.titlebar .button,
-.titlebar .button:first-child,
-.titlebar .button:last-child,
-.titlebar .button:only-child {
-    icon-shadow: 0px 1px @theme_shadow_dark_color;
+.titlebar  button,
+.titlebar  button:first-child,
+.titlebar  button:last-child,
+.titlebar  button:only-child {
+    -gtk-icon-shadow: 0px 1px @theme_shadow_dark_color;
     color: @wm_title;
     background: none;
     padding: 5px 5px 6px 5px;
@@ -5370,7 +5417,7 @@ GtkModelButton.button:selected,
 }
 
 .titlebar .titlebutton {
-    icon-shadow: 0px 1px @theme_shadow_dark_color;
+    -gtk-icon-shadow: 0px 1px @theme_shadow_dark_color;
     color: @wm_title;
     padding: 5px 5px 6px 5px;
     border-style: solid;
@@ -5382,11 +5429,11 @@ GtkModelButton.button:selected,
     background-color: transparent;
 }
 
-.titlebar .button:hover,
-.titlebar .button:focus:hover,
-.titlebar .button:focus:hover:active,
-.titlebar .button:checked,
-.titlebar .button:checked:focus,
+.titlebar  button:hover,
+.titlebar  button:focus:hover,
+.titlebar  button:focus:hover:active,
+.titlebar  button:checked,
+.titlebar  button:checked:focus,
 .titlebar .titlebutton:hover,
 .titlebar .titlebutton:hover:focus,
 .titlebar .titlebutton:hover:focus:active,
@@ -5410,19 +5457,19 @@ GtkModelButton.button:selected,
     background: none;
     color: @theme_text_dark_color;
     border-image: none;
-    icon-shadow: none;
+    -gtk-icon-shadow: none;
 }
 
 /* Middle titlebar-button */
-.titlebar .linked .button,
-.titlebar .linked .button:focus,
-.titlebar .linked .button:insensitive,
-.titlebar .button.raised.linked,
-.titlebar .button.raised.linked:focus,
-.titlebar .button.raised.linked:insensitive,
-.titlebar .raised.linked .button,
-.titlebar .raised.linked .button:focus,
-.titlebar .raised.linked .button:insensitive {
+.titlebar .linked  button,
+.titlebar .linked  button:focus,
+.titlebar .linked  button:disabled,
+.titlebar  button.raised.linked,
+.titlebar  button.raised.linked:focus,
+.titlebar  button.raised.linked:disabled,
+.titlebar .raised.linked  button,
+.titlebar .raised.linked  button:focus,
+.titlebar .raised.linked  button:disabled {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade(@button_raised_gradient_color_b, 0.90)),
@@ -5435,21 +5482,21 @@ GtkModelButton.button:selected,
     padding: 5px 5px 6px 5px;
 }
 
-.titlebar .linked .button:hover,
-.titlebar .linked .button:checked,
-.titlebar .linked .button:focus:hover:active,
-.titlebar .linked .button:checked:hover,
-.titlebar .linked .button:checked:focus:hover:active,
-.titlebar .button.raised.linked:hover,
-.titlebar .button.raised.linked:checked,
-.titlebar .button.raised.linked:focus:hover:active,
-.titlebar .button.raised.linked:checked:hover,
-.titlebar .button.raised.linked:checked:focus:hover:active,
-.titlebar .raised.linked .button:hover,
-.titlebar .raised.linked .button:checked,
-.titlebar .raised.linked .button:focus:hover:active,
-.titlebar .raised.linked .button:checked:hover,
-.titlebar .raised.linked .button:checked:focus:hover:active {
+.titlebar .linked  button:hover,
+.titlebar .linked  button:checked,
+.titlebar .linked  button:focus:hover:active,
+.titlebar .linked  button:checked:hover,
+.titlebar .linked  button:checked:focus:hover:active,
+.titlebar  button.raised.linked:hover,
+.titlebar  button.raised.linked:checked,
+.titlebar  button.raised.linked:focus:hover:active,
+.titlebar  button.raised.linked:checked:hover,
+.titlebar  button.raised.linked:checked:focus:hover:active,
+.titlebar .raised.linked  button:hover,
+.titlebar .raised.linked  button:checked,
+.titlebar .raised.linked  button:focus:hover:active,
+.titlebar .raised.linked  button:checked:hover,
+.titlebar .raised.linked  button:checked:focus:hover:active {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade(@menu_bg_dark_color, 2.03)),
@@ -5460,265 +5507,34 @@ GtkModelButton.button:selected,
                 inset -1px  0px shade(@selected_bg_color, 0.93),
                 inset  0px -1px shade(@selected_bg_color, 0.93);
     color: @theme_fg_dark_color;
-    border-width: 1px;
-    border-right-width: 0px;
-    border-left-width:  0px;
-    border-radius: 0;
-    padding: 5px 5px 6px 5px;
 }
 
-/* Leftmost titlebar-button */
-.titlebar .linked .button:first-child,
-.titlebar .linked .button:focus:first-child,
-.titlebar .linked .button:insensitive:first-child,
-.titlebar .button.raised.linked:first-child,
-.titlebar .button.raised.linked:focus:first-child,
-.titlebar .button.raised.linked:insensitive:first-child,
-.titlebar .raised.linked .button:first-child,
-.titlebar .raised.linked .button:focus:first-child,
-.titlebar .raised.linked .button:insensitive:first-child {
-    background-image: -gtk-gradient (linear,
-                                     left top, left bottom,
-                                     from (shade(@button_raised_gradient_color_b, 0.90)),
-                                     to   (shade(@button_raised_gradient_color_a, 0.80)));
-    color: @theme_fg_dark_color;
-    border-width: 1px;
-    border-right-width: 0;
-    border-radius: 5px;
-    border-bottom-right-radius: 0;
-    border-top-right-radius: 0;
-    padding: 5px 5px 6px 5px;
-}
-
-.titlebar .linked .button:hover:first-child,
-.titlebar .linked .button:checked:first-child,
-.titlebar .linked .button:focus:hover:active:first-child,
-.titlebar .linked .button:checked:hover:first-child,
-.titlebar .linked .button:checked:focus:hover:active:first-child,
-.titlebar .button.raised.linked:hover:first-child,
-.titlebar .button.raised.linked:checked:first-child,
-.titlebar .button.raised.linked:focus:hover:active:first-child,
-.titlebar .button.raised.linked:checked:hover:first-child,
-.titlebar .button.raised.linked:checked:focus:hover:active:first-child,
-.titlebar .raised.linked .button:hover:first-child,
-.titlebar .raised.linked .button:checked:first-child,
-.titlebar .raised.linked .button:focus:hover:active:first-child,
-.titlebar .raised.linked .button:checked:hover:first-child,
-.titlebar .raised.linked .button:checked:focus:hover:active:first-child {
-    background-image: -gtk-gradient (linear,
-                                     left top, left bottom,
-                                     from (shade(@menu_bg_dark_color, 2.03)),
-                                     to   (shade(@menu_bg_dark_color, 1.17)));
-    padding: 5px 5px 6px 5px;
-    box-shadow: inset  0px  1px shade(@selected_bg_color, 1.05),
-                inset  1px  0px shade(@selected_bg_color, 0.97),
-                inset -1px  0px shade(@selected_bg_color, 0.93),
-                inset  0px -1px shade(@selected_bg_color, 0.93);
-    color: @theme_fg_dark_color;
-    border-width: 1px;
-    border-right-width: 0;
-    border-radius: 5px;
-    border-bottom-right-radius: 0;
-    border-top-right-radius: 0;
-    padding: 5px 5px 6px 5px;
-}
-
-/* rightmost titlebar-button */
-.titlebar .linked .button:last-child,
-.titlebar .linked .button:focus:last-child,
-.titlebar .linked .button:insensitive:last-child,
-.titlebar .button.raised.linked:last-child,
-.titlebar .button.raised.linked:focus:last-child,
-.titlebar .button.raised.linked:insensitive:last-child,
-.titlebar .raised.linked .button:last-child,
-.titlebar .raised.linked .button:focus:last-child,
-.titlebar .raised.linked .button:insensitive:last-child {
-    background-image: -gtk-gradient (linear,
-                                     left top, left bottom,
-                                     from (shade(@button_raised_gradient_color_b, 0.90)),
-                                     to   (shade(@button_raised_gradient_color_a, 0.80)));
-    color: @theme_fg_dark_color;
-    border-width: 1px;
-    border-left-width: 0px;
-    border-radius: 5px;
-    border-bottom-left-radius: 0;
-    border-top-left-radius: 0;
-    padding: 5px 5px 6px 5px;
-}
-
-.titlebar .linked .button:hover:last-child,
-.titlebar .linked .button:checked:last-child,
-.titlebar .linked .button:focus:hover:active:last-child,
-.titlebar .linked .button:checked:hover:last-child,
-.titlebar .linked .button:checked:focus:hover:active:last-child,
-.titlebar .button.raised.linked:hover:last-child,
-.titlebar .button.raised.linked:checked:last-child,
-.titlebar .button.raised.linked:focus:hover:active:last-child,
-.titlebar .button.raised.linked:checked:hover:last-child,
-.titlebar .button.raised.linked:checked:focus:hover:active:last-child,
-.titlebar .raised.linked .button:hover:last-child,
-.titlebar .raised.linked .button:checked:last-child,
-.titlebar .raised.linked .button:focus:hover:active:last-child,
-.titlebar .raised.linked .button:checked:hover:last-child,
-.titlebar .raised.linked .button:checked:focus:hover:active:last-child {
-    background-image: -gtk-gradient (linear,
-                                     left top, left bottom,
-                                     from (shade(@menu_bg_dark_color, 2.03)),
-                                     to   (shade(@menu_bg_dark_color, 1.17)));
-    padding: 5px 5px 6px 5px;
-    box-shadow: inset  0px  1px shade(@selected_bg_color, 1.05),
-                inset  1px  0px shade(@selected_bg_color, 0.97),
-                inset -1px  0px shade(@selected_bg_color, 0.93),
-                inset  0px -1px shade(@selected_bg_color, 0.93);
-    color: @theme_fg_dark_color;
-    border-width: 1px;
-    border-left-width: 0px;
-    border-radius: 5px;
-    border-bottom-left-radius: 0;
-    border-top-left-radius: 0;
-    padding: 5px 5px 6px 5px;
-}
-
-/* Linked single titlebar-button */
-.titlebar .linked .button:only-child,
-.titlebar .linked .button:focus:only-child,
-.titlebar .linked .button:insensitive:only-child,
-.titlebar .button.raised.linked:only-child,
-.titlebar .button.raised.linked:focus:only-child,
-.titlebar .button.raised.linked:insensitive:only-child,
-.titlebar .raised.linked .button:only-child,
-.titlebar .raised.linked .button:focus:only-child,
-.titlebar .raised.linked .button:insensitive:only-child {
-    background-image: -gtk-gradient (linear,
-                                     left top, left bottom,
-                                     from (shade(@button_raised_gradient_color_b, 0.90)),
-                                     to   (shade(@button_raised_gradient_color_a, 0.80)));
-    color: @theme_fg_dark_color;
-    border-width: 1px;
-    border-radius: 5px;
-    padding: 5px 5px 6px 5px;
-}
-
-.titlebar .linked .button:hover:only-child,
-.titlebar .linked .button:checked:only-child,
-.titlebar .linked .button:focus:hover:active:only-child,
-.titlebar .linked .button:checked:hover:only-child,
-.titlebar .linked .button:checked:focus:hover:active:only-child,
-.titlebar .button.raised.linked:hover:only-child,
-.titlebar .button.raised.linked:checked:only-child,
-.titlebar .button.raised.linked:focus:hover:active:only-child,
-.titlebar .button.raised.linked:checked:hover:only-child,
-.titlebar .button.raised.linked:checked:focus:hover:active:only-child,
-.titlebar .raised.linked .button:hover:only-child,
-.titlebar .raised.linked .button:checked:only-child,
-.titlebar .raised.linked .button:focus:hover:active:only-child,
-.titlebar .raised.linked .button:checked:hover:only-child,
-.titlebar .raised.linked .button:checked:focus:hover:active:only-child {
-    background-image: -gtk-gradient (linear,
-                                     left top, left bottom,
-                                     from (shade(@menu_bg_dark_color, 2.03)),
-                                     to   (shade(@menu_bg_dark_color, 1.17)));
-    padding: 5px 5px 6px 5px;
-    box-shadow: inset  0px  1px shade(@selected_bg_color, 1.05),
-                inset  1px  0px shade(@selected_bg_color, 0.97),
-                inset -1px  0px shade(@selected_bg_color, 0.93),
-                inset  0px -1px shade(@selected_bg_color, 0.93);
-    color: @theme_fg_dark_color;
-    border-width: 1px;
-    border-radius: 5px;
-    padding: 5px 5px 6px 5px;
-}
-
-/* workaround to avoid unwanted black frames if switching compositor on/off */
-.background .window-frame  {
-    box-shadow: none;
-}
-
-.background.csd .window-frame {
-    border-color: darker(@theme_bg_dark_color);
-    border-radius: 7px 7px 0 0;
-    border-width: 1px;
-    border-style: solid;
-    background-color: @theme_bg_color;
-    box-shadow: 0 0 0 1px @wm_border, 0 2px 8px 3px @wm_shadow;
-    /* this is used for the resize cursor area */
-    margin: 10px;
-}
-
-/* workaround to avoid unwanted black frames if switching compositor on/off */
-.window-frame:backdrop {
-    background-color: @theme_bg_dark_color;
-/*    box-shadow: 0 0 0 1px shade(@wm_border,1.1), 0 2px 5px 1px @wm_shadow;*/
-    box-shadow: none;
-}
-
-.window-frame.tiled {
-    border-radius: 0;
-    background-color: @theme_bg_color;
-}
-
-.window-frame.ssd {
-    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.23);
-}
-
-.window-frame.solid-csd {
-    border-radius: 0;
-    margin: 1px;
-    background-color: @wm_bg_a;
-    border: solid 1px @wm_csd_solid_border_color;
-    box-shadow: none;
-}
-
-.window-frame.csd.popup {
-    border-radius: 0;
-    box-shadow: none;
-}
-
-.window-frame.csd.tooltip {
-    border-radius: 3px;
-    box-shadow: 0 1px 5px shade (@theme_selected_bg_color, 1.3);
-    padding: 4px 4px;
-}
-
-.window-frame.csd.message-dialog {
-    border-radius: 7px;
-    box-shadow: 0 1px 5px shade (@theme_selected_bg_color, 1.3);
-}
 /*********************
  * Spinner Animation *
  *********************/
-/* This is could be CPU-intensive */
+
+/*taken straight from Adwaita, it works */
 
 @keyframes spin {
-    to { -gtk-icon-transform: rotate(1turn); }
-}
-
-.spinner {
-    background-image: none;
-    background-color: blue;
-    opacity: 0;
-    -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
-}
-
-.spinner:active {
-    opacity: 1;
-    animation: spin 1s linear infinite;
-}
-
-.spinner:active:insensitive {
-    opacity: 0.5;
-}
-
-.button .spinner:active {
-    color: @theme_fg_color;
-}
+	to {
+    -gtk-icon-transform: rotate(1turn); } }
+spinner {
+	background: none;
+	opacity: 0;
+	/*remove icon, the default w/o it is more like gtk2 version was*/
+	/*-gtk-icon-source: -gtk-icontheme("process-working-symbolic"); */}
+spinner:checked {
+	opacity: 1;
+    animation: spin 1s linear infinite; }
+    spinner:checked:disabled {
+	opacity: 0.5; }
 
 /************************
  * overshoot/undershoot *
  ************************/
 
 /* displays at end of mouse scrolling */
-.overshoot.top {
+overshoot.top {
     background-image: -gtk-gradient(radial,
                                     center top, 0,
                                     center top, 0.5,
@@ -5737,7 +5553,7 @@ GtkModelButton.button:selected,
     box-shadow: none;
 }
 
-.overshoot.top:backdrop {
+overshoot.top:backdrop {
     background-image: -gtk-gradient(radial,
                                     center top, 0,
                                     center top, 0.5,
@@ -5751,7 +5567,7 @@ GtkModelButton.button:selected,
     box-shadow: none;
 }
 
-.overshoot.bottom {
+overshoot.bottom {
     background-image: -gtk-gradient(radial,
                                     center bottom, 0,
                                     center bottom, 0.5,
@@ -5770,7 +5586,7 @@ GtkModelButton.button:selected,
     box-shadow: none;
 }
 
-.overshoot.bottom:backdrop {
+overshoot.bottom:backdrop {
     background-image: -gtk-gradient(radial,
                                     center bottom, 0,
                                     center bottom, 0.5,
@@ -5784,7 +5600,7 @@ GtkModelButton.button:selected,
     box-shadow: none;
 }
 
-.overshoot.left {
+overshoot.left {
     background-image: -gtk-gradient(radial,
                                     left center, 0,
                                     left center, 0.5,
@@ -5803,7 +5619,7 @@ GtkModelButton.button:selected,
     box-shadow: none;
 }
 
-.overshoot.left:backdrop {
+overshoot.left:backdrop {
     background-image: -gtk-gradient(radial,
                                     left center, 0,
                                     left center, 0.5,
@@ -5817,7 +5633,7 @@ GtkModelButton.button:selected,
     box-shadow: none;
 }
 
-.overshoot.right {
+overshoot.right {
     background-image: -gtk-gradient(radial,
                                     right center, 0,
                                     right center, 0.5,
@@ -5836,7 +5652,7 @@ GtkModelButton.button:selected,
     box-shadow: none;
 }
 
-.overshoot.right:backdrop {
+overshoot.right:backdrop {
     background-image: -gtk-gradient(radial,
                                     right center, 0,
                                     right center, 0.5,
@@ -5851,7 +5667,7 @@ GtkModelButton.button:selected,
 }
 
 /* result is disable undershoot */
-.undershoot.top {
+undershoot.top {
     background-color: transparent;
     background-image: linear-gradient(to left,
                                       rgba(255, 255, 255, 0.2) 50%,
@@ -5862,7 +5678,7 @@ GtkModelButton.button:selected,
     background-position: center top;
 }
 
-.undershoot.bottom {
+undershoot.bottom {
     background-color: transparent;
     background-image: linear-gradient(to left,
                                       rgba(255, 255, 255, 0.2) 50%,
@@ -5873,7 +5689,7 @@ GtkModelButton.button:selected,
     background-position: center bottom;
 }
 
-.undershoot.left {
+undershoot.left {
     background-color: transparent;
     background-image: linear-gradient(to top,
                                       rgba(255, 255, 255, 0.2) 50%,
@@ -5884,7 +5700,7 @@ GtkModelButton.button:selected,
     background-position: left center;
 }
 
-.undershoot.right {
+undershoot.right {
     background-color: transparent;
     background-image: linear-gradient(to top,
                                       rgba(255, 255, 255, 0.2) 50%,
@@ -5899,17 +5715,17 @@ GtkModelButton.button:selected,
  * GtkStack *
  ************/
 
-GtkStack .horizontal .vertical .frame {
+stack .horizontal .vertical .frame {
     background-color: shade (@theme_bg_color, 1.1);
     border-width: 1px;
     border-color: @notebook_border;
 }
 
-GtkStackSidebar.sidebar .separator.horizontal {
-    -GtkWidget-separator-height: 0px;
+stackSidebar.sidebar .separator.horizontal {
+   /* -GtkWidget-separator-height: 0px; */
 }
 
-GtkStack .linked.vertical .entry {
+stack .linked.vertical .entry {
     border-radius: 5px;
     border-style: solid;
     border-width: 1px 1px 0px 1px;
@@ -5924,18 +5740,18 @@ GtkStack .linked.vertical .entry {
 }
 
 
-GtkStack .vertical.linked > GtkComboBox > GtkToggleButton.button:last-child,
-GtkStack .vertical.linked > GtkComboBox > GtkToggleButton.button:hover:last-child,
-GtkStack .vertical.linked > GtkComboBox > GtkToggleButton.button:focus:last-child,
-GtkStack .vertical.linked > GtkComboBox > GtkToggleButton.button:focus:hover:last-child,
-GtkStack .vertical.linked > GtkComboBox > GtkToggleButton.button:checked:last-child,
-GtkStack .vertical.linked > GtkComboBox > GtkToggleButton.button:insensitive:last-child,
-GtkStack .linked.vertical GtkToggleButton.button,
-GtkStack .linked.vertical GtkToggleButton.button:hover,
-GtkStack .linked.vertical GtkToggleButton.button:focus,
-GtkStack .linked.vertical GtkToggleButton.button:focus:hover,
-GtkStack .linked.vertical GtkToggleButton.button:checked,
-GtkStack .linked.vertical GtkToggleButton.button:insensitive {
+stack .vertical.linked > combobox > togglebutton.button:last-child,
+stack .vertical.linked > combobox > togglebutton.button:hover:last-child,
+stack .vertical.linked > combobox > togglebutton.button:focus:last-child,
+stack .vertical.linked > combobox > togglebutton.button:focus:hover:last-child,
+stack .vertical.linked > combobox > togglebutton.button:checked:last-child,
+stack .vertical.linked > combobox > togglebutton.button:disabled:last-child,
+stack .linked.vertical togglebutton.button,
+stack .linked.vertical togglebutton.button:hover,
+stack .linked.vertical togglebutton.button:focus,
+stack .linked.vertical togglebutton.button:focus:hover,
+stack .linked.vertical togglebutton.button:checked,
+stack .linked.vertical togglebutton.button:disabled {
     border-radius: 5px 5px 0 0;
     border-width: 1px;
     border-bottom-width: 1px;
@@ -5943,12 +5759,12 @@ GtkStack .linked.vertical GtkToggleButton.button:insensitive {
     padding: 3px 5px;
 }
 
-GtkStack .linked.vertical .button:last-child,
-GtkStack .linked.vertical .button:hover:last-child,
-GtkStack .linked.vertical .button:focus:last-child,
-GtkStack .linked.vertical .button:focus:hover:last-child,
-GtkStack .linked.vertical .button:checked:last-child,
-GtkStack .linked.vertical .button:insensitive:last-child {
+stack .linked.vertical .button:last-child,
+stack .linked.vertical .button:hover:last-child,
+stack .linked.vertical .button:focus:last-child,
+stack .linked.vertical .button:focus:hover:last-child,
+stack .linked.vertical .button:checked:last-child,
+stack .linked.vertical .button:disabled:last-child {
     border-radius: 0 0 5px 5px;
     border-width: 1px;
     border-top-width: 0;
@@ -5956,12 +5772,12 @@ GtkStack .linked.vertical .button:insensitive:last-child {
     padding: 5px 5px;
 }
 
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton:hover,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton:focus,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton:active,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton:checked,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton:insensitive {
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton:hover,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton:focus,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton:active,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton:checked,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton:disabled {
     border-radius: 0px;
     border-width: 1px;
     border-style: solid;
@@ -5969,26 +5785,26 @@ GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton:insensitive 
 }
 
 /* all to zero */
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:last-child,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:hover,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:hover:last-child,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:hover:active,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:hover:active:last-child,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:focus,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:focus:last-child,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:focus:hover,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:focus:hover:last-child,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:focus:hover:active,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:focus:hover:active:last-child,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:checked,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:checked:last-child,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:checked:hover,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:checked:hover:last-child,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:checked:focus:hover:active,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:checked:focus:hover:active:last-child,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:insensitive,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:first-child:insensitive {
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:last-child,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:hover,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:hover:last-child,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:hover:active,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:hover:active:last-child,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:focus,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:focus:last-child,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:focus:hover,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:focus:hover:last-child,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:focus:hover:active,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:focus:hover:active:last-child,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:checked,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:checked:last-child,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:checked:hover,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:checked:hover:last-child,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:checked:focus:hover:active,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:checked:focus:hover:active:last-child,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:disabled,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:first-child:disabled {
     border-radius: 0px;
     border-width: 0px;
     border-style: none;
@@ -5999,28 +5815,28 @@ GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:firs
     box-shadow: none;
 }
 
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:hover,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:focus:hover,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:focus,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:checked {
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:hover,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:focus:hover,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:focus,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:checked {
     border-width: 0 1px 0 1px;
     border-style: solid;
     border-color: shade(@notebook_border, 1.0);
 }
 
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:last-child,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:hover:last-child,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:focus:hover:last-child,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:focus:last-child,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:checked:last-child {
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:last-child,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:hover:last-child,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:focus:hover:last-child,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:focus:last-child,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:checked:last-child {
     border-width: 0px;
 }
 
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:hover,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:focus:hover,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:hover:last-child,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:focus:hover:last-child {
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:hover,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:focus:hover,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:hover:last-child,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:focus:hover:last-child {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade(@button_gradient1, 1.03)),
@@ -6029,8 +5845,8 @@ GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:focu
                                      to   (shade(@button_gradient4, 1.01)));
 }
 
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:active,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:active:last-child {
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:active,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:active:last-child {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade (@theme_bg_color, 1.20)),
@@ -6039,17 +5855,17 @@ GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:acti
                                      to (shade (@theme_bg_color, 0.80)));
 }
 
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:active,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:hover,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:focus:hover {
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:active,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:hover,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:focus:hover {
     border-width: 1px;
     border-style: solid;
     border-color: shade(@button_border_active, 1.0);
 }
 
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:active:last-child,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:hover:last-child,
-GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:focus:hover:last-child {
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:active:last-child,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:hover:last-child,
+stack .linked.vertical spinbutton.horizontal.entry.spinbutton .button:focus:hover:last-child {
     border-width: 1px;
     border-style: solid;
     border-width: 1px 1px 1px 0;
@@ -6059,36 +5875,36 @@ GtkStack .linked.vertical GtkSpinButton.horizontal.entry.spinbutton .button:focu
  * print dialog *
  ****************/
 
-GtkPrintUnixDialog.background .vertical.view.dialog-vbox {
+printdialog.background .vertical.view.dialog-vbox {
     background-color: shade (@theme_bg_color, 1.0);
 }
 
-GtkPrintUnixDialog.background .notebook {
+printdialog.background notebook {
     border-width: 0px 1px 1px 1px;
     border-radius: 0px 0px 4px 4px;
 }
 
-GtkPrintUnixDialog.background .notebook.header {
+printdialog.background notebook.header {
     border-radius: 0px;
 }
 
-GtkPrintUnixDialog.background .notebook tab GtkLabel {
+printdialog.background notebook tab label {
     color: mix (@theme_fg_color, @theme_bg_color, 0.40);
     font-weight: normal;
 }
 
-GtkPrintUnixDialog.background .notebook .prelight-page,
-GtkPrintUnixDialog.background .notebook .prelight-page GtkLabel {
+printdialog.background notebook .prelight-page,
+printdialog.background notebook .prelight-page label {
     color: mix (@theme_fg_color, @theme_bg_color, 0.15);
 }
 
-GtkPrintUnixDialog.background .notebook .active-page,
-.notebook tab .active-page GtkLabel {
+printdialog.background notebook .active-page,
+notebook tab .active-page label {
     color: @theme_fg_color;
 }
 
-GtkPrintUnixDialog.background .notebook tab.top:active,
-GtkPrintUnixDialog.background .notebook tab.top:hover:active {
+printdialog.background notebook tab.top:active,
+printdialog.background notebook tab.top:hover:active {
     background-image: linear-gradient(to bottom,
                                       shade(@theme_bg_color, 1.18),
                                       shade(@theme_bg_color, 1.1));
@@ -6099,7 +5915,7 @@ GtkPrintUnixDialog.background .notebook tab.top:hover:active {
     box-shadow: none;
 }
 
-GtkPrintUnixDialog.background .notebook tab.top:hover {
+printdialog.background notebook header.top tab:hover {
     background-image: linear-gradient(to bottom,
                                       alpha(@theme_base_color, 0.0),
                                       alpha(@theme_base_color, 0.3));
@@ -6110,15 +5926,15 @@ GtkPrintUnixDialog.background .notebook tab.top:hover {
     box-shadow: none;
 }
 
-GtkPrintUnixDialog.background .notebook tab.top:active {
+printdialog.background notebook header.top tab:active {
     border-bottom-color: @notebook_active_tab_border;
 }
 
-GtkPrintUnixDialog.background .notebook .text-button {
+printdialog.background notebook .text-button {
     background-color: transparent;
 }
 
-GtkPrintUnixDialog.background .vertical.view.dialog-vbox .notebook GtkToggleButton.button {
+printdialog.background .vertical.view.dialog-vbox notebook togglebutton.button {
     padding: 4px;
     border-radius: 4px;
 }
@@ -6127,37 +5943,37 @@ GtkPrintUnixDialog.background .vertical.view.dialog-vbox .notebook GtkToggleButt
  * GtkFileChooser *
  ******************/
 
-GtkFileChooserWidget.vertical GtkPaned.horizontal {
+filechooser.vertical paned.horizontal {
     -GtkPaned-handle-size: 3px;
     border-color: transparent;
 }
 
 /* workaround for broken first/last-child logic with linked buttons
    in pathbar with gtk+-3.18 */
-.path-bar.linked .button:dir(ltr),
-.path-bar.linked .button:dir(ltr):hover,
-.path-bar.linked .button:dir(ltr):hover:active,
-.path-bar.linked .button:dir(ltr):checked,
-.path-bar.linked .button:dir(ltr):checked:hover,
-.path-bar.linked .button:dir(ltr):checked:hover:active,
-.path-bar.linked .button:dir(ltr):first-child,
-.path-bar.linked .button:dir(ltr):hover:first-child,
-.path-bar.linked .button:dir(ltr):hover:active:first-child,
-.path-bar.linked .button:dir(ltr):checked:first-child,
-.path-bar.linked .button:dir(ltr):checked:hover:first-child,
-.path-bar.linked .button:dir(ltr):checked:hover:active:first-child,
-.path-bar.linked .button:dir(ltr):last-child,
-.path-bar.linked .button:dir(ltr):hover:last-child,
-.path-bar.linked .button:dir(ltr):hover:active:last-child,
-.path-bar.linked .button:dir(ltr):checked:last-child,
-.path-bar.linked .button:dir(ltr):checked:hover:last-child,
-.path-bar.linked .button:dir(ltr):checked:hover:active:last-child {
+.path-bar.linked button:dir(ltr),
+.path-bar.linked button:dir(ltr):hover,
+.path-bar.linked button:dir(ltr):hover:active,
+.path-bar.linked button:dir(ltr):checked,
+.path-bar.linked button:dir(ltr):checked:hover,
+.path-bar.linked button:dir(ltr):checked:hover:active,
+.path-bar.linked button:dir(ltr):first-child,
+.path-bar.linked button:dir(ltr):hover:first-child,
+.path-bar.linked button:dir(ltr):hover:active:first-child,
+.path-bar.linked button:dir(ltr):checked:first-child,
+.path-bar.linked button:dir(ltr):checked:hover:first-child,
+.path-bar.linked button:dir(ltr):checked:hover:active:first-child,
+.path-bar.linked button:dir(ltr):last-child,
+.path-bar.linked button:dir(ltr):hover:last-child,
+.path-bar.linked button:dir(ltr):hover:active:last-child,
+.path-bar.linked button:dir(ltr):checked:last-child,
+.path-bar.linked button:dir(ltr):checked:hover:last-child,
+.path-bar.linked button:dir(ltr):checked:hover:active:last-child {
 	border-width: 1px 0 1px 0px;
 	border-radius: 3px;
     padding: 0px 4px;
 }
 
-.path-bar.linked .button  {
+.path-bar.linked button  {
     box-shadow: inset  0px  2px alpha(#fff, 0.11),
                 inset  2px  0px alpha(#fff, 0.09),
                 inset -2px  0px alpha(#fff, 0.09),
@@ -6168,9 +5984,9 @@ GtkFileChooserWidget.vertical GtkPaned.horizontal {
                 inset  0px -1px alpha(shade(@button_border, 0.88), 0.90);
 }
 
-.path-bar.linked .button:hover,
-.path-bar.linked .button:checked,
-.path-bar.linked .button:checked:active {
+.path-bar.linked button:hover,
+.path-bar.linked button:checked,
+.path-bar.linked button:checked:active {
     box-shadow: inset  0px  1px shade(@selected_bg_color, 1.05),
                 inset  1px  0px shade(@selected_bg_color, 0.97),
                 inset -1px  0px shade(@selected_bg_color, 0.93),
@@ -6227,4 +6043,3 @@ GtkFileChooserWidget.vertical GtkPaned.horizontal {
 .floating-bar.bottom.left {
     box-shadow: inset -1px 1px alpha(#fff, 0.07);
 }
-

--- a/desktop-themes/Green-Submarine/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/Green-Submarine/gtk-3.0/gtk-widgets.css
@@ -9,20 +9,20 @@
     background-clip: padding-box;
     /*-GtkButton-default-border: 0;
     -GtkButton-child-displacement-x: 1;
-    -GtkButton-child-displacement-y: 1;*/
+    -GtkButton-child-displacement-y: 1;
     -GtkButton-image-spacing: 0;
     -GtkButton-interior-focus: true;
-    -GtkButton-inner-border: 3;
+    -GtkButton-inner-border: 3;*/
     -GtkButtonBox-child-min-height: 26;
-    -GtkCheckButton-indicator-size: 16;
-    -GtkCheckMenuItem-indicator-size: 12;
+    /*-GtkCheckButton-indicator-size: 16;
+    -GtkCheckMenuItem-indicator-size: 12;*/
     -GtkComboBox-arrow-scaling: 0.75;
     -GtkDialog-button-spacing: 4; /* ie. logout dialog */
     -GtkDialog-action-area-border: 10; /* ie. logout dialog */
     -GtkExpander-expander-size: 14;
     -GtkHTML-link-color: @link_color;
     -GtkIMHtml-hyperlink-color: @link_color;
-/*    -GtkMenu-horizontal-padding: 0;
+     /* -GtkMenu-horizontal-padding: 0;
     -GtkMenu-vertical-padding: 0;       */
     -GtkMenuBar-internal-padding: 0;
     -GtkPaned-handle-size: 1;
@@ -765,10 +765,10 @@ button {
 
 button {
     transition: all 400ms ease-out;
-    -GtkButton-image-spacing: 4;
+    /*-GtkButton-image-spacing: 4;
     -GtkButton-interior-focus: true;
-   /* -GtkButton-default-border: 0;*/
-    -GtkButton-inner-border: 3;
+    -GtkButton-default-border: 0;
+    -GtkButton-inner-border: 3;*/
     -GtkArrow-arrow-scaling: 0.5;
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,

--- a/desktop-themes/Green-Submarine/gtk-3.0/mate-applications.css
+++ b/desktop-themes/Green-Submarine/gtk-3.0/mate-applications.css
@@ -5,18 +5,19 @@
 /**** Window ***/
 
 /* background of all views */
-CajaNavigationWindow .view {
+/*Caja icon views-these are widgets w/o css nodes or valid names, .view is applied only to */
+window.background>*>paned>box>paned>box>notebook>stack>box>box>scrolledwindow.frame {
     background-color: shade (@base_color, 1.0);
     color: @theme_fg_color;
 }
 
-/* since gtk+-3.18 */
-CajaNavigationWindow FMListView .view {
+/* Caja list view */
+window.background>*>paned>box>paned>box>notebook>stack>box>box>scrolledwindow>*>treeview.view{
     background-color: shade (@base_color, 1.0);
 }
 
 /* caja sidebar */
-CajaWindow FMTreeView .view,
+window.background*>paned>box>notebook>stack>scrolledwindow.frame treeview.view,
 CajaWindow CajaNotesViewer .view,
 CajaWindow CajaPlacesSidebar .view,
 CajaWindow CajaHistorySidebar .view,
@@ -26,8 +27,8 @@ CajaWindow CajaInformationPanel .vertical {
 }
 
 /* the small line between sidebar and view */
-CajaWindow GtkPaned.horizontal {
-    -GtkPaned-handle-size: 3px;
+CajaWindow paned.horizontal {
+    -paned-handle-size: 3px;
     border-color: transparent;
 }
 
@@ -78,16 +79,16 @@ CajaWindow CajaEmblemSidebar .scrollbar {
     -GtkScrolledWindow-scrollbars-within-bevel: 1;
 }
 
-CajaWindow FMTreeView .scrollbar.trough,
-CajaWindow CajaNotesViewer .scrollbar.trough,
-CajaWindow CajaPlacesSidebar .scrollbar.trough,
-CajaWindow CajaHistorySidebar .scrollbar.trough,
-CajaWindow CajaEmblemSidebar .scrollbar.trough,
-CajaWindow FMTreeView .scrollbar.trough.vertical,
-CajaWindow CajaNotesViewer .scrollbar.trough.vertical,
-CajaWindow CajaPlacesSidebar .scrollbar.trough.vertical,
-CajaWindow CajaHistorySidebar .scrollbar.trough.vertical,
-CajaWindow CajaEmblemSidebar .scrollbar.trough.vertical {
+CajaWindow FMTreeView scrollbar trough,
+CajaWindow CajaNotesViewer  scrollbar trough,
+CajaWindow CajaPlacesSidebar  scrollbar trough,
+CajaWindow CajaHistorySidebar  scrollbar trough,
+CajaWindow CajaEmblemSidebar  scrollbar trough,
+CajaWindow FMTreeView  scrollbar trough.vertical,
+CajaWindow CajaNotesViewer  scrollbar trough.vertical,
+CajaWindow CajaPlacesSidebar  scrollbar trough.vertical,
+CajaWindow CajaHistorySidebar  scrollbar trough.vertical,
+CajaWindow CajaEmblemSidebar  scrollbar trough.vertical {
     background-image: -gtk-gradient (linear, left top, left bottom,
                                     from (shade (@theme_bg_color, 0.98)),
                                     to (shade (@theme_bg_color, 1.06)));
@@ -403,8 +404,8 @@ CajaTrashBar .button *:checked:hover {
     text-shadow: 0px 1px @theme_shadow_color;
 }
 
-.question .button:insensitive,
-CajaTrashBar .button:insensitive {
+.question .button:disabled,
+CajaTrashBar .button:disabled {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade(@nautilus_cluebar_color, 0.95)),
@@ -417,8 +418,8 @@ CajaTrashBar .button:insensitive {
                 inset  0px -1px shade(@nautilus_cluebar_color, 0.78);
 }
 
-.question .button *:insensitive,
-CajaTrashBar .button *:insensitive {
+.question .button *:disabled,
+CajaTrashBar .button *:disabled {
     color: mix(@nautilus_cluebar_color, @theme_fg_color, 0.50);
     text-shadow: none;
 }
@@ -576,14 +577,14 @@ FMPropertiesWindow .vertical.dialog-vbox .notebook GtkViewport {
 /* tab styling */
 CajaNavigationWindow CajaNotebook.notebook {
     border-style: none;
-    -GtkNotebook-tab-overlap: 1;
+    /*-GtkNotebook-tab-overlap: 1; */
 }
 
-CajaNavigationWindow GtkPaned.horizontal GtkPaned.horizontal .vertical tab.top,
-CajaNavigationWindow GtkPaned.horizontal GtkPaned.horizontal .vertical tab.top:active,
-CajaNavigationWindow GtkPaned.horizontal GtkPaned.horizontal .vertical tab.top:active:hover,
-CajaNavigationWindow GtkPaned.horizontal GtkPaned.horizontal .vertical tab.reorderable-page,
-CajaNavigationWindow GtkPaned.horizontal GtkPaned.horizontal .vertical tab.reorderable-page:hover {
+CajaNavigationWindow paned.horizontal paned.horizontal .vertical tab.top,
+CajaNavigationWindow paned.horizontal paned.horizontal .vertical tab.top:active,
+CajaNavigationWindow paned.horizontal paned.horizontal .vertical tab.top:active:hover,
+CajaNavigationWindow paned.horizontal paned.horizontal .vertical tab.reorderable-page,
+CajaNavigationWindow paned.horizontal paned.horizontal .vertical tab.reorderable-page:hover {
     border-radius: 4px 4px 0px 0px;
     border-width: 1px 1px 0px 1px;
     border-color: @notebook_border;
@@ -603,7 +604,7 @@ CajaNavigationWindow CajaNotebook.notebook tab .button.flat {
 }
 
 EelEditableLabel.entry,
-EelEditableLabel.entry:focused {
+EelEditableLabel.entry:focus {
    border-image: none;
    border-width: 1px;
    border-color: @theme_fg_color;
@@ -617,14 +618,14 @@ EelEditableLabel.entry:focused {
 }
 
 /* desktop mode */
-CajaDesktopWindow.background .caja-canvas-item {
+window>*>box>box>box>scrolledwindow>.view .caja-canvas-item {
     color: white;
     text-shadow: 1px 1px alpha (#000000, 0.8);
 }
 
-CajaDesktopWindow.background .caja-canvas-item:active,
-CajaDesktopWindow.background .caja-canvas-item:prelight,
-CajaDesktopWindow.background .caja-canvas-item:selected {
+window>*>box>box>box>scrolledwindow>.view .caja-canvas-item:active,
+window>*>box>box>box>scrolledwindow>.view .caja-canvas-item:hover,
+window>*>box>box>box>scrolledwindow>.view .caja-canvas-item:selected {
     text-shadow: none;
 }
 
@@ -633,15 +634,17 @@ CajaDesktopWindow.background .caja-canvas-item:selected {
  ****************/
 
 /* first make all transparent */
+.mate-panel-menu-bar,
 PanelToplevel.background.horizontal {
     background-color: transparent;
 }
 
+.mate-panel-menu-bar .menubar,
 WnckSelector.menubar,
 PanelMenuBar.menubar,
-WnckSelector GtkMenuItem,
-PanelMenuBar GtkMenuItem,
-MatePanelApplet GtkToggleButton.button {
+WnckSelector menuitem,
+PanelMenuBar menuitem,
+#PanelApplet togglebutton.button {
     border-image: none;
     background-image: none;
     background-color: transparent;
@@ -713,11 +716,11 @@ GdictApplet .entry {
     padding: 3px 4px;
 }
 
-MatePanelApplet {
+#PanelApplet {
     border-width: 0;
 }
 
-MatePanelAppletFrameDBus PanelSeparator,
+#PanelAppletFrameDBus PanelSeparator,
 PanelSeparator {
     border-width: 0;
     background-image: -gtk-gradient (linear, left top, left bottom,
@@ -728,7 +731,7 @@ PanelSeparator {
 }
 
 /* the grid left from wnckpager and wncktasklist */
-MatePanelAppletFrameDBus {
+#PanelAppletFrameDBus {
     background-image: -gtk-scaled(url("assets/panel-grid.svg"));
     background-color: transparent;
     background-repeat: no-repeat;
@@ -806,8 +809,9 @@ PanelMenuButton .menu .menuitem:hover {
 /* desktop-applet, clockapplet, drivemount, character-map,
 dictionary */
 
-MatePanelApplet .button,
-MatePanelApplet .button.flat {
+.mate-panel-menu-bar button,
+#PanelApplet .button,
+#PanelApplet .button.flat {
     background-image: none;
     background-color: transparent;
 /*    border-color: shade (@theme_selected_bg_color, 1.30); */
@@ -821,12 +825,12 @@ MatePanelApplet .button.flat {
     padding: 6px;
 }
 
-MatePanelApplet .button:hover:active,
-MatePanelApplet .button:checked,
-MatePanelApplet .button:checked:hover,
-MatePanelApplet .button.flat:hover:active,
-MatePanelApplet .button.flat:checked,
-MatePanelApplet .button.flat:checked:hover {
+#PanelApplet button:hover:active,
+#PanelApplet button:checked,
+#PanelApplet button:checked:hover,
+#PanelApplet button.flat:hover:active,
+#PanelApplet button.flat:checked,
+#PanelApplet button.flat:checked:hover {
     background-image: none;
     border-color: @selected_bg_color;
     background-color: shade (@selected_bg_color, 0.70);
@@ -837,8 +841,8 @@ MatePanelApplet .button.flat:checked:hover {
     padding: 6px;
 }
 
-MatePanelApplet .button:hover,
-MatePanelApplet .button.flat:hover {
+#PanelApplet button:hover,
+#PanelApplet button.flat:hover {
     background-image: none;
     border-color: @selected_bg_color;
     background-color: shade (@selected_bg_color, 1.10);
@@ -850,12 +854,12 @@ MatePanelApplet .button.flat:hover {
 }
 
 /* drivemount */
-DriveList .button,
-DriveList .button.flat,
-DriveList .button:hover,
-DriveList .button.flat:hover,
-DriveList .button:checked,
-DriveList .button.flat:checked {
+DriveList button,
+DriveList button.flat,
+DriveList button:hover,
+DriveList button.flat:hover,
+DriveList button:checked,
+DriveList button.flat:checked {
     padding: 4px;
     border-radius: 5px;
     border-color: transparent;
@@ -863,8 +867,8 @@ DriveList .button.flat:checked {
 }
 
 /*Wncklist */
-WnckTasklist .button,
-WnckTasklist .button.flat {
+.mate-panel-menu-bar #PanelPlug #PanelApple button,
+.mate-panel-menu-bar #PanelPlug #PanelApplet button.flat {
     background-image: none;
     background-color: transparent;
     border-radius: 5px;
@@ -874,14 +878,15 @@ WnckTasklist .button.flat {
     padding: 2px;
 }
 
-WnckTasklist .button:hover:active,
-WnckTasklist .button:checked,
-WnckTasklist .button:checked:hover,
-WnckTasklist .button.flat:hover:active,
-WnckTasklist .button.flat:checked:hover,
-WnckTasklist .button.flat:checked {
+.mate-panel-menu-bar #PanelPlug #PanelApplet button:hover:active,
+.mate-panel-menu-bar #PanelPlug #PanelApplet button:checked,
+.mate-panel-menu-bar #PanelPlug #PanelApplet button:checked:hover,
+.mate-panel-menu-bar #PanelPlug #PanelApplet button.flat:hover:active,
+.mate-panel-menu-bar #PanelPlug #PanelApplet button.flat:checked:hover,
+.mate-panel-menu-bar #PanelPlug #PanelApplet button.flat:checked {
     background-image: none;
-    border-color: @selected_bg_color;
+    /*border-color: @selected_bg_color;*/
+	border-color:transparent;          /*can't match gtk3.18 perfect, the drawing is different*/
     background-color: shade (@selected_bg_color, 0.70);
     border-radius: 5px;
     border-width: 1px;
@@ -890,8 +895,9 @@ WnckTasklist .button.flat:checked {
     padding: 2px;
 }
 
-WnckTasklist .button:hover,
-WnckTasklist .button.flat:hover {
+
+.mate-panel-menu-bar #PanelPlug #PanelApplet button:hover,
+.mate-panel-menu-bar #PanelPlug #PanelApplet button.flat:hover {
     background-image: none;
     border-color: @selected_bg_color;
     background-color: shade (@selected_bg_color, 1.10);
@@ -903,7 +909,7 @@ WnckTasklist .button.flat:hover {
 }
 
 /* set normal button WnckSelector */
-WnckSelector.menubar .menuitem {
+.mate-panel-menu-bar menubar menuitem {
     background-image: none;
     background-color: transparent;
     border-style: none;
@@ -912,7 +918,7 @@ WnckSelector.menubar .menuitem {
 }
 
 /* set selected button WnckSelector */
-WnckSelector.menubar .menuitem:hover {
+.mate-panel-menu-bar menubar menuitem:hover {
     background-image: none;
     border-color: @selected_bg_color;
     background-color: shade (@selected_bg_color, 0.70);
@@ -923,7 +929,7 @@ WnckSelector.menubar .menuitem:hover {
 }
 
 /* set WnckSelector selected menuitem */
-WnckSelector.menubar .menu .menuitem:hover {
+.mate-panel-menu-bar menubar menuitem:hover {
     background-color: shade (@theme_bg_dark_color, 1.2);
     color: shade (@theme_selected_bg_color, 1.3);
     background-image: none;
@@ -937,7 +943,7 @@ WnckSelector.menubar .menu .menuitem:hover {
 
 ClockBox,
 .mate-panel-menu-bar.menubar,
-MatePanelApplet > GtkMenuBar.menubar {
+#PanelApplet > GtkMenuBar.menubar {
     font: normal;
 }
 
@@ -974,7 +980,7 @@ NaTrayApplet {
 }
 
 /* system-monitor-applet */
-MatePanelApplet .horizontal .vertical .frame {
+#PanelApplet .horizontal .vertical .frame {
     box-shadow: inset  0px  1px shade (@menu_bg_dark_color, 1.3),
                 inset  1px  0px shade (@menu_bg_dark_color, 1.3),
                 inset -1px  0px shade (@menu_bg_dark_color, 1.3),
@@ -1022,7 +1028,7 @@ MatePanelApplet .horizontal .vertical .frame {
     margin: 0px;
 }
 
-.mate-panel-applet-slider .frame .button:insensitive {
+.mate-panel-applet-slider .frame .button:disabled {
     box-shadow: none;
 }
 
@@ -1103,7 +1109,7 @@ PlumaWindow .button.flat:hover {
 /* notebook text area */
 PlumaWindow .notebook {
     border-style: none;
-    -GtkNotebook-tab-overlap: 1;
+   /* -GtkNotebook-tab-overlap: 1;*/
 }
 
 PlumaWindow .notebook tab.top {
@@ -1201,7 +1207,7 @@ PlumaPanel.vertical PlumaCloseButton.button.flat {
 PlumaPanel.vertical PlumaCloseButton.button.flat:hover {
     border-radius: 4px;
     border-style: none;
-    -gtk-image-effect: highlight;
+    /*-gtk-image-effect: highlight;*/
     box-shadow: inset  0px  1px shade(@selected_bg_color, 1.05),
                 inset  1px  0px shade(@selected_bg_color, 0.97),
                 inset -1px  0px shade(@selected_bg_color, 0.93),
@@ -1212,7 +1218,7 @@ PlumaPanel.vertical .notebook {
     border-radius: 0px;
 }
 
-PlumaFileBrowserWidget.vertical GtkToggleButton.button {
+PlumaFileBrowserWidget.vertical togglebutton.button {
     padding: 4px ;
 }
 
@@ -1345,7 +1351,7 @@ EvWindow .toolbar .button.flat {
     padding: 0px 4px;
 }
 
-EvWindow .vertical.primary-toolbar .horizontal.toolbar EphyZoomControl GtkToggleButton:prelight.button {
+EvWindow .vertical.primary-toolbar .horizontal.toolbar EphyZoomControl togglebutton:hover.button {
     padding: 4px;
     border-radius: 4px;
 }
@@ -1414,7 +1420,6 @@ EomThumbNav .button.flat:hover {
                 inset  0px -1px shade(@selected_bg_color, 0.93);
 }
 
-EomThumbNav .button.flat:insensitive {
+EomThumbNav .button.flat:disabled {
     border-color: transparent;
 }
-

--- a/desktop-themes/Green-Submarine/gtk-3.0/mate-applications.css
+++ b/desktop-themes/Green-Submarine/gtk-3.0/mate-applications.css
@@ -2,15 +2,7 @@
  * CAJA File manager *
  *********************/
 
-/**** Desktop View ***/
-
-/* do not flash the desktop with a color during theme switching */
-CajaDesktopWindow FMDesktopIconView .view {
-    background-color: transparent;
-    background-image: none;
-}
-
-/**** View ***/
+/**** Window ***/
 
 /* background of all views */
 CajaNavigationWindow .view {
@@ -22,8 +14,6 @@ CajaNavigationWindow .view {
 CajaNavigationWindow FMListView .view {
     background-color: shade (@base_color, 1.0);
 }
-
-/**** Window ***/
 
 /* caja sidebar */
 CajaWindow FMTreeView .view,
@@ -611,32 +601,33 @@ CajaNavigationWindow CajaNotebook.notebook tab .button.flat {
     padding: 0px;
     border-radius: 4px;
 }
-/*
+
+EelEditableLabel.entry,
+EelEditableLabel.entry:focused {
+   border-image: none;
+   border-width: 1px;
+   border-color: @theme_fg_color;
+   box-shadow: none;
+   border-radius: 3px;
+   text-shadow: none;
+}
+
 .caja-canvas-item {
-    border-radius: 3px;
+    border-radius: 4px;
 }
 
-*//* desktop mode *//*
-.caja-desktop.caja-canvas-item {
+/* desktop mode */
+CajaDesktopWindow.background .caja-canvas-item {
     color: white;
-    text-shadow: 1px 1px black;
+    text-shadow: 1px 1px alpha (#000000, 0.8);
 }
 
-.caja-desktop.caja-canvas-item:checked {
-    background-image: none;
-    color: @theme_text_color;
-}
-
-.caja-desktop.caja-canvas-item:selected {
-    color: @theme_selected_fg_color;
-}
-
-.caja-desktop.caja-canvas-item:checked,
-.caja-desktop.caja-canvas-item:prelight,
-.caja-desktop.caja-canvas-item:selected {
+CajaDesktopWindow.background .caja-canvas-item:active,
+CajaDesktopWindow.background .caja-canvas-item:prelight,
+CajaDesktopWindow.background .caja-canvas-item:selected {
     text-shadow: none;
 }
-*/
+
 /****************
  * Mate-Panel *
  ****************/

--- a/desktop-themes/Green-Submarine/gtk-3.0/menu.css
+++ b/desktop-themes/Green-Submarine/gtk-3.0/menu.css
@@ -3,8 +3,8 @@
  *
  *************************/
 
-.toolbar .raised .menu,
-.menu {
+toolbar .raised  menu,
+menu {
     /* menu contextual */
     background-color: @menu_bg_dark_color;
     background-image: -gtk-gradient (linear,
@@ -18,25 +18,25 @@
     border-image: none;
 }
 
-.menu:selected {
+menu:selected {
     background-color: @theme_selected_bg_color;
 }
 
-GtkMenuItem,
-GtkMenuItem:insensitive {
+menuitem,
+menuitem:disabled {
     background-color: @menu_bg_dark_color;
 }
 
-.menubar .menu.button:hover,
-.menubar .menu.button:active,
-.menubar .menu.button:active:insensitive,
-.menubar .menu.button:insensitive,
-.menubar .menu.button,
-.primary-toolbar .menu.button:hover,
-.primary-toolbar .menu.button:active,
-.primary-toolbar .menu.button:active:insensitive,
-.primary-toolbar .menu.button:insensitive,
-.primary-toolbar .menu.button {
+menubar  menu button:hover,
+menubar  menu button:active,
+menubar  menu button:active:disabled,
+menubar  menu button:disabled,
+menubar  menu button,
+primary-toolbar  menu button:hover,
+primary-toolbar  menu button:active,
+primary-toolbar  menu button:active:disabled,
+primary-toolbar  menu button:disabled,
+primary-toolbar  menu button {
     background-color: shade (@menu_bg_dark_color, 1.07);
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
@@ -48,7 +48,7 @@ GtkMenuItem:insensitive {
     border-image: none;
 }
 
-.menu.button {
+menu button {
     padding: 0px;
     background-image: none;
     background-color: shade (@menu_bg_dark_color, 0.95);
@@ -58,14 +58,20 @@ GtkMenuItem:insensitive {
     border-style: none;
 }
 
-.menu.button GtkArrow {
+menu button arrow {
     color: @menu_fg_dark_color;
 }
+
+menuitem check, menuitem radio {
+  min-height: 16px;
+  min-width: 16px;
+}
+
 
 /***********
  * menubar *
  ***********/
-.menubar {
+menubar {
     -GtkWidget-window-dragging: true;
     /* line 3D  (dark) */
     box-shadow: inset  0px -1px @menu_line_dark_color;
@@ -82,15 +88,15 @@ GtkMenuItem:insensitive {
 /***************
  * menubaritem *
  ***************/
-.menubar.menuitem  {
+menubar menuitem  {
     padding: 5px 5px;
     transition: all 300ms ease-out;
     border-radius: 0px;
     border-width: 0px;
 }
 
-.menubar.menuitem:hover,
-.menubar .menuitem:hover {
+menubar menuitem:hover,
+menubar  menuitem:hover {
     padding: 5px 5px;
     background-color: shade (@theme_bg_dark_color, 1.2);
     border-radius: 5px;
@@ -101,39 +107,39 @@ GtkMenuItem:insensitive {
 /************
  * menuitem *
  ************/
-.menubar .menuitem {
+menubar  menuitem {
     padding: 5px 5px;
     transition: all 300ms ease-out;
     color: @theme_fg_dark_color;
     text-shadow: 1px 1px @theme_shadow_dark_color;
 }
 
-Genericmenuitem .menuitem *,
-DbusmenuGtkMenu .menuitem *,
-.toolbar .raised .button .menuitem *,
-.toolbar.menubar .button .menuitem *,
-.toolbar .menuitem *,
-.primary-toolbar .menuitem *,
-.primary-toolbar .button .menuitem *,
-.menu .menuitem *, 
-.menuitem {
+/*Genericmenuitem  menuitem *,
+DbusmenuGtkMenu  menuitem *, */
+toolbar .raised  button  menuitem *,
+toolbar menubar  button  menuitem *,
+toolbar  menuitem *,
+primary-toolbar  menuitem *,
+primary-toolbar  button  menuitem *,
+menu  menuitem *, 
+menuitem {
 /* Fix height change in nautilus menu item view options */
     padding: 0px;
     border-width: 0px;
 }
-
-Genericmenuitem .menuitem,
-DbusmenuGtkMenu .menuitem,
-.toolbar .raised .button .menuitem,
-.toolbar.menubar .button .menuitem,
-.toolbar.menubar .linked .button .menuitem,
-.toolbar .menuitem,
-.primary-toolbar .menuitem,
-.primary-toolbar .button .menuitem,
-.menu .menuitem, 
-.menuitem {
+/*
+Genericmenuitem  menuitem,
+DbusmenuGtkMenu  menuitem,*/
+toolbar .raised  button  menuitem,
+toolbar menubar  button  menuitem,
+toolbar menubar .linked  button  menuitem,
+toolbar  menuitem,
+primary-toolbar  menuitem,
+primary-toolbar  button  menuitem,
+menu  menuitem, 
+menuitem {
     transition: all 300ms ease-out;
-    -GtkMenuItem-arrow-scaling: 0.7;
+    -menuitem-arrow-scaling: 0.7;
     padding: 2px 4px;
     border-radius: 0px;
     color: @menu_fg_dark_color;
@@ -141,41 +147,41 @@ DbusmenuGtkMenu .menuitem,
     padding: 5px 5px;
 }
 
-.toolbar .menuitem GtkLabel,
-.primary-toolbar .menuitem GtkLabel,
-.toolbar .raised .button .menuitem GtkLabel,
-.toolbar.menubar .button .menuitem GtkLabel,
-.primary-toolbar .button .menuitem GtkLabel {
+toolbar  menuitem GtkLabel,
+primary-toolbar  menuitem GtkLabel,
+toolbar .raised  button  menuitem GtkLabel,
+toolbar menubar  button  menuitem GtkLabel,
+primary-toolbar  button  menuitem GtkLabel {
     color: @menu_fg_dark_color;
     text-shadow: 1px 1px @menu_shadow_dark_color;
 }
 
-GtkTreeMenu.menu {
+treemenu menu {
     background-color: @menu_bg_dark_color;
 }
 
-GtkTreeMenu .menuitem {
+treemenu  menuitem {
     border-style: none;
     border-width: 0px;
 }
 
-.toolbar GtkComboBox .menuitem,
-GtkComboBox .menuitem {
+toolbar combobox  menuitem,
+combobox  menuitem {
     transition: all 500ms ease-out;
     color: @menu_fg_dark_color;
     text-shadow: 0px 1px @menu_shadow_dark_color;
 }
 
-/* needed for .menuitem with gtk+-3.18 */
-GtkTreeMenu.menu .menuitem GtkCellView {
+/* needed for  menuitem with gtk+-3.18 */
+treemenu menu  menuitem cellview {
     background-image: none;
     background-color: transparent;
     color: @menu_fg_dark_color;
     text-shadow: 0px 1px @menu_shadow_dark_color;
 }
 
-GtkTreeMenu.menu .menuitem:hover,
-GtkComboBox .menuitem:hover {
+treemenu menu  menuitem:hover,
+combobox  menuitem:hover {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
                                      from (shade(@menu_bg_dark_color, 2.03)),
@@ -184,13 +190,13 @@ GtkComboBox .menuitem:hover {
     text-shadow: 0px 1px @theme_selected_shadow_color;
 }
 
-GtkTreeMenu.menu .menuitem:hover GtkCellView {
+treemenu menu  menuitem:hover cellview {
     color: shade (@theme_selected_bg_color, 1.3);
        text-shadow: 0px 1px @theme_selected_shadow_color;
 }
 
-.menuitem:hover,
-.menu .menuitem:hover {
+menuitem:hover,
+menu  menuitem:hover {
     /* contextual menu item-selected */
     background-color: shade (@theme_bg_dark_color, 1.2);
     background-image: -gtk-gradient (linear,
@@ -209,64 +215,64 @@ GtkTreeMenu.menu .menuitem:hover GtkCellView {
                 inset  0px -1px shade (@theme_selected_bg_color, 1.3);
 }
 
-.toolbar .menuitem *:hover,
-.primary-toolbar .toolbar .button .menuitem *:hover,
-.primary-toolbar.toolbar .button .menuitem *:hover,
-.toolbar .raised .button .menuitem *:hover, /* menuitem opciones visualizacion nautilus  */
-.toolbar.menubar .button .menuitem *:hover, 
-GtkComboBox .menuitem *:hover, 
-GtkTreeMenu .menuitem *:active,
-GtkTreeMenu .menuitem *:prelight,
-.menuitem *:active,
-.menuitem *:prelight,
-.menuitem *:hover, 
-.menuitem:hover,
-.menu .menuitem:hover {
+toolbar  menuitem *:hover,
+primary-toolbar  toolbar  button  menuitem *:hover,
+primary-toolbar toolbar  button  menuitem *:hover,
+toolbar .raised  button  menuitem *:hover, /* menuitem opciones visualizacion nautilus  */
+toolbar menubar  button  menuitem *:hover, 
+combobox  menuitem *:hover, 
+treemenu  menuitem *:active,
+treemenu  menuitem *:hover,
+menuitem *:active,
+ menuitem *:hover,
+ menuitem *:hover, 
+ menuitem:hover,
+ menu  menuitem:hover {
     color: shade (@theme_selected_bg_color, 1.3);
     text-shadow: 0px 1px @theme_selected_shadow_color;
 }
 
-.primary-toolbar .menuitem *:insensitive,
-.toolbar .raised .button .menuitem *:insensitive,
-.toolbar.menubar .button .menuitem *:insensitive,
-.primary-toolbar .button .menuitem *:insensitive,
-.toolbar .menuitem *:insensitive,
-.menuitem:insensitive,
-.menuitem *:insensitive {
+primary-toolbar  menuitem *:disabled,
+toolbar .raised  button  menuitem *:disabled,
+toolbar menubar  button  menuitem *:disabled,
+primary-toolbar  button  menuitem *:disabled,
+toolbar  menuitem *:disabled,
+menuitem:disabled,
+menuitem *:disabled {
     /* contextual menu insensitive */
     color: mix (@menu_fg_dark_color, @menu_bg_dark_color, 0.4);
     text-shadow: none;
 }
 
-.menuitem.check,
-.menuitem.radio,
-.menuitem.check:hover,
-.menuitem.radio:hover,
-.menuitem.check:insensitive,
-.menuitem.radio:insensitive,
-.menuitem.check:active:insensitive,
-.menuitem.radio:active:insensitive,
-.menuitem.check:checked:insensitive,
-.menuitem.radio:checked:insensitive,
-.menuitem.check:inconsistent:insensitive,
-.menuitem.radio:inconsistent:insensitive {
+menuitem check,
+menuitem radio,
+menuitem check:hover,
+menuitem radio:hover,
+menuitem check:disabled,
+menuitem radio:disabled,
+menuitem check:active:disabled,
+menuitem radio:active:disabled,
+menuitem check:checked:disabled,
+menuitem radio:checked:disabled,
+menuitem check:indeterminate:disabled,
+menuitem radio:indeterminate:disabled {
     border-width: 0px;
     border-style: none;
     background-image: none;
 }
 
-.toolbar .raised .button .menuitem.check:inconsistent,
-.toolbar .raised .button .menuitem.radio:inconsistent,
-.menuitem.check:inconsistent,
-.menuitem.radio:inconsistent,
-.toolbar .raised .button .menuitem.check:active,
-.toolbar .raised .button .menuitem.radio:active,
-.menuitem.check:active,
-.menuitem.radio:active,
-.toolbar .raised .button .menuitem.check:checked,
-.toolbar .raised .button .menuitem.radio:checked,
-.menuitem.check:checked,
-.menuitem.radio:checked {
+toolbar .raised  button  menuitem check:indeterminate,
+toolbar .raised  button  menuitem radio:indeterminate,
+menuitem check:indeterminate,
+menuitem radio:indeterminate,
+toolbar .raised  button  menuitem check:active,
+toolbar .raised  button  menuitem radio:active,
+menuitem check:active,
+menuitem radio:active,
+toolbar .raised  button  menuitem check:checked,
+toolbar .raised  button  menuitem radio:checked,
+menuitem check:checked,
+menuitem radio:checked {
     border-width: 0px;
     border-style: none;
     background-image: none;
@@ -275,47 +281,47 @@ GtkTreeMenu .menuitem *:prelight,
     color: @menu_fg_dark_color;
 }
 
-.toolbar .raised .button .menuitem.check:inconsistent:hover,
-.toolbar .raised .button .menuitem.radio:inconsistent:hover,
-.menuitem.check:inconsistent:hover,
-.menuitem.radio:inconsistent:hover,
-.toolbar .raised .button .menuitem.check:active:hover,
-.toolbar .raised .button .menuitem.radio:active:hover,
-.menuitem.check:active:hover,
-.menuitem.radio:active:hover,
-.toolbar .raised .button .menuitem.check:checked:hover,
-.toolbar .raised .button .menuitem.radio:checked:hover,
-.menuitem.check:checked:hover,
-.menuitem.radio:checked:hover {
+toolbar .raised  button  menuitem check:indeterminate:hover,
+toolbar .raised  button  menuitem radio:indeterminate:hover,
+menuitem check:indeterminate:hover,
+menuitem radio:indeterminate:hover,
+toolbar .raised  button  menuitem check:active:hover,
+toolbar .raised  button  menuitem radio:active:hover,
+menuitem check:active:hover,
+menuitem radio:active:hover,
+toolbar .raised  button  menuitem check:checked:hover,
+toolbar .raised  button  menuitem radio:checked:hover,
+menuitem check:checked:hover,
+menuitem radio:checked:hover {
     border-color: @theme_selected_fg_color;
     color: @theme_selected_fg_color;
 }
 
-.menuitem.arrow:hover {
+menuitem.arrow:hover {
     border-color: @theme_selected_fg_color;
     color: shade (@theme_selected_bg_color, 1.6);
 }
 
-.menuitem.check:insensitive,
-.menuitem.radio:insensitive,
-.menuitem.check:active:insensitive,
-.menuitem.radio:active:insensitive,
-.menuitem.check:checked:insensitive,
-.menuitem.radio:checked:insensitive,
-.menuitem.check:inconsistent:insensitive,
-.menuitem.radio:inconsistent:insensitive {
+menuitem check:disabled,
+menuitem radio:disabled,
+menuitem check:active:disabled,
+menuitem radio:active:disabled,
+menuitem check:checked:disabled,
+menuitem radio:checked:disabled,
+menuitem check:indeterminate:disabled,
+menuitem radio:indeterminate:disabled {
     color: mix (@menu_fg_dark_color, @menu_bg_dark_color, 0.6);
     text-shadow: none;
 }
 
-.menubar .menuitem GtkCalendar,
-.menubar .menuitem GtkCalendar.button,
-.menubar .menuitem GtkCalendar.header,
-.menubar .menuitem GtkCalendar.view,
-.primary-toolbar .menuitem GtkCalendar,
-.primary-toolbar .menuitem GtkCalendar.button,
-.primary-toolbar .menuitem GtkCalendar.header,
-.primary-toolbar .menuitem GtkCalendar.view {
+menubar  menuitem calendar,
+menubar  menuitem calendar button,
+menubar  menuitem calendar.header,
+menubar  menuitem calendar.view,
+primary-toolbar  menuitem calendar,
+primary-toolbar  menuitem calendar button,
+primary-toolbar  menuitem calendar.header,
+primary-toolbar  menuitem calendar.view {
     background-color: @menu_bg_dark_color;
     background-image: none;
     border-radius: 0;
@@ -325,13 +331,13 @@ GtkTreeMenu .menuitem *:prelight,
     color: @menu_fg_dark_color;
 }
 
-.menubar .menuitem GtkCalendar,
-.primary-toolbar .menuitem GtkCalendar {
+menubar  menuitem calendar,
+primary-toolbar  menuitem calendar {
     background-color: shade (@menu_bg_dark_color, 1.3);
     background-image: none;
 }
 
-.menubar .menuitem GtkScale.trough {
+menubar  menuitem GtkScale.trough {
     background-image: -gtk-gradient (linear,
                                      left top,
                                      left bottom,
@@ -345,32 +351,32 @@ GtkTreeMenu .menuitem *:prelight,
                 inset -1px -1px alpha(#000, 0.08);
 }
 
-
-Genericmenuitem .menuitem .accelerator,
-DbusmenuGtkMenu .menuitem .accelerator,
-.menubar .menuitem .accelerator,
-.primary-toolbar .menuitem .accelerator {
+/*
+Genericmenuitem  menuitem .accelerator,
+DbusmenuGtkMenu  menuitem .accelerator,*/
+menubar  menuitem .accelerator,
+primary-toolbar  menuitem .accelerator {
     color: alpha (@menu_fg_dark_color, 0.8);
 }
-
-Genericmenuitem .menuitem .accelerator:hover,
-DbusmenuGtkMenu .menuitem .accelerator:hover,
-.menubar .menuitem .accelerator:hover,
-.primary-toolbar .menuitem .accelerator:hover {
+/*
+Genericmenuitem  menuitem .accelerator:hover,
+DbusmenuGtkMenu  menuitem .accelerator:hover,*/
+menubar  menuitem .accelerator:hover,
+primary-toolbar  menuitem .accelerator:hover {
     color: alpha (@theme_selected_fg_color, 0.8);
 }
-
-Genericmenuitem .menuitem .accelerator:insensitive,
-DbusmenuGtkMenu .menuitem .accelerator:insensitive,
-.menubar .menuitem .accelerator:insensitive,
-.primary-toolbar .menuitem .accelerator:insensitive {
+/*
+Genericmenuitem  menuitem .accelerator:disabled,
+DbusmenuGtkMenu  menuitem .accelerator:disabled,*/
+menubar  menuitem .accelerator:disabled,
+primary-toolbar  menuitem .accelerator:disabled {
     color: alpha (mix (@menu_fg_dark_color, @menu_bg_dark_color, 0.4), 0.8);
     text-shadow: none;
 }
 
-.menuitem.separator {
-    -GtkMenuItem-horizontal-padding: 0;
-    -GtkWidget-separator-height: 1;
+menuitem.separator {
+    -menuitem-horizontal-padding: 0;
+    min-height: 1px;
     /* border-color: shade (@menu_bg_dark_color, 0.90);
     -unico-inner-stroke-color: alpha (shade (@menu_bg_dark_color, 1.18), 0.6); */
     border-image: -gtk-gradient (linear,
@@ -384,8 +390,8 @@ DbusmenuGtkMenu .menuitem .accelerator:insensitive,
 /***************
  * Menu Button *
  ***************/
-.button.menuitem.menubar:active,
-.button.menuitem.menubar *:active {
+button menuitem menubar:active,
+button menuitem menubar *:active {
     color: @menu_fg_dark_color;
     background-image: none;
     background-color: @menu_bg_dark_color;

--- a/desktop-themes/Green-Submarine/gtk-3.0/other-applications.css
+++ b/desktop-themes/Green-Submarine/gtk-3.0/other-applications.css
@@ -789,3 +789,30 @@ DConfWindow GtkPaned.horizontal {
     background-color: @theme_bg_color;
 }
 
+DConfKeyView.view row:selected,
+DConfKeyView.view row:selected:hover  {
+    background-image: -gtk-gradient (linear,
+                                     left top,
+                                     left bottom,
+                                     from (shade(@sidebar_selected_bg, 0.90)),
+                                     color-stop (0.40, shade (@sidebar_selected_bg, 0.98)),
+                                     to (shade(@sidebar_selected_bg, 1.05)));
+    color:  @theme_selected_fg_color;
+}
+
+DConfKeyView.view .entry.spinbutton {
+    padding: 2px 0px 2px 4px;
+    box-shadow: none;
+    border-style: none;
+}
+
+DConfKeyView.view .spinbutton .button,
+DConfKeyView.view .spinbutton .button:hover {
+    border-style: none;
+}
+
+DConfKeyView.view .spinbutton .button:last-child,
+DConfKeyView.view .spinbutton .button:hover:last-child {
+    border-radius: 0 5px 5px 0;
+}
+

--- a/desktop-themes/Green-Submarine/gtk-3.0/other-applications.css
+++ b/desktop-themes/Green-Submarine/gtk-3.0/other-applications.css
@@ -1,5 +1,21 @@
 /* nemo */
 
+
+/* background of all views */
+/*Caja icon views-these are widgets w/o css nodes or valid names, .view is applied only to */
+
+window.background>grid>paned>box>paned>box>notebook>stack>box>*>scrolledwindow{
+    background-color: shade (@base_color, 1.0);
+    color: @theme_fg_color;
+}
+
+/**** NemoSidebar ***/
+
+window.background>grid>paned>box>scrolledwindow>viewport.frame,
+window.background>grid>paned>box>scrolledwindow>viewport treeview.view{
+	background-color: shade(@theme_bg_color, 1.08);
+}
+
 NemoSearchBar.info {
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
@@ -129,7 +145,7 @@ NemoTrashBar .button *:checked:hover {
     text-shadow: 0px 1px @theme_shadow_color;
 }
 
-NemoTrashBar .button:insensitive {
+NemoTrashBar .button:disabled {
 /* .button:active:hover */
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
@@ -143,7 +159,7 @@ NemoTrashBar .button:insensitive {
                 inset  0px -1px shade(@nautilus_cluebar_color, 0.78);
 }
 
-NemoTrashBar .button *:insensitive {
+NemoTrashBar .button *:disabled {
     color: mix(@nautilus_cluebar_color, @theme_fg_color, 0.50);
     text-shadow: none;
 }
@@ -495,7 +511,7 @@ NemoWindow .toolbar .button:checked:hover {
 }
 
 NemoWindow .notebook {
-    -GtkNotebook-initial-gap: 0;
+    /*-GtkNotebook-initial-gap: 0; deprecated */
     background-color: @theme_base_color;
     background-image: -gtk-gradient (linear,
                                      left top, left bottom,
@@ -580,7 +596,7 @@ NemoWindow .notebook tab .button GtkImage {
     border-color: transparent;
     border-width: 1px;
     padding: 0;
-    icon-shadow: 1px 1px @theme_shadow_color;
+    -gtk-icon-shadow: 1px 1px @theme_shadow_color;
 }
 
 NemoWindow .notebook tab .button GtkImage:hover {
@@ -594,7 +610,7 @@ NemoWindow .notebook tab .button GtkImage:checked,
 NemoWindow .notebook tab .button GtkImage:active:hover {
     background-color: alpha(black, 0.15); 
     color: shade(@theme_fg_color, 1.00);
-    icon-shadow: 0px 1px @theme_shadow_color;
+    -gtk-icon-shadow: 0px 1px @theme_shadow_color;
     border-color: alpha(black, 0.27) 
                   alpha(black, 0.13) 
                   alpha(black, 0.13) 
@@ -606,7 +622,7 @@ NemoWindow .notebook tab .button GtkImage:active:hover {
 }
 
 /* desktop mode */
-.nemo-desktop.nemo-canvas-item {
+window>*>box>box>box>scrolledwindow>.view .nemo-canvas-item {
     color: white;
     text-shadow: 1px 1px black;
 }
@@ -623,7 +639,7 @@ NemoWindow .notebook tab .button GtkImage:active:hover {
 
 .nemo-desktop.nemo-canvas-item:active,
 .nemo-desktop.nemo-canvas-item:checked,
-.nemo-desktop.nemo-canvas-item:prelight,
+.nemo-desktop.nemo-canvas-item:hover,
 .nemo-desktop.nemo-canvas-item:selected,
 .nemo-desktop.nemo-canvas-item:checked {
     text-shadow: none;
@@ -815,4 +831,3 @@ DConfKeyView.view .spinbutton .button:last-child,
 DConfKeyView.view .spinbutton .button:hover:last-child {
     border-radius: 0 5px 5px 0;
 }
-

--- a/desktop-themes/Green-Submarine/gtk-3.0/scrollbar.css
+++ b/desktop-themes/Green-Submarine/gtk-3.0/scrollbar.css
@@ -2,7 +2,7 @@
  * Scrollbars *
  **************/
 
-.scrollbar {
+scrollbar {
     background-image: none;
     border-style: solid;
     -GtkRange-stepper-size: 16;
@@ -21,7 +21,7 @@
 
  /* the small square between scrollbars!!!
      no borders with background-image */
-.scrollbars-junction {
+scrollbars-junction {
     background-image: linear-gradient(to bottom,
                                       shade(@theme_bg_color, 1.05),
                                       shade(@theme_bg_color, 1.05));
@@ -34,8 +34,8 @@
     box-shadow: none;
 }
 
-.scrollbar.trough,
-.scrollbar.trough.vertical {
+scrollbar trough,
+scrollbar.vertical trough {
     background-image: -gtk-gradient (linear, left top, left bottom,
                                      from (shade (@theme_bg_color, 0.98)),
                                      to (shade (@theme_bg_color, 1.06)));
@@ -49,7 +49,7 @@
     box-shadow: none;
 }
 
-.scrollbar.trough.horizontal {
+scrollbar.horizontal trough {
     background-image: -gtk-gradient (linear, left top, right top,
                                      from (shade (@theme_bg_color, 0.98)),
                                      to (shade (@theme_bg_color, 1.06)));
@@ -63,17 +63,18 @@
 }
 
 /* Sliders and buttons */
-.scrollbar.slider.vertical {
+scrollbar.vertical slider {
     background-image: -gtk-gradient (linear, left top, left bottom,
                                      from (shade (@theme_bg_color, 0.95)),
                                      to (shade (@theme_bg_color, 0.8)));
+	border-style:solid;
     border-color: shade (@theme_bg_color, 0.65);
     border-radius: 10px;
     border-width: 1px;
 }
 
-.scrollbar.slider.vertical:hover,
-.scrollbar.slider.vertical:hover:active {
+scrollbar.vertical slider:hover,
+scrollbar.vertical slider:hover:active {
     background-image: -gtk-gradient (linear, left top, left bottom,
                                      from (shade (@theme_bg_color, 0.85)),
                                      to (shade (@theme_bg_color, 0.7)));
@@ -81,17 +82,18 @@
     border-width: 0 0 0 0;
 }
 
-.scrollbar.slider.horizontal {
+scrollbar.horizontal slider {
     background-image: -gtk-gradient (linear, left top, right top,
                                      from (shade (@theme_bg_color, 0.95)),
                                      to (shade (@theme_bg_color, 0.8)));
+	border-style:solid;
     border-color: shade (@theme_bg_color, 0.65);
     border-radius: 10px;
     border-width: 1px;
 }
 
-.scrollbar.slider.horizontal:hover,
-.scrollbar.slider.horizontal:hover:active {
+scrollbar.horizontal slider:hover,
+scrollbar.horizontal slider:hover:active {
     background-image: -gtk-gradient (linear, left top, right top,
                                      from (shade (@theme_bg_color, 0.85)),
                                      to (shade (@theme_bg_color, 0.7)));
@@ -99,18 +101,18 @@
     border-width: 0 0 0 0;
 }
 
-.scrollbar.slider:insensitive {
+scrollbar slider:disabled {
     background-color: shade (@theme_bg_color, 0.9);
 }
 
-.scrollbar.trough:insensitive {
+scrollbar trough:disabled {
     background-color: shade (@theme_bg_color, 1.06);
 }
 
-.scrollbar.button,
-.scrollbar.button:hover,
-.scrollbar.button:hover:active,
-.scrollbar.button:insensitive {
+scrollbar button,
+scrollbar button:hover,
+scrollbar button:hover:active,
+scrollbar button:disabled {
     box-shadow: none;
     border-style: none;
     border-image: none;
@@ -119,44 +121,44 @@
     background-color: transparent;
 }
 
-.scrollbar.button:hover,
-.scrollbar.button:hover:active {
+scrollbar button:hover,
+scrollbar button:hover:active {
     background-color: alpha(shade(@scrollbar_trough, 0.8), 0.5);
 }
-
-.scrollbar.button.top:hover {
+/* -gtk-image-effect is an invalid property name in GTK 3.20
+scrollbar.button.top:hover {
     box-shadow: none;
     -gtk-image-effect: highlight;
 }
 
-.scrollbar.button.bottom:hover {
+scrollbar.button.bottom:hover {
     box-shadow: none;
     -gtk-image-effect: highlight;
 }
 
-.scrollbar.button.right:hover {
+scrollbar.button.right:hover {
     box-shadow: none;
     -gtk-image-effect: highlight;
 }
 
-.scrollbar.button.left:hover {
+scrollbar.button.left:hover {
     box-shadow: none;
     -gtk-image-effect: highlight;
 }
-
-.scrollbar.button {
+*/
+scrollbar button {
     color: @theme_fg_color;
 }
 
-.scrollbar.button:hover {
+scrollbar button:hover {
     color: @theme_fg_color;
 }
 
-.scrollbar.button:insensitive {
+scrollbar button:disabled {
     color: @insensitive_fg_color;
 }
 
-.scrollbar.slider.fine-tune:prelight:active {
+scrollbar slider.fine-tune:hover:active {
     background-image: url("assets/slider_fine_horizontal.svg"),
                       linear-gradient(to top,
                                       shade(@scrollbar_slider, 0.9),
@@ -170,7 +172,7 @@
     border-width: 1px;
 }
 
-.scrollbar.slider.vertical.fine-tune:prelight:active {
+scrollbar slider.vertical.fine-tune:hover:active {
     background-image: url("assets/slider_fine_vertical.svg"),
                       linear-gradient(to left,
                                       shade(@scrollbar_slider, 0.9),
@@ -184,7 +186,7 @@
     border-width: 1px;
 }
 
-.scrollbar.slider.fine-tune:prelight:active {
+scrollbar slider.fine-tune:hover:active {
     background-image: url("assets/slider_fine_horizontal.svg"),
                       linear-gradient(to top,
                                       shade(@scrollbar_slider, 0.9),
@@ -198,7 +200,7 @@
     border-width: 1px;
 }
 
-.scrollbar.slider.vertical.fine-tune:prelight:active {
+scrollbar slider.vertical.fine-tune:hover:active {
     background-image: url("assets/slider_fine_vertical.svg"),
                       linear-gradient(to left,
                                       shade(@scrollbar_slider, 0.9),
@@ -227,15 +229,15 @@ OsScrollbar:active {
     background-color: shade (@theme_bg_color, 0.6);
 }
 
-OsThumb:insensitive,
-OsScrollbar:insensitive {
+OsThumb:disabled,
+OsScrollbar:disabled {
     background-color: shade (@theme_bg_color, 0.85);
 }
 
 /*******************
  * scrolled window *
  *******************/
-GtkScrolledWindow.frame {
+scrolledwindow.frame {
     border-top-color: shade (@theme_bg_color, 0.84);
     border-right-color: shade (@theme_bg_color, 0.76);
     border-bottom-color: shade (@theme_bg_color, 0.86);

--- a/desktop-themes/Green-Submarine/gtk-3.0/sidebar.css
+++ b/desktop-themes/Green-Submarine/gtk-3.0/sidebar.css
@@ -2,41 +2,60 @@
  * Sidebar *
  ***********/
 
+sidebar,
 .sidebar {
     -GtkTreeView-horizontal-separator: 6px;
     -GtkTreeView-vertical-separator: 1px;
 }
 
+
 .sidebar,
 .sidebar.view,
 .sidebar .view,
-.sidebar.view:prelight,
-.sidebar .view:prelight {
+.sidebar.view:hover,
+.sidebar .view:hover {
     border-radius: 0px;
     color: @sidebar_fg_color;
     text-shadow: 0px 1px @theme_shadow_color;
     background-color: @sidebar_background;
 }
 
+.sidebar-button{
+	background-color: transparent;
+	background-image: none;
+	border-style:none;
+	border-image:none;
+	border-width: 0px;	
+	border-color: transparent;
+	box-shadow: none;
+}  
+
 /* dialog open */
-GtkPlacesSidebar.sidebar.frame .frame GtkListBox.sidebar.list,
-GtkPlacesSidebar.sidebar.frame .frame .sidebar.list .list-row.activatable.sidebar-row {
+
+filechooser stack.view,
+filechooser box.vertical.view {
+	background-color:transparent; /*still more spurious matches to .view */
+}
+
+placessidebar.sidebar.frame  list{
      background-color: @sidebar_background;
 }
 
-GtkPlacesSidebar.sidebar.frame .frame .sidebar.list .list-row.activatable.sidebar-row:selected {
+placessidebar.sidebar.frame  list row.activatable.sidebar-row:active,
+placessidebar.sidebar.frame  list row.activatable.sidebar-row:selected {
      border-radius: 6px;
 }
 
-GtkPlacesSidebar.sidebar.frame .frame .sidebar.list .list-row.activatable.sidebar-row .sidebar-revealer .sidebar-icon {
+placessidebar.sidebar.frame  list row.activatable.sidebar-row,
+placessidebar.sidebar.frame .frame .sidebar list list-row.activatable .sidebar-row .sidebar-revealer .sidebar-icon {
      padding: 4px 8px 4px 6px;
 }
 
-GtkPlacesSidebar.sidebar.frame .frame .sidebar.list .list-row.activatable.sidebar-row .sidebar-revealer .sidebar-label {
+placessidebar  .sidebar-label {
      padding: 4px 0px 4px 1px;
 }
 
-GtkPlacesSidebar.sidebar.frame .frame .sidebar.list .list-row.activatable.sidebar-row .sidebar-revealer .sidebar-button.image-button.button {
+placessidebar.sidebar.frame .frame .sidebar list  list-row.activatable.sidebar-row .sidebar-revealer .sidebar-button.image-button.button {
     background-color: transparent;
     background-image: none;
     border-image:none;
@@ -44,11 +63,11 @@ GtkPlacesSidebar.sidebar.frame .frame .sidebar.list .list-row.activatable.sideba
     padding: 4px 12px 4px 0px;
 }
 
-.sidebar.view:selected,
-.sidebar.view *:selected,
-.sidebar .view:selected,
-.sidebar .view *:selected,
-.sidebar .view:selected:prelight {
+.sidebar. row:selected,
+.sidebar row *:selected,
+.sidebar row:selected,
+.sidebar row *:selected,
+.sidebar row:selected:hover {
     border-style: solid;
     border-width: 1px 0px 0px 0px;
     border-color: shade (@sidebar_selected_bg, 0.90) #bbb shade (@sidebar_selected_bg, 1.05);
@@ -65,7 +84,8 @@ GtkPlacesSidebar.sidebar.frame .frame .sidebar.list .list-row.activatable.sideba
 
 .sidebar row:hover,
 .sidebar .view row:hover,
-.sidebar GtkTreeView row:hover {
+.sidebar treeview row:hover
+ {
     background-image: -gtk-gradient (linear,
                                      left top,
                                      left bottom,
@@ -81,9 +101,9 @@ GtkPlacesSidebar.sidebar.frame .frame .sidebar.list .list-row.activatable.sideba
     text-shadow: none;
 }
 
-.sidebar .radio,
-.sidebar .radio:focus,
-.sidebar .radio:selected {
+.sidebar radio,
+.sidebar radio:focus,
+.sidebar radio:selected {
     background-image: none;
     background-color: alpha(@theme_base_color, 0.0);
 }
@@ -95,7 +115,7 @@ SourceList.pane-separator {
 }
 
 GtkHCollapsablePaned .pane-separator,
-GtkHCollapsablePaned .pane-separator:prelight,
+GtkHCollapsablePaned .pane-separator:hover,
 GtkHCollapsablePaned .pane-separator:selected {
     background-image: none;
     background-color: @sidebar_background;
@@ -107,7 +127,7 @@ GtkHCollapsablePaned .pane-separator:selected {
 /* Marlin sidebar separator */
 VarkaWidgetsHCollapsiblePaned,
 VarkaWidgetsHCollapsiblePaned.pane-separator,
-VarkaWidgetsHCollapsiblePaned.pane-separator:prelight,
+VarkaWidgetsHCollapsiblePaned.pane-separator:hover,
 VarkaWidgetsHCollapsiblePaned.pane-separator:selected {
     border-width: 0px;
     border-color: shade(@sidebar_background, 0.80);
@@ -117,4 +137,3 @@ VarkaWidgetsHCollapsiblePaned.pane-separator:selected {
                                     color-stop(0.50, @sidebar_background),
                                     to   (#a9a9a9));
 }
-

--- a/desktop-themes/GreenLaguna/gtk-3.0/mate-applications.css
+++ b/desktop-themes/GreenLaguna/gtk-3.0/mate-applications.css
@@ -17,12 +17,6 @@ CajaNavigationWindow CajaNotebook .vertical .vertical FMIconView.frame {
     border-radius: 2px;
 }
 
-/* do not flash the desktop with a color during theme switching */
-CajaDesktopWindow FMDesktopIconView .view {
-    background-color: transparent;
-    background-image: none;
-}
-
 /* FIXME, doesn't work */
 .caja-inactive-pane .view {
 	background-color: shade(@theme_bg_color, 0.9);
@@ -201,26 +195,44 @@ CajaWindow .notebook NautilusQueryEditor .toolbar {
 	padding: 5px 7px;
 }
 
-.caja-canvas-item {
-	border-radius: 5px;
+.caja-canvas-item,
+EelEditableLabel.entry {
+	border-radius: 4px;
 }
 
-.caja-desktop.nautilus-canvas-item {
-	color: @theme_bg_color;
-	text-shadow: 1px 1px black;
+/* view */
+CajaNavigationWindow.background .view.caja-canvas-item {
+    color: @theme_fg_color;
+	text-shadow: none;
 }
 
-.caja-desktop.nautilus-canvas-item:active {
+CajaNavigationWindow.background .view.caja-canvas-item:active,
+CajaNavigationWindow.background .view.caja-canvas-item:selected {
+    color: @theme_selected_fg_color;
+}
+
+/**** Desktop Drawn ***/
+CajaDesktopWindow.background FMIconContainer.view EelEditableLabel.entry {
+   border-image: none;
+   text-shadow: none;
+}
+
+CajaDesktopWindow.background .caja-canvas-item {
+	color: @theme_selected_fg_color;
+    text-shadow: 1px 1px alpha (#000000, 0.8);
+}
+
+CajaDesktopWindow.background .caja-canvas-item:active {
 	color: @theme_text_color;
 }
 
-.caja-desktop.nautilus-canvas-item:selected {
+CajaDesktopWindow.background .caja-canvas-item:selected {
 	color: @theme_selected_fg_color;
 }
 
-.caja-desktop.nautilus-canvas-item:active,
-.caja-desktop.nautilus-canvas-item:prelight,
-.caja-desktop.nautilus-canvas-item:selected {
+CajaDesktopWindow.background .caja-canvas-item:active,
+CajaDesktopWindow.background .caja-canvas-item:prelight,
+CajaDesktopWindow.background .caja-canvas-item:selected {
 	text-shadow: none;
 }
 

--- a/desktop-themes/GreenLaguna/gtk-3.0/other-applications.css
+++ b/desktop-themes/GreenLaguna/gtk-3.0/other-applications.css
@@ -42,6 +42,13 @@ DConfWindow GtkPaned.horizontal {
     background-color: @theme_bg_color;
 }
 
+DConfKeyView.view .spinbutton .button {
+    border-image: none;
+    border-style: solid;
+    border-width:  1px;
+    border-radius: 0px;
+}
+
 /********
  * Nemo *
  ********/

--- a/desktop-themes/Menta/gtk-3.0/mate-applications.css
+++ b/desktop-themes/Menta/gtk-3.0/mate-applications.css
@@ -2,12 +2,6 @@
  * CAJA File manager *
  *********************/
 
-/* do not flash the desktop with a color during theme switching */
-CajaDesktopWindow FMDesktopIconView .view {
-    background-color: transparent;
-    background-image: none;
-}
-
 /* for breadcrumbs path bar */
 
 .caja-pathbar-button,
@@ -241,27 +235,40 @@ CajaWindow CajaHistorySidebar .vertical.scrollbar.overlay-indicator {
 	-GtkRange-slider-width: 11;
 }
 
-/* desktop mode */
-.caja-desktop.caja-canvas-item {
-    color: @theme_bg_color;
-    text-shadow: 1px 1px alpha (#000000, 0.8);
+.caja-canvas-item {
+    border-radius: 3px;
 }
 
-.caja-desktop.caja-canvas-item:active {
-    background-image: none;
-    background-color: alpha (@theme_bg_color, 0.84);
+/* view */
+CajaNavigationWindow.background .view.caja-canvas-item {
     color: @theme_fg_color;
 }
 
-.caja-desktop.caja-canvas-item:selected {
-    background-image: none;
-    background-color: alpha (@theme_selected_bg_color, 0.84);
+CajaNavigationWindow.background .view.caja-canvas-item:active,
+CajaNavigationWindow.background .view.caja-canvas-item:selected {
     color: @theme_selected_fg_color;
 }
 
-.caja-desktop.caja-canvas-item:active,
-.caja-desktop.caja-canvas-item:prelight,
-.caja-desktop.caja-canvas-item:selected {
+/* desktop mode */
+CajaDesktopWindow.background FMIconContainer.view EelEditableLabel.entry {
+   border-image: none;
+   border-width: 1px;
+   text-shadow: none;
+}
+
+CajaDesktopWindow.background .caja-canvas-item {
+    color: @theme_selected_fg_color;
+    text-shadow: 1px 1px alpha (#000000, 0.8);
+}
+
+CajaDesktopWindow.background .caja-canvas-item:selected {
+    background-color: @theme_selected_bg_color;
+    color: @theme_selected_fg_color;
+}
+
+CajaDesktopWindow.background .caja-canvas-item:active,
+CajaDesktopWindow.background .caja-canvas-item:prelight,
+CajaDesktopWindow.background .caja-canvas-item:selected {
     text-shadow: none;
 }
 

--- a/desktop-themes/Menta/gtk-3.0/other-applications.css
+++ b/desktop-themes/Menta/gtk-3.0/other-applications.css
@@ -355,6 +355,28 @@ DConfWindow GtkPaned.horizontal {
     background-color: @theme_bg_color;
 }
 
+DConfKeyView.view row:selected,
+DConfKeyView.view row:selected:hover  {
+    color:  @theme_selected_fg_color;
+}
+
+DConfKeyView.view .entry.spinbutton {
+    padding: 1px 0px 1px 4px;
+}
+
+DConfKeyView.view .spinbutton .button {
+    border-image: none;
+    border-style: solid;
+    border-width: 0px 0px 0px 1px;
+    border-color: @theme_selected_bg_color;
+    border-radius: 0px;
+    box-shadow: none;
+}
+
+DConfKeyView.view .spinbutton .button:last-child {
+    border-radius: 0 2px 2px 0;
+}
+
 /*****************
  * Ubuntu styles *
  *****************/

--- a/desktop-themes/TraditionalGreen/gtk-3.0/mate-applications.css
+++ b/desktop-themes/TraditionalGreen/gtk-3.0/mate-applications.css
@@ -2,12 +2,6 @@
  * Caja *
  ************/
 
-/* do not flash the desktop with a color during theme switching */
-CajaDesktopWindow FMDesktopIconView .view {
-    background-color: transparent;
-    background-image: none;
-}
-
 /* caja sidebar */
 CajaWindow FMTreeView .view,
 CajaWindow CajaNotesViewer .view,
@@ -39,21 +33,41 @@ CajaWindow .primary-toolbar.toolbar.horizontal GtkComboBox .button {
     padding: 4px 4px;
 }
 
-.caja-desktop.caja-canvas-item {
+.caja-canvas-item,
+EelEditableLabel.entry {
+	border-radius: 3px;
+}
+
+EelEditableLabel.entry,
+EelEditableLabel.entry:focus {
+   border-image: none;
+   border-width: 1px;
+   border-color: @theme_fg_color;
+   box-shadow: none;
+   border-radius: 3px;
+   text-shadow: none;
+}
+
+/* desktop */
+CajaDesktopWindow.background .caja-canvas-item {
 	color: @theme_base_color;
 	text-shadow: 1px 1px alpha (@theme_fg_color, 0.8);
 }
 
-.caja-desktop.caja-canvas-item:active,
-.caja-desktop.caja-canvas-item:prelight,
-.caja-desktop.caja-canvas-item:selected {
+CajaDesktopWindow.background .caja-canvas-item:active,
+CajaDesktopWindow.background .caja-canvas-item:prelight,
+CajaDesktopWindow.background .caja-canvas-item:selected {
 	text-shadow: none;
+    color: @theme_fg_color;
 }
 
+/* view */
+CajaNavigationWindow.background .view.caja-canvas-item {
+    color: @theme_fg_color;
+}
 
-.caja-desktop .entry {
-	background-image: none;
-	border-image: none;
+CajaNavigationWindow.background .view.caja-canvas-item:selected {
+    color: @theme_fg_color;
 }
 
 /***************

--- a/desktop-themes/TraditionalOk/gtk-3.0/mate-applications.css
+++ b/desktop-themes/TraditionalOk/gtk-3.0/mate-applications.css
@@ -2,12 +2,6 @@
  * Caja *
  ************/
 
-/* do not flash the desktop with a color during theme switching */
-CajaDesktopWindow FMDesktopIconView .view {
-    background-color: transparent;
-    background-image: none;
-}
-
 /* caja sidebar */
 CajaWindow FMTreeView .view,
 CajaWindow CajaNotesViewer .view,
@@ -39,34 +33,40 @@ CajaWindow .primary-toolbar.toolbar.horizontal GtkComboBox .button {
     padding: 4px 4px;
 }
 
-/* moved eject button to left better for overlay scrollbars */
-CajaWindow CajaPlacesSidebar .view row {
-    padding: 0px 4px 0px 0px;
+.caja-canvas-item,
+EelEditableLabel.entry {
+	border-radius: 3px;
 }
 
-/* better for overlay scrollbars */
-CajaWindow FMTreeView .vertical.scrollbar.overlay-indicator,
-CajaWindow CajaNotesViewer .vertical.scrollbar.overlay-indicator,
-CajaWindow CajaPlacesSidebar .vertical.scrollbar.overlay-indicator,
-CajaWindow CajaEmblemSidebar .vertical.scrollbar.overlay-indicator,
-CajaWindow CajaHistorySidebar .vertical.scrollbar.overlay-indicator {
-	-GtkRange-slider-width: 13;
+EelEditableLabel.entry,
+EelEditableLabel.entry:focus {
+   border-image: none;
+   border-width: 1px;
+   border-color: @theme_fg_color;
+   box-shadow: none;
+   border-radius: 3px;
+   text-shadow: none;
 }
 
-.caja-desktop.caja-canvas-item {
+/* desktop */
+CajaDesktopWindow.background .caja-canvas-item {
 	color: @theme_base_color;
 	text-shadow: 1px 1px alpha (@theme_fg_color, 0.8);
 }
 
-.caja-desktop.caja-canvas-item:active,
-.caja-desktop.caja-canvas-item:prelight,
-.caja-desktop.caja-canvas-item:selected {
+CajaDesktopWindow.background .caja-canvas-item:active,
+CajaDesktopWindow.background .caja-canvas-item:prelight,
+CajaDesktopWindow.background .caja-canvas-item:selected {
 	text-shadow: none;
 }
 
-.caja-desktop .entry {
-	background-image: none;
-	border-image: none;
+/* view */
+CajaNavigationWindow.background .view.caja-canvas-item {
+    color: @theme_fg_color;
+}
+
+CajaNavigationWindow.background .view.caja-canvas-item:selected {
+    color: @theme_sectected_fg_color;
 }
 
 /***************

--- a/desktop-themes/TraditionalOkTest/gtk-3.0/mate-applications.css
+++ b/desktop-themes/TraditionalOkTest/gtk-3.0/mate-applications.css
@@ -2,12 +2,6 @@
  * Caja *
  ************/
 
-/* do not flash the desktop with a color during theme switching */
-CajaDesktopWindow FMDesktopIconView .view {
-    background-color: transparent;
-    background-image: none;
-}
-
 /* caja sidebar */
 CajaWindow FMTreeView .view,
 CajaWindow CajaNotesViewer .view,
@@ -39,21 +33,41 @@ CajaWindow .primary-toolbar.toolbar.horizontal GtkComboBox .button {
     padding: 4px 4px;
 }
 
-.caja-desktop.caja-canvas-item {
-	color: @theme_base_color;
+.caja-canvas-item,
+EelEditableLabel.entry {
+	border-radius: 3px;
+}
+
+EelEditableLabel.entry,
+EelEditableLabel.entry:focus {
+   border-image: none;
+   border-width: 1px;
+   border-color: @theme_fg_color;
+   box-shadow: none;
+   border-radius: 3px;
+   text-shadow: none;
+}
+
+/* desktop */
+CajaDesktopWindow.background .caja-canvas-item {
+	color: @theme_sectected_fg_color;
 	text-shadow: 1px 1px alpha (@theme_fg_color, 0.8);
 }
 
-.caja-desktop.caja-canvas-item:active,
-.caja-desktop.caja-canvas-item:prelight,
-.caja-desktop.caja-canvas-item:selected {
+CajaDesktopWindow.background .caja-canvas-item:active,
+CajaDesktopWindow.background .caja-canvas-item:prelight,
+CajaDesktopWindow.background .caja-canvas-item:selected {
 	text-shadow: none;
+    color: @theme_sectected_fg_color;
 }
 
+/* view */
+CajaNavigationWindow.background .view.caja-canvas-item {
+    color: @theme_fg_color;
+}
 
-.caja-desktop .entry {
-	background-image: none;
-	border-image: none;
+CajaNavigationWindow.background .view.caja-canvas-item:selected {
+    color: @theme_sectected_fg_color;
 }
 
 /***************


### PR DESCRIPTION
Not perfect but a mostly functional port of BlackMATE to gtk3.19.7 which will become gtk3.20. No guarantees that GNOME won't break something and force further work this early.

A note concerning application themes: Caja and Nemo got some crucial work to basically match older versions of GTK3 in BlackMATE, but theming applications is very difficult in GTK 3.19 as the application window names and custom widget names other than the #name variety are no longer recognized by GTK. The old selectors are silently ignored, so I left most of the old application theming in place as a guide for future work rather than cutting it out. Deprecated and renamed style properties and pseudoclasses were fixed everywhere they turned up though because these cause warnings and theme parsing errors