### PR TITLE
TraditionalOK GTK3: Core colors through color scheme

### DIFF
--- a/desktop-themes/TraditionalOk/gtk-3.0/gtk.css
+++ b/desktop-themes/TraditionalOk/gtk-3.0/gtk.css
@@ -29,7 +29,7 @@
 /* Core colors are only used in the current file, as bases for other
    color declarations. */
 
-@define-color core_color_a #a4c2e8; /* Core color for blue widgets in TraditionalOK. */
+@define-color core_color_a shade(@theme_selected_bg_color, 1.15); /* Core color for blue widgets in TraditionalOK. */
 @define-color core_color_b #edeceb; /* Core color for gray widgets in TraditionalOK. */
 
 /********************************************


### PR DESCRIPTION
Hi,

Shouldn't core colors to be defined through the colors in the color scheme?

Cheers!