### PR TITLE
Traditional and Menta theme families:  Resolved Caja sidebar display issues (resolves #274)

### DIFF
--- a/desktop-themes/BlueMenta/gtk-3.0/mate-applications.css
+++ b/desktop-themes/BlueMenta/gtk-3.0/mate-applications.css
@@ -165,11 +165,6 @@
     color: @theme_unfocused_fg_color;
 }
 
-/* treeview rows */
-.caja-side-pane treeview.view {
-    padding: 2px 0px;
-}
-
 /* to avoid overlap with eject buttons */
 .caja-side-pane scrolledwindow scrollbar.vertical.left.overlay-indicator,
 .caja-side-pane scrolledwindow scrollbar.vertical.left.overlay-indicator trough,

--- a/desktop-themes/BlueMenta/gtk-3.0/mate-applications.css
+++ b/desktop-themes/BlueMenta/gtk-3.0/mate-applications.css
@@ -165,6 +165,11 @@
     color: @theme_unfocused_fg_color;
 }
 
+/* treeview rows */
+.caja-side-pane treeview.view {
+    padding: 2px;
+}
+
 /* to avoid overlap with eject buttons */
 .caja-side-pane scrolledwindow scrollbar.vertical.left.overlay-indicator,
 .caja-side-pane scrolledwindow scrollbar.vertical.left.overlay-indicator trough,

--- a/desktop-themes/Menta/gtk-3.0/mate-applications.css
+++ b/desktop-themes/Menta/gtk-3.0/mate-applications.css
@@ -165,11 +165,6 @@
     color: @theme_unfocused_fg_color;
 }
 
-/* treeview rows */
-.caja-side-pane treeview.view {
-    padding: 2px 0px;
-}
-
 /* to avoid overlap with eject buttons */
 .caja-side-pane scrolledwindow scrollbar.vertical.left.overlay-indicator,
 .caja-side-pane scrolledwindow scrollbar.vertical.left.overlay-indicator trough,

--- a/desktop-themes/Menta/gtk-3.0/mate-applications.css
+++ b/desktop-themes/Menta/gtk-3.0/mate-applications.css
@@ -165,6 +165,11 @@
     color: @theme_unfocused_fg_color;
 }
 
+/* treeview rows */
+.caja-side-pane treeview.view {
+    padding: 2px;
+}
+
 /* to avoid overlap with eject buttons */
 .caja-side-pane scrolledwindow scrollbar.vertical.left.overlay-indicator,
 .caja-side-pane scrolledwindow scrollbar.vertical.left.overlay-indicator trough,

--- a/desktop-themes/TraditionalGreen/gtk-3.0/mate-applications.css
+++ b/desktop-themes/TraditionalGreen/gtk-3.0/mate-applications.css
@@ -12,16 +12,6 @@
     color: @theme_fg_color;
 }
 
-/* move whole the frame, to free eject button for overlay scrollbars */
-.caja-side-pane scrolledwindow.frame {
-    padding: 0px;
-    margin: 0px 0px 0px -8px;
-}
-
-.caja-side-pane scrolledwindow.frame treeview.view {
-    padding: 3px 0px 3px 0px;
-}
-
 /* better for overlay scrollbars */
 /* to avoid overlap with eject buttons */
 .caja-side-pane scrolledwindow scrollbar.vertical.right.overlay-indicator,

--- a/desktop-themes/TraditionalOk/gtk-3.0/mate-applications.css
+++ b/desktop-themes/TraditionalOk/gtk-3.0/mate-applications.css
@@ -12,16 +12,6 @@
     color: @theme_fg_color;
 }
 
-/* move whole the frame, to free eject button for overlay scrollbars */
-.caja-side-pane scrolledwindow.frame {
-    padding: 0px;
-    margin: 0px 0px 0px -8px;
-}
-
-.caja-side-pane scrolledwindow.frame treeview.view {
-    padding: 3px 0px 3px 0px;
-}
-
 /* better for overlay scrollbars */
 /* to avoid overlap with eject buttons */
 .caja-side-pane scrolledwindow scrollbar.vertical.right.overlay-indicator,


### PR DESCRIPTION
Several lines in the Traditional and Menta theme families, seemingly related to historical overlay scrolling issues, have been removed.  These lines were causing the doubling in height of some rows in the Caja Places, Tree, History and Bookmarks sidebars in all themes, and the chopping off of the left side of said Caja sidebars in the Traditional family of themes.

Please see issue #274 for more discussion about this theming regression.