### PR TITLE
Menta themes: set color to the notebook header border

### DIFF
--- a/desktop-themes/BlueMenta/gtk-3.0/mate-applications.css
+++ b/desktop-themes/BlueMenta/gtk-3.0/mate-applications.css
@@ -906,6 +906,7 @@ window.background.mate-terminal > box.vertical > notebook > stack > box {
 
 window.background.mate-terminal > box.vertical > notebook > header.top {
     border-width: 0px 0px 0px 1px;
+    border-color: @theme_bg_color;
 }
 
 /*************************

--- a/desktop-themes/Menta/gtk-3.0/mate-applications.css
+++ b/desktop-themes/Menta/gtk-3.0/mate-applications.css
@@ -909,6 +909,7 @@ window.background.mate-terminal > box.vertical > notebook > stack > box {
 
 window.background.mate-terminal > box.vertical > notebook > header.top {
     border-width: 0px 0px 0px 1px;
+    border-color: @theme_bg_color;
 }
 
 /*************************


### PR DESCRIPTION
after the commit https://github.com/mate-desktop/mate-themes/commit/15152c6c5716464fba57e44c324a168e9a5a3101 we have this issue:

![image4493](https://cloud.githubusercontent.com/assets/7734191/24481575/746bde6c-14eb-11e7-93cd-dd0ce7319e5b.png)

If we move the left tab to the right

This is the fix for menta themes, using the exactly color needed, I don't know if this color is defined with some name

I don't know how to do for traditional themes, I need to use a gradient color for the border

Probably more themes are affected, I didn't test all