### PR TITLE
Fix more HighContrast themes visibility with metacity

### DIFF
--- a/desktop-themes/HighContrastInverse/metacity-1/metacity-theme-1.xml
+++ b/desktop-themes/HighContrastInverse/metacity-1/metacity-theme-1.xml
@@ -279,13 +279,13 @@
 </frame_style>
 
 <frame_style name="maximized_unfocused" geometry="normal_small_borders" parent="normal_unfocused">
-  <piece position="entire_background" draw_ops="blank"/>
+  <piece position="entire_background" draw_ops="background_unfocused"/>
   <button function="maximize" state="normal" draw_ops="restore_button"/>
   <button function="maximize" state="pressed" draw_ops="restore_button_pressed"/>
 </frame_style>
 
 <frame_style name="maximized_focused" geometry="normal_small_borders" parent="normal_focused">
-  <piece position="entire_background" draw_ops="focus_outline"/>
+  <piece position="entire_background" draw_ops="focus_background"/>
   <button function="maximize" state="normal" draw_ops="restore_button"/>
   <button function="maximize" state="pressed" draw_ops="restore_button_pressed"/>
 </frame_style>

--- a/marco-themes/HighContrast/metacity-theme-1.xml
+++ b/marco-themes/HighContrast/metacity-theme-1.xml
@@ -284,13 +284,13 @@
 </frame_style>
 
 <frame_style name="maximized_unfocused" geometry="normal_small_borders" parent="normal_unfocused">
-  <piece position="entire_background" draw_ops="blank"/>
+  <piece position="entire_background" draw_ops="background_unfocused"/>
   <button function="maximize" state="normal" draw_ops="restore_button"/>
   <button function="maximize" state="pressed" draw_ops="restore_button_pressed"/>
 </frame_style>
 
 <frame_style name="maximized_focused" geometry="normal_small_borders" parent="normal_focused">
-  <piece position="entire_background" draw_ops="focus_outline"/>
+  <piece position="entire_background" draw_ops="focus_background"/>
   <button function="maximize" state="normal" draw_ops="restore_button"/>
   <button function="maximize" state="pressed" draw_ops="restore_button_pressed"/>
 </frame_style>


### PR DESCRIPTION
This completes cf0a970f26d3 ("Fix HighContrast themes visibility with
metacity").

When maximized windows are rendered with metacity (e.g. with
metacity-theme-viewer), the back background parts of HighContrast and
HighContrastInverse actually show up transparent. This is because the
maximized_unfocused and maximized_focused styles do not use the proper
focus draw_ops like normal_focused and normal_unfocused.