### PR TITLE
scrolledwindows: Remove applet border and background

### DIFF
--- a/desktop-themes/BlackMATE/gtk-3.0/mate-applications.css
+++ b/desktop-themes/BlackMATE/gtk-3.0/mate-applications.css
@@ -667,7 +667,8 @@ na-tray-applet {
     border-width: 1px;
 }
 
-/* globalmenu (vala-panel-appmenu) */
+/* mate-dock-applet, globalmenu (vala-panel-appmenu) */
+#PanelApplet > scrolledwindow > viewport.frame,
 #PanelApplet > .-vala-panel-appmenu-core > scrolledwindow > viewport.frame {
     background-color: transparent;
 }

--- a/desktop-themes/GreenLaguna/gtk-3.0/mate-applications.css
+++ b/desktop-themes/GreenLaguna/gtk-3.0/mate-applications.css
@@ -494,7 +494,8 @@ na-tray-applet > widget > box {
     border-style: solid;
 }
 
-/* globalmenu (vala-panel-appmenu) */
+/* mate-dock-applet, globalmenu (vala-panel-appmenu) */
+#PanelApplet > scrolledwindow > viewport.frame,
 #PanelApplet > .-vala-panel-appmenu-core > scrolledwindow > viewport.frame {
     background-color: transparent;
 }

--- a/desktop-themes/TraditionalGreen/gtk-3.0/mate-applications.css
+++ b/desktop-themes/TraditionalGreen/gtk-3.0/mate-applications.css
@@ -129,8 +129,13 @@ PanelToplevel > grid > button {
     border-radius: 0px;
 }
 
-#PanelApplet {
+#PanelApplet,
+#PanelApplet scrolledwindow {
     border-width: 0;
+}
+
+#PanelApplet scrolledwindow > viewport.frame {
+    background-color: transparent;
 }
 
 PanelSeparator {

--- a/desktop-themes/TraditionalOk/gtk-3.0/mate-applications.css
+++ b/desktop-themes/TraditionalOk/gtk-3.0/mate-applications.css
@@ -128,8 +128,13 @@ PanelToplevel > grid > button {
     border-radius: 0px;
 }
 
-#PanelApplet {
+#PanelApplet,
+#PanelApplet scrolledwindow {
     border-width: 0;
+}
+
+#PanelApplet scrolledwindow > viewport.frame {
+    background-color: transparent;
 }
 
 PanelSeparator {


### PR DESCRIPTION
This fixes some display issues with applets that contain a GtkScrolledWindow on some themes. The main example here is the [mate-dock-applet](https://github.com/ubuntu-mate/mate-dock-applet).

**BlackMATE**
before (wrong background color):
![blackmate-before](https://user-images.githubusercontent.com/259780/67294655-17acc500-f4b4-11e9-8eee-5d6f2da893e4.png)
after:
![blackmate-after](https://user-images.githubusercontent.com/259780/67294654-17acc500-f4b4-11e9-819d-9f563b694daa.png)

**GreenLaguna**
before (wrong background color):
![greenlaguna-before](https://user-images.githubusercontent.com/259780/67294661-17acc500-f4b4-11e9-8b0f-690b24c09727.png)
after:
![greenlaguna-after](https://user-images.githubusercontent.com/259780/67294658-17acc500-f4b4-11e9-805a-ac13a55c65dc.png)

**TraditionalGreen/TraditionalOk**
before (unnecessary border):
![traditional-before](https://user-images.githubusercontent.com/259780/67294669-1a0f1f00-f4b4-11e9-88c5-1f034c95bcd3.png)
after:
![traditional-after](https://user-images.githubusercontent.com/259780/67294668-1a0f1f00-f4b4-11e9-9ec5-7fcf6e13d5c3.png)