### PR TITLE
Update default cursor size

### DIFF
--- a/desktop-themes/TraditionalGreen/index.theme.in
+++ b/desktop-themes/TraditionalGreen/index.theme.in
@@ -9,5 +9,5 @@ GtkTheme=TraditionalGreen
 MetacityTheme=TraditionalGreen
 IconTheme=menta
 CursorTheme=mate
-CursorSize=16
+CursorSize=24
 ButtonLayout=:minimize,maximize,close

--- a/desktop-themes/TraditionalOk/index.theme.in
+++ b/desktop-themes/TraditionalOk/index.theme.in
@@ -9,5 +9,5 @@ GtkTheme=TraditionalOk
 MetacityTheme=TraditionalOk
 IconTheme=mate
 CursorTheme=mate
-CursorSize=16
+CursorSize=24
 ButtonLayout=:minimize,maximize,close


### PR DESCRIPTION
The mate cursor theme does not have a 16px size cursor. This causes
problems when switching between HiDPI and Regular resolutions, as the
system cannot determine which cursor size to scale from. Updating the
Traditional themes to use 24px looks better for both regular and HiDPI
displays and fixes pointer size glitches.