### PR TITLE
Traditional themes: fix tooltip shadow on openindiana

### DIFF
--- a/desktop-themes/TraditionalGreen/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/TraditionalGreen/gtk-3.0/gtk-widgets.css
@@ -70,7 +70,7 @@ tooltip.background,
     border-style: solid;
     border-width: 1px;
     border-color: @theme_tooltip_border_color;
-    border-radius: 0px;
+    border-radius: 2px;
     background-color: @theme_tooltip_bg_color;
     color: @theme_tooltip_fg_color;
     text-shadow: none;

--- a/desktop-themes/TraditionalOk/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/TraditionalOk/gtk-3.0/gtk-widgets.css
@@ -70,7 +70,7 @@ tooltip.background,
     border-style: solid;
     border-width: 1px;
     border-color: @theme_tooltip_border_color;
-    border-radius: 0px;
+    border-radius: 2px;
     background-color: @theme_tooltip_bg_color;
     color: @theme_tooltip_fg_color;
     text-shadow: none;


### PR DESCRIPTION
The compositor doesn't apply the shadow mask if border-radius is 0

closes https://github.com/mate-desktop/mate-themes/issues/255