### PR TITLE
Some minor tweaks (mainly padding related) for Menta and BlueMenta GTK+ 3

### DIFF
--- a/desktop-themes/BlueMenta/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/BlueMenta/gtk-3.0/gtk-widgets.css
@@ -2918,7 +2918,7 @@ menu > menuitem,
     min-height: 18px;
     background-color: transparent;
     transition: all 150ms ease-out;
-    padding: 6px 5px;
+    padding: 3px 5px;
 	text-shadow: none;
 	color: @menu_fg_color;
 }

--- a/desktop-themes/BlueMenta/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/BlueMenta/gtk-3.0/gtk-widgets.css
@@ -135,7 +135,7 @@ tooltip label,
 .tooltip label {
 	text-shadow: none;
 	color: @theme_tooltip_fg_color;
-	padding: 8px;
+	padding: 0px;
 }
 
 tooltip decoration,

--- a/desktop-themes/BlueMenta/gtk-3.0/mate-applications.css
+++ b/desktop-themes/BlueMenta/gtk-3.0/mate-applications.css
@@ -357,7 +357,7 @@ window.background, /* selector where outlines are writen on GtkTrayIcon */
 .mate-panel-menu-bar menubar > menuitem {
     transition: all 200ms ease-out;
     text-shadow: none;
-    font-weight: 600;
+    font-weight: normal;
     padding: 4px;
 }
 

--- a/desktop-themes/BlueMenta/gtk-3.0/mate-applications.css
+++ b/desktop-themes/BlueMenta/gtk-3.0/mate-applications.css
@@ -509,7 +509,7 @@ na-tray-applet {
 
 /* remove right space a bit */
 na-tray-applet > widget > box {
-    margin: 0px 2px 0px 0px;
+    margin: 1px 2px 1px 1px;
 }
 
 /* no background for icon-padding area */

--- a/desktop-themes/Menta/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/Menta/gtk-3.0/gtk-widgets.css
@@ -2918,7 +2918,7 @@ menu menuitem,
     min-height: 18px;
     background-color: transparent;
     transition: all 150ms ease-out;
-    padding: 6px 5px;
+    padding: 3px 5px;
 	text-shadow: none;
 	color: @menu_fg_color;
 }

--- a/desktop-themes/Menta/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/Menta/gtk-3.0/gtk-widgets.css
@@ -135,7 +135,7 @@ tooltip label,
 .tooltip label {
 	text-shadow: none;
 	color: @theme_tooltip_fg_color;
-	padding: 8px;
+	padding: 0px;
 }
 
 tooltip decoration,

--- a/desktop-themes/Menta/gtk-3.0/mate-applications.css
+++ b/desktop-themes/Menta/gtk-3.0/mate-applications.css
@@ -350,7 +350,7 @@ window.background, /* selector where outlines are writen on GtkTrayIcon */
 .mate-panel-menu-bar menubar menuitem {
     transition: all 200ms ease-out;
     text-shadow: none;
-    font-weight: 600;
+    font-weight: normal;
     padding: 4px;
 }
 

--- a/desktop-themes/Menta/gtk-3.0/mate-applications.css
+++ b/desktop-themes/Menta/gtk-3.0/mate-applications.css
@@ -501,7 +501,7 @@ na-tray-applet {
 
 /* remove right space a bit */
 na-tray-applet > widget > box {
-    margin: 0px 2px 0px 0px;
+    margin: 1px 2px 1px 1px;
 }
 
 /* no background for icon-padding area */


### PR DESCRIPTION
Decrease padding on tooltips and menu items as they are oversized. Reduce font weighting for the panel main menu buttons as they are currently bolded which looks out of place. Also increase the systray applet margins for left, top and bottom to 1 so that icons like the nm-applet icon don't look distorted.