### PR TITLE
Restore Polish translation credits from GNOME

### DIFF
--- a/po/gnome-copyrights.txt
+++ b/po/gnome-copyrights.txt
@@ -736,16 +736,14 @@
 
 
 ========== pl.po ==========
-# translation of mate-themes to Polish
-# Artur Flinta <aflinta@gmail.com>, 2006.
-# Tomasz Dominikowski <tdominikowski@aviary.pl>, 2008
-# Copyright (C) 2001-2008 Free Software Foundation, Inc.
-# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-# Aviary.pl
-# Jeśli masz jakiekolwiek uwagi odnoszące się do tłumaczenia lub chcesz
-# pomóc w jego rozwijaniu i pielęgnowaniu, napisz do nas:
-# matepl@aviary.pl
-# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+# Polish translation for gnome-themes.
+# Copyright © 2003-2009 the gnome-themes authors.
+# This file is distributed under the same license as the gnome-themes package.
+# Zbigniew Chyla <chyla@alice.ci.pwr.wroc.pl>, 2003.
+# Artur Flinta <aflinta@at.kernel.pl>, 2003-2007.
+# Tomasz Dominikowski <dominikowski@gmail.com>, 2008-2009.
+# Aviary.pl <gnomepl@aviary.pl>, 2008-2009.
+#
 
 
 


### PR DESCRIPTION
This commit restores proper credits and copyrights for the Polish translation that were somehow lost during forking, using historical information from git.gnome.org.