### PR TITLE
Traditional themes - use applet handles from menta

### DIFF
--- a/desktop-themes/TraditionalGreen/gtk-3.0/img/Makefile.am
+++ b/desktop-themes/TraditionalGreen/gtk-3.0/img/Makefile.am
@@ -35,6 +35,7 @@ theme_DATA = \
 	menuitem-radio-hover.png \
 	menuitem-radio-insensitive.png \
 	menuitem-radio.png \
+	panel-grid.svg \
 	pane-separator-grip-horz.png \
 	pane-separator-grip-vert.png \
 	radio-checked-hover.png \

--- a/desktop-themes/TraditionalGreen/gtk-3.0/img/panel-grid.svg
+++ b/desktop-themes/TraditionalGreen/gtk-3.0/img/panel-grid.svg
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="view-more-symbolic.svg"
+   height="22"
+   id="svg7384"
+   inkscape:version="0.91 r13725"
+   version="1.1"
+   width="12">
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     inkscape:bbox-nodes="false"
+     inkscape:bbox-paths="true"
+     bordercolor="#666666"
+     borderopacity="1"
+     inkscape:current-layer="layer12"
+     inkscape:cx="37.386562"
+     inkscape:cy="10"
+     gridtolerance="10"
+     inkscape:guide-bbox="true"
+     guidetolerance="10"
+     id="namedview88"
+     inkscape:object-nodes="false"
+     inkscape:object-paths="false"
+     objecttolerance="10"
+     pagecolor="#3a3b39"
+     inkscape:pageopacity="1"
+     inkscape:pageshadow="2"
+     showborder="true"
+     showgrid="false"
+     showguides="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-bbox-midpoints="false"
+     inkscape:snap-global="true"
+     inkscape:snap-grids="true"
+     inkscape:snap-nodes="true"
+     inkscape:snap-others="false"
+     inkscape:snap-to-guides="true"
+     inkscape:window-height="444"
+     inkscape:window-maximized="0"
+     inkscape:window-width="534"
+     inkscape:window-x="788"
+     inkscape:window-y="500"
+     inkscape:zoom="2.8284271">
+    <inkscape:grid
+       empspacing="2"
+       enabled="true"
+       id="grid4866"
+       originx="119.9998px"
+       originy="650px"
+       snapvisiblegridlinesonly="true"
+       spacingx="1px"
+       spacingy="1px"
+       type="xygrid"
+       visible="true" />
+    <inkscape:grid
+       color="#000000"
+       empcolor="#000000"
+       empopacity="0"
+       empspacing="4"
+       enabled="true"
+       id="grid5968"
+       opacity="0.1254902"
+       originx="119.9998px"
+       originy="650px"
+       snapvisiblegridlinesonly="true"
+       spacingx="0.5px"
+       spacingy="0.5px"
+       type="xygrid"
+       visible="true" />
+  </sodipodi:namedview>
+  <title
+     id="title9167">Gnome Symbolic Icon Theme</title>
+  <defs
+     id="defs7386" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer9"
+     inkscape:label="status"
+     style="display:inline"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer10"
+     inkscape:label="devices"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer11"
+     inkscape:label="apps"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer13"
+     inkscape:label="places"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer14"
+     inkscape:label="mimetypes"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer15"
+     inkscape:label="emblems"
+     style="display:inline"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="g71291"
+     inkscape:label="emotes"
+     style="display:inline"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="g4953"
+     inkscape:label="categories"
+     style="display:inline"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer12"
+     inkscape:label="actions"
+     style="display:inline"
+     transform="translate(-121.0004,-861)">
+    <rect
+       height="4"
+       id="rect20592"
+       rx="0.38461545"
+       ry="0.50229359"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new"
+       width="4"
+       x="125.23243"
+       y="864.17157" />
+    <rect
+       height="4"
+       id="rect16730"
+       rx="0.38461545"
+       ry="0.50229359"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new"
+       width="4"
+       x="125.23243"
+       y="870.17157" />
+    <rect
+       height="4"
+       id="rect16732"
+       rx="0.38461545"
+       ry="0.50229359"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new"
+       width="4"
+       x="125.23243"
+       y="876.17157" />
+  </g>
+</svg>

--- a/desktop-themes/TraditionalGreen/gtk-3.0/mate-applications.css
+++ b/desktop-themes/TraditionalGreen/gtk-3.0/mate-applications.css
@@ -113,6 +113,13 @@ MatePanelApplet {
     text-shadow: none;
 }
 
+MatePanelAppletFrameDBus {
+    background-image: -gtk-scaled(url("img/panel-grid.svg"));
+    background-color: transparent;
+    background-repeat: no-repeat;
+    background-position: left;
+}
+
 /* workaround to avoid unwanted black frames if switching compositor on/off */
 .mate-panel-menu-bar .window-frame.csd.popup {
     box-shadow: none;

--- a/desktop-themes/TraditionalOk/gtk-3.0/img/Makefile.am
+++ b/desktop-themes/TraditionalOk/gtk-3.0/img/Makefile.am
@@ -35,6 +35,7 @@ theme_DATA = \
 	menuitem-radio-hover.png \
 	menuitem-radio-insensitive.png \
 	menuitem-radio.png \
+	panel-grid.svg \
 	pane-separator-grip-horz.png \
 	pane-separator-grip-vert.png \
 	radio-checked-hover.png \

--- a/desktop-themes/TraditionalOk/gtk-3.0/img/panel-grid.svg
+++ b/desktop-themes/TraditionalOk/gtk-3.0/img/panel-grid.svg
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="view-more-symbolic.svg"
+   height="22"
+   id="svg7384"
+   inkscape:version="0.91 r13725"
+   version="1.1"
+   width="12">
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     inkscape:bbox-nodes="false"
+     inkscape:bbox-paths="true"
+     bordercolor="#666666"
+     borderopacity="1"
+     inkscape:current-layer="layer12"
+     inkscape:cx="37.386562"
+     inkscape:cy="10"
+     gridtolerance="10"
+     inkscape:guide-bbox="true"
+     guidetolerance="10"
+     id="namedview88"
+     inkscape:object-nodes="false"
+     inkscape:object-paths="false"
+     objecttolerance="10"
+     pagecolor="#3a3b39"
+     inkscape:pageopacity="1"
+     inkscape:pageshadow="2"
+     showborder="true"
+     showgrid="false"
+     showguides="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-bbox-midpoints="false"
+     inkscape:snap-global="true"
+     inkscape:snap-grids="true"
+     inkscape:snap-nodes="true"
+     inkscape:snap-others="false"
+     inkscape:snap-to-guides="true"
+     inkscape:window-height="444"
+     inkscape:window-maximized="0"
+     inkscape:window-width="534"
+     inkscape:window-x="788"
+     inkscape:window-y="500"
+     inkscape:zoom="2.8284271">
+    <inkscape:grid
+       empspacing="2"
+       enabled="true"
+       id="grid4866"
+       originx="119.9998px"
+       originy="650px"
+       snapvisiblegridlinesonly="true"
+       spacingx="1px"
+       spacingy="1px"
+       type="xygrid"
+       visible="true" />
+    <inkscape:grid
+       color="#000000"
+       empcolor="#000000"
+       empopacity="0"
+       empspacing="4"
+       enabled="true"
+       id="grid5968"
+       opacity="0.1254902"
+       originx="119.9998px"
+       originy="650px"
+       snapvisiblegridlinesonly="true"
+       spacingx="0.5px"
+       spacingy="0.5px"
+       type="xygrid"
+       visible="true" />
+  </sodipodi:namedview>
+  <title
+     id="title9167">Gnome Symbolic Icon Theme</title>
+  <defs
+     id="defs7386" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer9"
+     inkscape:label="status"
+     style="display:inline"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer10"
+     inkscape:label="devices"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer11"
+     inkscape:label="apps"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer13"
+     inkscape:label="places"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer14"
+     inkscape:label="mimetypes"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer15"
+     inkscape:label="emblems"
+     style="display:inline"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="g71291"
+     inkscape:label="emotes"
+     style="display:inline"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="g4953"
+     inkscape:label="categories"
+     style="display:inline"
+     transform="translate(-121.0004,-861)" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer12"
+     inkscape:label="actions"
+     style="display:inline"
+     transform="translate(-121.0004,-861)">
+    <rect
+       height="4"
+       id="rect20592"
+       rx="0.38461545"
+       ry="0.50229359"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new"
+       width="4"
+       x="125.23243"
+       y="864.17157" />
+    <rect
+       height="4"
+       id="rect16730"
+       rx="0.38461545"
+       ry="0.50229359"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new"
+       width="4"
+       x="125.23243"
+       y="870.17157" />
+    <rect
+       height="4"
+       id="rect16732"
+       rx="0.38461545"
+       ry="0.50229359"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new"
+       width="4"
+       x="125.23243"
+       y="876.17157" />
+  </g>
+</svg>

--- a/desktop-themes/TraditionalOk/gtk-3.0/mate-applications.css
+++ b/desktop-themes/TraditionalOk/gtk-3.0/mate-applications.css
@@ -112,6 +112,13 @@ MatePanelApplet {
     text-shadow: none;
 }
 
+MatePanelAppletFrameDBus {
+    background-image: -gtk-scaled(url("img/panel-grid.svg"));
+    background-color: transparent;
+    background-repeat: no-repeat;
+    background-position: left;
+}
+
 /* workaround to avoid unwanted black frames if switching compositor on/off */
 .mate-panel-menu-bar .window-frame.csd.popup {
     box-shadow: none;


### PR DESCRIPTION
1) Remove handles from the systray applet and the show desktop applet in both Traditional themes. They don't really add anything and, in my opinion, make the panel look more messy. See the vertical lines just to the left of the bluetooth icon in the screenshot: 

    ![screenshot at 2017-03-26 17-29-58](https://cloud.githubusercontent.com/assets/9774166/24333330/ba05d784-124d-11e7-84df-7a7b13c93f14.png)

2) There is inconsistency in the menu colors used for TraditionalGreen and TraditionalOk. TraditionalOk GTK+ 2 and TraditionalGreen GTK+ 2 & 3 use the base color which is white whilst TraditionalOk GTK+ 3 uses the background color which is grey. To bring TraditionalOk in line with everything else I changed the menu color to the base color. Aside from consistency, I prefer the white menus to the grey ones - I think they stand out more.
