### PR TITLE
Migrate from intltool to gettext

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,17 +1,16 @@
 SUBDIRS = \
+	po	\
 	marco-themes \
 	icon-themes \
 	desktop-themes \
-	cursor-themes \
-	po
+	cursor-themes
+
+ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 
 EXTRA_DIST = \
-	autogen.sh \
-	intltool-extract.in \
-	intltool-merge.in \
-	intltool-update.in
+	autogen.sh
 
-DISTCLEANFILES=intltool-extract intltool-merge intltool-update
+DISTCLEANFILES=
 
 # Build ChangeLog from GIT  history
 ChangeLog:

--- a/configure.ac
+++ b/configure.ac
@@ -10,13 +10,9 @@ AM_INIT_AUTOMAKE([1.9 tar-ustar dist-xz no-dist-gzip check-news])
 # configure or passing V=1 to make
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
-IT_PROG_INTLTOOL([0.35.0])
 PKG_PROG_PKG_CONFIG([0.19])
-
-AM_GLIB_GNU_GETTEXT
-GETTEXT_PACKAGE=AC_PACKAGE_NAME
-AC_SUBST(GETTEXT_PACKAGE)
-AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE, "$GETTEXT_PACKAGE", [Gettext package.])
+AM_GNU_GETTEXT_VERSION([0.19.8])
+AM_GNU_GETTEXT([external])
 
 # Workaround to make aclocal get the right flags
 AC_SUBST(ACLOCAL_AMFLAGS, "\${ACLOCAL_FLAGS}")

--- a/cursor-themes/mate-black/Makefile.am
+++ b/cursor-themes/mate-black/Makefile.am
@@ -1,12 +1,13 @@
 THEME_NAME=mate-black
 THEME_IN_FILES=index.theme.in
 
-@INTLTOOL_THEME_RULE@
- 
 themedir = $(datadir)/icons/$(THEME_NAME)
 
 theme_DATA = \
 	index.theme
+
+$(theme_DATA): $(THEME_IN_FILES)
+	$(AM_V_GEN) $(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
 
 SUBDIRS = \
 	cursors

--- a/cursor-themes/mate-black/index.theme.in
+++ b/cursor-themes/mate-black/index.theme.in
@@ -1,4 +1,4 @@
 [Icon Theme]
-_Name=MATE (Black)
+Name=MATE (Black)
 Example=start-here
 

--- a/desktop-themes/BlackMATE-border/Makefile.am
+++ b/desktop-themes/BlackMATE-border/Makefile.am
@@ -1,11 +1,11 @@
 THEME_NAME=BlackMATE-border
 THEME_IN_FILES=index.theme.in
 
-@INTLTOOL_THEME_RULE@
-
 themedir = $(datadir)/themes/$(THEME_NAME)
 
 theme_DATA = index.theme
+$(theme_DATA): $(THEME_IN_FILES)
+	$(AM_V_GEN) $(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
 
 SUBDIRS = \
 	metacity-1

--- a/desktop-themes/BlackMATE/Makefile.am
+++ b/desktop-themes/BlackMATE/Makefile.am
@@ -1,14 +1,15 @@
 THEME_NAME=	BlackMATE
 THEME_IN_FILES=index.theme.in
 
-@INTLTOOL_THEME_RULE@
- 
 themedir = $(datadir)/themes/$(THEME_NAME)
 
 theme_DATA = \
 	COPYING \
 	index.theme \
 	README
+
+%.theme: %.theme.in
+	$(AM_V_GEN) $(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
 
 SUBDIRS =		\
 	gtk-2.0		\

--- a/desktop-themes/BlackMATE/index.theme.in
+++ b/desktop-themes/BlackMATE/index.theme.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=X-GNOME-Metatheme
 Name=BlackMATE
-_Comment=A clean dark theme
+Comment=A clean dark theme
 Encoding=UTF-8
 
 [X-GNOME-Metatheme]

--- a/desktop-themes/Blue-Submarine-border/Makefile.am
+++ b/desktop-themes/Blue-Submarine-border/Makefile.am
@@ -1,11 +1,12 @@
 THEME_NAME=Blue-Submarine-border
 THEME_IN_FILES=index.theme.in
 
-@INTLTOOL_THEME_RULE@
- 
 themedir = $(datadir)/themes/$(THEME_NAME)
 
 theme_DATA = index.theme
+
+$(theme_DATA): $(THEME_IN_FILES)
+	$(AM_V_GEN) $(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
 
 SUBDIRS = \
 	metacity-1

--- a/desktop-themes/Blue-Submarine/Makefile.am
+++ b/desktop-themes/Blue-Submarine/Makefile.am
@@ -1,11 +1,12 @@
 THEME_NAME=Blue-Submarine
 THEME_IN_FILES=index.theme.in
 
-@INTLTOOL_THEME_RULE@
- 
 themedir = $(datadir)/themes/$(THEME_NAME)
 
 theme_DATA = index.theme
+
+$(theme_DATA): $(THEME_IN_FILES)
+	$(AM_V_GEN) $(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
 
 SUBDIRS =		\
 	cinnamon	\

--- a/desktop-themes/Blue-Submarine/index.theme.in
+++ b/desktop-themes/Blue-Submarine/index.theme.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=X-GNOME-Metatheme
 Name=Blue-Submarine
-_Comment=A medium blue theme with dark menus and panel
+Comment=A medium blue theme with dark menus and panel
 Encoding=UTF-8
 
 [X-GNOME-Metatheme]

--- a/desktop-themes/BlueMenta-border/Makefile.am
+++ b/desktop-themes/BlueMenta-border/Makefile.am
@@ -1,14 +1,15 @@
 THEME_NAME=BlueMenta-border
 THEME_IN_FILES=index.theme.in
 
-@INTLTOOL_THEME_RULE@
- 
 themedir = $(datadir)/themes/$(THEME_NAME)
 
 theme_DATA = \
 	COPYING \
 	index.theme \
 	README
+
+%.theme: %.theme.in
+	$(AM_V_GEN) $(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
 
 SUBDIRS =		\
 	metacity-1

--- a/desktop-themes/BlueMenta-border/index.theme.in
+++ b/desktop-themes/BlueMenta-border/index.theme.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=X-GNOME-Metatheme
 Name=BlueMenta-border
-_Comment=A clean light theme with blue elements with huge borders for using without compositor
+Comment=A clean light theme with blue elements with huge borders for using without compositor
 Encoding=UTF-8
 
 [X-GNOME-Metatheme]

--- a/desktop-themes/BlueMenta/Makefile.am
+++ b/desktop-themes/BlueMenta/Makefile.am
@@ -1,14 +1,15 @@
 THEME_NAME=BlueMenta
 THEME_IN_FILES=index.theme.in
 
-@INTLTOOL_THEME_RULE@
- 
 themedir = $(datadir)/themes/$(THEME_NAME)
 
 theme_DATA = \
 	COPYING \
 	index.theme \
 	README
+
+%.theme: %.theme.in
+	$(AM_V_GEN) $(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
 
 SUBDIRS =		\
 	cinnamon \

--- a/desktop-themes/BlueMenta/index.theme.in
+++ b/desktop-themes/BlueMenta/index.theme.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=X-GNOME-Metatheme
 Name=BlueMenta
-_Comment=A clean light theme with blue elements
+Comment=A clean light theme with blue elements
 Encoding=UTF-8
 
 [X-GNOME-Metatheme]

--- a/desktop-themes/ContrastHigh/Makefile.am
+++ b/desktop-themes/ContrastHigh/Makefile.am
@@ -1,11 +1,12 @@
 THEME_NAME=ContrastHigh
 THEME_IN_FILES=index.theme.in
 
-@INTLTOOL_THEME_RULE@
- 
 themedir = $(datadir)/themes/$(THEME_NAME)
 
 theme_DATA = index.theme
+
+$(theme_DATA): $(THEME_IN_FILES)
+	$(AM_V_GEN) $(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
 
 DISTCLEANFILES = index.theme
 EXTRA_DIST = index.theme.in

--- a/desktop-themes/ContrastHigh/index.theme.in
+++ b/desktop-themes/ContrastHigh/index.theme.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=X-GNOME-Metatheme
 Name=High Contrast
-_Comment=High contrast theme
+Comment=High contrast theme
 Encoding=UTF-8
 
 [X-GNOME-Metatheme]

--- a/desktop-themes/Green-Submarine-border/Makefile.am
+++ b/desktop-themes/Green-Submarine-border/Makefile.am
@@ -1,11 +1,12 @@
 THEME_NAME=Green-Submarine-border
 THEME_IN_FILES=index.theme.in
 
-@INTLTOOL_THEME_RULE@
- 
 themedir = $(datadir)/themes/$(THEME_NAME)
 
 theme_DATA = index.theme
+
+$(theme_DATA): $(THEME_IN_FILES)
+	$(AM_V_GEN) $(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
 
 SUBDIRS = \
 	metacity-1

--- a/desktop-themes/Green-Submarine-border/index.theme.in
+++ b/desktop-themes/Green-Submarine-border/index.theme.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=X-GNOME-Metatheme
 Name=Green-Submarine-border
-_Comment=A medium green theme with dark menus and panel with huge borders for using without compositor
+Comment=A medium green theme with dark menus and panel with huge borders for using without compositor
 Encoding=UTF-8
 
 [X-GNOME-Metatheme]

--- a/desktop-themes/Green-Submarine/Makefile.am
+++ b/desktop-themes/Green-Submarine/Makefile.am
@@ -1,11 +1,12 @@
 THEME_NAME=Green-Submarine
 THEME_IN_FILES=index.theme.in
 
-@INTLTOOL_THEME_RULE@
- 
 themedir = $(datadir)/themes/$(THEME_NAME)
 
 theme_DATA = index.theme
+
+$(theme_DATA): $(THEME_IN_FILES)
+	$(AM_V_GEN) $(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
 
 SUBDIRS =		\
 	cinnamon	\

--- a/desktop-themes/Green-Submarine/index.theme.in
+++ b/desktop-themes/Green-Submarine/index.theme.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=X-GNOME-Metatheme
 Name=Green-Submarine
-_Comment=A medium green theme with dark menus and panel
+Comment=A medium green theme with dark menus and panel
 Encoding=UTF-8
 
 [X-GNOME-Metatheme]

--- a/desktop-themes/GreenLaguna-border/Makefile.am
+++ b/desktop-themes/GreenLaguna-border/Makefile.am
@@ -1,13 +1,14 @@
 THEME_NAME=GreenLaguna-border
 THEME_IN_FILES=index.theme.in
 
-@INTLTOOL_THEME_RULE@
- 
 themedir = $(datadir)/themes/$(THEME_NAME)
 
 theme_DATA = \
 	COPYING \
 	index.theme
+
+%.theme: %.theme.in
+	$(AM_V_GEN) $(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
 
 SUBDIRS = \
 	metacity-1

--- a/desktop-themes/GreenLaguna/Makefile.am
+++ b/desktop-themes/GreenLaguna/Makefile.am
@@ -1,14 +1,15 @@
 THEME_NAME=GreenLaguna
 THEME_IN_FILES=index.theme.in
 
-@INTLTOOL_THEME_RULE@
- 
 themedir = $(datadir)/themes/$(THEME_NAME)
 
 theme_DATA = \
 	COPYING \
 	index.theme \
 	README
+
+%.theme: %.theme.in
+	$(AM_V_GEN) $(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
 
 SUBDIRS =		\
 	gtk-2.0		\

--- a/desktop-themes/GreenLaguna/index.theme.in
+++ b/desktop-themes/GreenLaguna/index.theme.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=X-GNOME-Metatheme
 Name=GreenLaguna
-_Comment=A clean light green theme
+Comment=A clean light green theme
 Encoding=UTF-8
 
 [X-GNOME-Metatheme]

--- a/desktop-themes/HighContrastInverse/Makefile.am
+++ b/desktop-themes/HighContrastInverse/Makefile.am
@@ -1,11 +1,12 @@
 THEME_NAME=HighContrastInverse
 THEME_IN_FILES=index.theme.in
 
-@INTLTOOL_THEME_RULE@ 
-
 themedir = $(datadir)/themes/$(THEME_NAME)
 
 theme_DATA = index.theme
+
+$(theme_DATA): $(THEME_IN_FILES)
+	$(AM_V_GEN) $(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
 
 SUBDIRS =      \
 	gtk-2.0	   \

--- a/desktop-themes/HighContrastInverse/index.theme.in
+++ b/desktop-themes/HighContrastInverse/index.theme.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=X-GNOME-Metatheme
-_Name=High Contrast Inverse
-_Comment=White-on-black text and icons
+Name=High Contrast Inverse
+Comment=White-on-black text and icons
 Encoding=UTF-8
 
 [X-GNOME-Metatheme]

--- a/desktop-themes/Menta-border/Makefile.am
+++ b/desktop-themes/Menta-border/Makefile.am
@@ -1,14 +1,15 @@
 THEME_NAME=Menta-border
 THEME_IN_FILES=index.theme.in
 
-@INTLTOOL_THEME_RULE@
- 
 themedir = $(datadir)/themes/$(THEME_NAME)
 
 theme_DATA = \
 	COPYING \
 	index.theme \
 	README
+
+%.theme: %.theme.in
+	$(AM_V_GEN) $(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
 
 SUBDIRS = \
 	metacity-1

--- a/desktop-themes/Menta/Makefile.am
+++ b/desktop-themes/Menta/Makefile.am
@@ -1,14 +1,15 @@
 THEME_NAME=Menta
 THEME_IN_FILES=index.theme.in
 
-@INTLTOOL_THEME_RULE@
- 
 themedir = $(datadir)/themes/$(THEME_NAME)
 
 theme_DATA = \
 	COPYING \
 	index.theme \
 	README
+
+%.theme: %.theme.in
+	$(AM_V_GEN) $(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
 
 SUBDIRS = \
 	cinnamon \

--- a/desktop-themes/Menta/index.theme.in
+++ b/desktop-themes/Menta/index.theme.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=X-GNOME-Metatheme
 Name=Menta
-_Comment=A clean light theme with green elements
+Comment=A clean light theme with green elements
 Encoding=UTF-8
 
 [X-GNOME-Metatheme]

--- a/desktop-themes/TraditionalGreen/Makefile.am
+++ b/desktop-themes/TraditionalGreen/Makefile.am
@@ -1,13 +1,14 @@
 THEME_NAME=TraditionalGreen
 THEME_IN_FILES=index.theme.in
 
-@INTLTOOL_THEME_RULE@
- 
 themedir = $(datadir)/themes/$(THEME_NAME)
 
 theme_DATA = \
 	COPYING \
 	index.theme
+
+%.theme: %.theme.in
+	$(AM_V_GEN) $(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
 
 SUBDIRS =		\
 	gtk-2.0		\

--- a/desktop-themes/TraditionalGreen/index.theme.in
+++ b/desktop-themes/TraditionalGreen/index.theme.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=X-GNOME-Metatheme
 Name=TraditionalGreen
-_Comment=Green port of Clearlooks-Phenix
+Comment=Green port of Clearlooks-Phenix
 Encoding=UTF-8
 
 [X-GNOME-Metatheme]

--- a/desktop-themes/TraditionalOk/Makefile.am
+++ b/desktop-themes/TraditionalOk/Makefile.am
@@ -1,13 +1,14 @@
 THEME_NAME=TraditionalOk
 THEME_IN_FILES=index.theme.in
 
-@INTLTOOL_THEME_RULE@
- 
 themedir = $(datadir)/themes/$(THEME_NAME)
 
 theme_DATA = \
 	COPYING \
 	index.theme
+
+%.theme: %.theme.in
+	$(AM_V_GEN) $(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
 
 SUBDIRS =		\
 	gtk-2.0		\

--- a/desktop-themes/TraditionalOk/index.theme.in
+++ b/desktop-themes/TraditionalOk/index.theme.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=X-GNOME-Metatheme
 Name=TraditionalOk
-_Comment=Port of Clearlooks-Phenix
+Comment=Port of Clearlooks-Phenix
 Encoding=UTF-8
 
 [X-GNOME-Metatheme]

--- a/po/Makevars
+++ b/po/Makevars
@@ -1,0 +1,78 @@
+# Makefile variables for PO directory in any package using GNU gettext.
+
+# Usually the message domain is the same as the package name.
+DOMAIN = $(PACKAGE)
+
+# These two variables depend on the location of this directory.
+subdir = po
+top_builddir = ..
+
+# These options get passed to xgettext.
+XGETTEXT_OPTIONS = --from-code=UTF-8 --language=Desktop --add-comments
+
+# This is the copyright holder that gets inserted into the header of the
+# $(DOMAIN).pot file.  Set this to the copyright holder of the surrounding
+# package.  (Note that the msgstr strings, extracted from the package's
+# sources, belong to the copyright holder of the package.)  Translators are
+# expected to transfer the copyright for their translations to this person
+# or entity, or to disclaim their copyright.  The empty string stands for
+# the public domain; in this case the translators are expected to disclaim
+# their copyright.
+COPYRIGHT_HOLDER = MATE Desktop Environment team
+
+# This tells whether or not to prepend "GNU " prefix to the package
+# name that gets inserted into the header of the $(DOMAIN).pot file.
+# Possible values are "yes", "no", or empty.  If it is empty, try to
+# detect it automatically by scanning the files in $(top_srcdir) for
+# "GNU packagename" string.
+PACKAGE_GNU =
+
+# This is the email address or URL to which the translators shall report
+# bugs in the untranslated strings:
+# - Strings which are not entire sentences, see the maintainer guidelines
+#   in the GNU gettext documentation, section 'Preparing Strings'.
+# - Strings which use unclear terms or require additional context to be
+#   understood.
+# - Strings which make invalid assumptions about notation of date, time or
+#   money.
+# - Pluralisation problems.
+# - Incorrect English spelling.
+# - Incorrect formatting.
+# It can be your email address, or a mailing list address where translators
+# can write to without being subscribed, or the URL of a web page through
+# which the translators can contact you.
+MSGID_BUGS_ADDRESS =
+
+# This is the list of locale categories, beyond LC_MESSAGES, for which the
+# message catalogs shall be used.  It is usually empty.
+EXTRA_LOCALE_CATEGORIES =
+
+# This tells whether the $(DOMAIN).pot file contains messages with an 'msgctxt'
+# context.  Possible values are "yes" and "no".  Set this to yes if the
+# package uses functions taking also a message context, like pgettext(), or
+# if in $(XGETTEXT_OPTIONS) you define keywords with a context argument.
+USE_MSGCTXT = no
+
+# These options get passed to msgmerge.
+# Useful options are in particular:
+#   --previous            to keep previous msgids of translated messages,
+#   --quiet               to reduce the verbosity.
+MSGMERGE_OPTIONS =
+
+# These options get passed to msginit.
+# If you want to disable line wrapping when writing PO files, add
+# --no-wrap to MSGMERGE_OPTIONS, XGETTEXT_OPTIONS, and
+# MSGINIT_OPTIONS.
+MSGINIT_OPTIONS =
+
+# This tells whether or not to regenerate a PO file when $(DOMAIN).pot
+# has changed.  Possible values are "yes" and "no".  Set this to no if
+# the POT file is checked in the repository and the version control
+# program ignores timestamps.
+PO_DEPENDS_ON_POT = yes
+
+# This tells whether or not to forcibly update $(DOMAIN).pot and
+# regenerate PO files on "make dist".  Possible values are "yes" and
+# "no".  Set this to no if the POT file and PO files are maintained
+# externally.
+DIST_DEPENDS_ON_UPDATE_PO = yes


### PR DESCRIPTION
When the gettext version is 0.20 (on Archlinux), it will fail on some po files, I am not sure if this is a bug in gettext 0.20 or a bug in po file.