### PR TITLE
GTK+-3.20 Submarine themes: enable outlines on mate control center

### DIFF
--- a/desktop-themes/Blue-Submarine/gtk-3.0/mate-applications.css
+++ b/desktop-themes/Blue-Submarine/gtk-3.0/mate-applications.css
@@ -1063,6 +1063,8 @@ vte-terminal {
     border-image: none;
     border-radius: 6px;
     padding: 4px;
+    outline-style: dashed;
+    outline-color: shade (@theme_selected_bg_color, 0.8);
 }
 
 /*********

--- a/desktop-themes/Green-Submarine/gtk-3.0/mate-applications.css
+++ b/desktop-themes/Green-Submarine/gtk-3.0/mate-applications.css
@@ -1075,6 +1075,8 @@ vte-terminal {
     border-image: none;
     border-radius: 6px;
     padding: 4px;
+    outline-style: dashed;
+    outline-color: shade (@theme_selected_bg_color, 0.8);
 }
 
 /*********


### PR DESCRIPTION
Fixes: (green submarine and blue submarine) the focus don't works successfully over mate control center

I commented the issue here:

https://github.com/mate-desktop/mate-themes/issues/156#issuecomment-272580509