### PR TITLE
Change url project's website

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ(2.53)
 
-AC_INIT([mate-themes], [3.22.19], [http://www.mate-desktop.org])
+AC_INIT([mate-themes], [3.22.19], [https://mate-desktop.org])
 AC_CONFIG_SRCDIR([icon-themes])
 
 AM_INIT_AUTOMAKE([1.9 tar-ustar dist-xz no-dist-gzip check-news])


### PR DESCRIPTION
Now the official web site is https://mate-desktop.org/.