### PR TITLE
Fix HighContrast bogus transparency with metacity

### DIFF
--- a/desktop-themes/HighContrastInverse/metacity-1/metacity-theme-1.xml
+++ b/desktop-themes/HighContrastInverse/metacity-1/metacity-theme-1.xml
@@ -135,11 +135,11 @@
   <line color="gtk:fg[NORMAL]"
         x1="ButtonIPad" y1="ButtonIPad"
         x2="width - ButtonIPad - 1" y2="height - ButtonIPad - 1"
-        width="1"/>
+        width="3"/>
   <line color="gtk:fg[NORMAL]"
         x1="ButtonIPad" y1="height - ButtonIPad - 1"
         x2="width - ButtonIPad - 1" y2="ButtonIPad"
-	width="1"/>
+	width="3"/>
 </draw_ops>
 
 <draw_ops name="close_button_pressed">
@@ -147,7 +147,9 @@
 </draw_ops>
 
 <draw_ops name="outer_bevel">
-  <rectangle color="gtk:fg[NORMAL]"
+  <rectangle color="gtk:bg[NORMAL]" filled="true"
+             x="1" y="1" width="width-3" height="height-3"/>
+  <rectangle color="gtk:fg[NORMAL]" filled="false"
              x="0" y="0" width="width-1" height="height-1"/>
   <line color="gtk:light[NORMAL]"
         x1="1" y1="1" x2="1" y2="height-2"/>

--- a/marco-themes/HighContrast/metacity-theme-1.xml
+++ b/marco-themes/HighContrast/metacity-theme-1.xml
@@ -72,11 +72,18 @@
 </draw_ops>
 
 <draw_ops name="menu_button">
-  <gtk_arrow state="normal" shadow="out" arrow="down"
-             x="ArrowSpacer `min` (width-MinArrowSize)/2"
-             y="ArrowSpacer `min` (height-MinArrowSize)/2"
-             width="(width-(ArrowSpacer*2)) `max` MinArrowSize"
-             height="(height-(ArrowSpacer*2)) `max` MinArrowSize"/>
+  <line color="gtk:bg[NORMAL]"
+             x1="ArrowSpacer `min` (width-MinArrowSize)/2"
+	     y1="ArrowSpacer `min` (height-MinArrowSize)/2"
+	     x2="width/2"
+	     y2="(height - ArrowSpacer) `max` (height - (height-MinArrowSize)/2)"
+	     width="3"/>
+  <line color="gtk:bg[NORMAL]"
+             x1="(width - ArrowSpacer) `max` (width - (width-MinArrowSize)/2)"
+	     y1="ArrowSpacer `min` (height-MinArrowSize)/2"
+	     x2="width/2"
+	     y2="(height - ArrowSpacer) `max` (height - (height-MinArrowSize)/2)"
+	     width="3"/>
 </draw_ops>
 
 <draw_ops name="menu_button_pressed">
@@ -135,11 +142,11 @@
   <line color="gtk:bg[NORMAL]"
         x1="ButtonIPad" y1="ButtonIPad"
         x2="width - ButtonIPad - 1" y2="height - ButtonIPad - 1"
-        width="1"/>
+        width="3"/>
   <line color="gtk:bg[NORMAL]"
         x1="ButtonIPad" y1="height - ButtonIPad - 1"
         x2="width - ButtonIPad - 1" y2="ButtonIPad"
-	width="1"/>
+	width="3"/>
 </draw_ops>
 
 <draw_ops name="close_button_pressed">
@@ -147,7 +154,7 @@
 </draw_ops>
 
 <draw_ops name="outer_bevel">
-  <rectangle color="gtk:fg[NORMAL]"
+  <rectangle color="gtk:fg[NORMAL]" filled="true"
              x="0" y="0" width="width-1" height="height-1"/>
   <line color="gtk:light[NORMAL]"
         x1="1" y1="1" x2="1" y2="height-2"/>


### PR DESCRIPTION
When rendered with metacity (e.g. with metacity-theme-viewer), the
back background parts of HighContrast and HighContrastInverse actually
show up transparent. This is because the corresponding rectangles were
missing the filled attribute.

In the HighContrast case, the gtk_arrow is black (and there is currently no
way to change the color), so a white rectangle needs to be added under it.

Fixes #211