### PR TITLE
Traditional themes: make padding in notebook tabs smaller

### DIFF
--- a/desktop-themes/TraditionalGreen/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/TraditionalGreen/gtk-3.0/gtk-widgets.css
@@ -1804,7 +1804,7 @@ notebook header tab {
 
 notebook header.top tab {
     margin: 0px 0px 0px -1px;
-	padding: 6px;
+    padding: 4px 6px 2px 6px;
     border-width: 0px 1px 1px 1px;
     border-radius: 3px 3px 0px 0px;
     background-image: linear-gradient(to bottom,
@@ -1822,7 +1822,7 @@ notebook header.top tab:checked {
 
 notebook header.right tab {
     margin: -1px 0px 0px 0px;
-    padding: 6px;
+    padding: 6px 4px 6px 2px;
     border-width: 1px 0px 1px 1px;
     border-radius: 0px 3px 3px 0px;
     background-image: linear-gradient(to left,
@@ -1840,7 +1840,7 @@ notebook header.right tab:checked {
 
 notebook header.bottom tab {
     margin: 0px 0px 0px -1px;
-    padding: 6px;
+    padding: 2px 6px 4px 6px;
     border-width: 1px 1px 0px 1px;
     border-radius: 0px 0px 3px 3px;
     background-image: linear-gradient(to top,
@@ -1858,7 +1858,7 @@ notebook header.bottom tab:checked {
 
 notebook header.left tab {
     margin: -1px 0px 0px 0px;
-    padding: 6px;
+    padding: 6px 2px 6px 4px;
     border-width: 1px 1px 1px 0px;
     border-radius: 3px 0px 0px 3px;
     background-image: linear-gradient(to right,

--- a/desktop-themes/TraditionalOk/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/TraditionalOk/gtk-3.0/gtk-widgets.css
@@ -1805,7 +1805,7 @@ notebook header tab {
 
 notebook header.top tab {
     margin: 0px 0px 0px -1px;
-	padding: 6px;
+    padding: 4px 6px 2px 6px;
     border-width: 0px 1px 1px 1px;
     border-radius: 3px 3px 0px 0px;
     background-image: linear-gradient(to bottom,
@@ -1823,7 +1823,7 @@ notebook header.top tab:checked {
 
 notebook header.right tab {
     margin: -1px 0px 0px 0px;
-    padding: 6px;
+    padding: 6px 4px 6px 2px;
     border-width: 1px 0px 1px 1px;
     border-radius: 0px 3px 3px 0px;
     background-image: linear-gradient(to left,
@@ -1841,7 +1841,7 @@ notebook header.right tab:checked {
 
 notebook header.bottom tab {
     margin: 0px 0px 0px -1px;
-    padding: 6px;
+    padding: 2px 6px 4px 6px;
     border-width: 1px 1px 0px 1px;
     border-radius: 0px 0px 3px 3px;
     background-image: linear-gradient(to top,
@@ -1859,7 +1859,7 @@ notebook header.bottom tab:checked {
 
 notebook header.left tab {
     margin: -1px 0px 0px 0px;
-    padding: 6px;
+    padding: 6px 2px 6px 4px;
     border-width: 1px 1px 1px 0px;
     border-radius: 3px 0px 0px 3px;
     background-image: linear-gradient(to right,


### PR DESCRIPTION
issue related: https://github.com/mate-desktop/mate-themes/issues/159

I think now it looks better, like the traditional appearance