### PR TITLE
Fixed URL colors for Firefox search suggestions

### DIFF
--- a/desktop-themes/BlackMATE/README
+++ b/desktop-themes/BlackMATE/README
@@ -31,6 +31,16 @@ a:visited[class="symlink"] {
 }
 /*------------- end -------------*/
 
+Also, create '~/.mozilla/firefox/<YOUR_PROFILE>/chrome/userChrome.css' and paste these lines in it:
+
+/*------------ start ------------*/
+
+.autocomplete-richlistbox richlistitem .ac-url,
+.autocomplete-richlistbox richlistitem .ac-separator {
+	color: #2EB8E6 !important;
+}
+/*------------- end -------------*/
+
 Seamonkey
 ==========
 Do the same thing for Seamonkey. The difference is just your profile folder, which is inside '~/.mozilla/seamonkey/'.


### PR DESCRIPTION
By default, FF uses #0000EE for the URLs (and separator) for the search suggestions and it looks bad, so I changed it to #2EB8E6 (same as GtkWidget::link-color).