### PR TITLE
Menta themes: mate-terminal fix: set border on the left of the first tab

### DIFF
--- a/desktop-themes/BlueMenta/gtk-3.0/mate-applications.css
+++ b/desktop-themes/BlueMenta/gtk-3.0/mate-applications.css
@@ -570,6 +570,13 @@ window.background.mate-terminal > box.vertical > notebook > header.top tab:check
     border-width: 1px;
 }
 
+window.background.mate-terminal > box.vertical > notebook:not(.frame) {
+    border-radius: 4px 0px 0px 0px;
+    border-style: solid;
+    border-color: @borders;
+    border-width: 0px 0px 0px 1px;
+}
+
 /****************
  * Pluma *
  ****************/

--- a/desktop-themes/Menta/gtk-3.0/mate-applications.css
+++ b/desktop-themes/Menta/gtk-3.0/mate-applications.css
@@ -569,6 +569,13 @@ window.background.mate-terminal > box.vertical > notebook > header.top tab:check
     border-width: 1px;
 }
 
+window.background.mate-terminal > box.vertical > notebook:not(.frame) {
+    border-radius: 4px 0px 0px 0px;
+    border-style: solid;
+    border-color: @borders;
+    border-width: 0px 0px 0px 1px;
+}
+
 /****************
  * Pluma *
  ****************/


### PR DESCRIPTION
The issue (menta theme capture screen):

![image4493](https://cloud.githubusercontent.com/assets/7734191/24432815/ddbd47a6-1424-11e7-96bb-38a4b30d4cc9.png)

I did it the same in traditional themes

Note: This is only for mate-terminal and doesn't affect another applications