### PR TITLE
gtk-stop deprecated since version 3.10

### DIFF
--- a/common/gtk-stock-icons.rc
+++ b/common/gtk-stock-icons.rc
@@ -88,7 +88,7 @@
   stock["gtk-sort-ascending"] =	{{ "stock_sort-ascending.png" }}
   stock["gtk-sort-descending"] ={{ "stock_sort-descending.png" }}
   stock["gtk-spell-check"] =	{{ "stock_spell-check.png" }}
-  stock["gtk-stop"] =		{{ "stock_stop.png" }}
+  stock["process-stop"] =	{{ "stock_stop.png" }}
   stock["gtk-strikethrough"] =	{{ "stock_strikethrough.png" }}
   stock["gtk-undelete"] =	{{ "stock_undelete.png" }}
   stock["gtk-underline"] =	{{ "stock_underline.png" }}


### PR DESCRIPTION
Error loading button UI: /usr/local/share/mate-calc/buttons-programming.ui:38:41 Object with ID image1 not found

https://github.com/mate-desktop/mate-calc/blob/931b63cc3b4805a0c5b9f6eaa424498b7cde026b/data/buttons-programming.ui#L8

REF: https://developer.gnome.org/gtk3/stable/gtk3-Stock-Items.html