### PR TITLE
Fix hard to resize windows in BlackMATE

### DIFF
--- a/desktop-themes/BlackMATE/metacity-1/metacity-theme-1.xml
+++ b/desktop-themes/BlackMATE/metacity-1/metacity-theme-1.xml
@@ -13,8 +13,8 @@
 <!--================-->
 
 <frame_geometry name="normal" rounded_top_left="true" rounded_bottom_left="true" rounded_top_right="true" rounded_bottom_right="true">
-  <distance name="left_width" value="2"/>
-  <distance name="right_width" value="2"/>
+  <distance name="left_width" value="5"/>
+  <distance name="right_width" value="5"/>
   <distance name="bottom_height" value="6"/>
   <distance name="left_titlebar_edge" value="4"/>
   <distance name="right_titlebar_edge" value="4"/>

--- a/desktop-themes/BlackMATE/metacity-1/metacity-theme-2.xml
+++ b/desktop-themes/BlackMATE/metacity-1/metacity-theme-2.xml
@@ -13,8 +13,8 @@
 <!--================-->
 
 <frame_geometry name="normal" rounded_top_left="true" rounded_bottom_left="true" rounded_top_right="true" rounded_bottom_right="true">
-  <distance name="left_width" value="2"/>
-  <distance name="right_width" value="2"/>
+  <distance name="left_width" value="5"/>
+  <distance name="right_width" value="5"/>
   <distance name="bottom_height" value="6"/>
   <distance name="left_titlebar_edge" value="4"/>
   <distance name="right_titlebar_edge" value="4"/>

--- a/desktop-themes/BlackMATE/metacity-1/metacity-theme-3.xml
+++ b/desktop-themes/BlackMATE/metacity-1/metacity-theme-3.xml
@@ -22,9 +22,9 @@
 
 <frame_geometry name="normal" title_scale="medium" rounded_top_left="4" rounded_top_right="4">
 	<!-- frame widths -->
-	<distance name="left_width" value="1" />
-	<distance name="right_width" value="1" />
-	<distance name="bottom_height" value="1" />
+	<distance name="left_width" value="5" />
+	<distance name="right_width" value="5" />
+	<distance name="bottom_height" value="6" />
 	<!-- distance of the left button from the left edge -->
 	<distance name="left_titlebar_edge" value="1"/>
 	<distance name="right_titlebar_edge" value="0"/>


### PR DESCRIPTION
With recent changes in (probably) GTK3, windows became hard to resize in BlackMATE due to 1px border width requiring exact alignment of the cursor in metacity-theme-3.xml .
https://github.com/mate-desktop/mate-themes/issues/249
Change left/right borders to 5px and bottom border to 6px (the latter already specified for metacity-theme-1.xml and  metacity-theme-2.xml ).