### PR TITLE
BlackMATE, ContrastHighInverse: fix caja renaming when theme actually applied

### DIFF
--- a/desktop-themes/BlackMATE/gtk-3.0/mate-applications.css
+++ b/desktop-themes/BlackMATE/gtk-3.0/mate-applications.css
@@ -216,6 +216,7 @@
 	                                  shade(@less_dark_color, 0.5) 10%,
 	                                  @less_dark_color 50%,
 	                                  shade(@less_dark_color, 1.5));
+   color: @theme_fg_color;
 }
 
 /****************

--- a/desktop-themes/BlackMATE/gtk-3.0/mate-applications.css
+++ b/desktop-themes/BlackMATE/gtk-3.0/mate-applications.css
@@ -210,16 +210,12 @@
 
 .caja-desktop .entry,
 .caja-navigation-window .view .entry{
-/* Keep the caret visible with Caja's hardcoded renaming label style*/
-	caret-color: #000000;
-/*  This is overridden by caja.css, without which 3ed party themes don't work
 	border-radius: 4px;	
 	background-image: linear-gradient(to bottom,
 	                                  shade(@less_dark_color, 0.2),
 	                                  shade(@less_dark_color, 0.5) 10%,
 	                                  @less_dark_color 50%,
 	                                  shade(@less_dark_color, 1.5));
-*/
 }
 
 /****************

--- a/desktop-themes/BlackMATE/gtk-3.0/other-applications.css
+++ b/desktop-themes/BlackMATE/gtk-3.0/other-applications.css
@@ -269,10 +269,6 @@ NemoQueryEditor .toolbar .entry:focus {
 	text-shadow: none;
 }
 
-.nemo-desktop .entry{
-	caret-color: #000000;
-}
-
 /*************
  * Yumex-DNF *
  *************/

--- a/desktop-themes/ContrastHighInverse/gtk-3.0/mate-applications.css
+++ b/desktop-themes/ContrastHighInverse/gtk-3.0/mate-applications.css
@@ -56,6 +56,7 @@ CajaNavigationWindow.background .view.caja-canvas-item {
    border-style: solid;
    border-width: 1px;
    border-color: @theme_fg_color;
+   color: @theme_fg_color;
    box-shadow: none;
    border-radius: 2px;
    text-shadow: none;


### PR DESCRIPTION
For use with https://github.com/mate-desktop/caja/pull/690, these go together to permit theming caja's renaming label, use sane defaults when the theme does not support Caja,  and fix https://github.com/mate-desktop/caja/issues/688 