### PR TITLE
gtk-widgets.css: Add the missing .context-menu class

### DIFF
--- a/desktop-themes/BlackMATE/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/BlackMATE/gtk-3.0/gtk-widgets.css
@@ -2016,6 +2016,12 @@ scrollbar.vertical .slider.fine-tune:hover:active  {
  * Menus *
  *********/
 
+/* Decouple the font of context menus from their entry/textview */
+.context-menu {
+        font: initial;
+        text-shadow: none;
+}
+
 /* this controls the general appearance of the menubar */
 menubar,
 .menubar {

--- a/desktop-themes/BlueMenta/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/BlueMenta/gtk-3.0/gtk-widgets.css
@@ -3021,6 +3021,7 @@ toolbar button menuitem {
 	text-shadow: none;
 }
 
+/* Decouple the font of context menus from their entry/textview */
 .context-menu {
 	font: initial;
 	text-shadow: none;

--- a/desktop-themes/GreenLaguna/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/GreenLaguna/gtk-3.0/gtk-widgets.css
@@ -2323,6 +2323,12 @@ filechooser paned.horizontal box.vertical box.horizontal .view box.vertical {
  * Menus *
  *********/
 
+/* Decouple the font of context menus from their entry/textview */
+.context-menu {
+        font: initial;
+        text-shadow: none;
+}
+
 /* this controls the general appearance of the menubar */
 menubar,
 .menubar {

--- a/desktop-themes/Menta/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/Menta/gtk-3.0/gtk-widgets.css
@@ -3021,6 +3021,7 @@ toolbar button menuitem {
 	text-shadow: none;
 }
 
+/* Decouple the font of context menus from their entry/textview */
 .context-menu {
 	font: initial;
 	text-shadow: none;

--- a/desktop-themes/TraditionalGreen/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/TraditionalGreen/gtk-3.0/gtk-widgets.css
@@ -2396,6 +2396,12 @@ treemenu menuitem {
     padding: 2px;
 }
 
+/* Decouple the font of context menus from their entry/textview */
+.context-menu {
+        font: initial;
+        text-shadow: none;
+}
+
 menu,
 .menu {
     font-weight: normal;

--- a/desktop-themes/TraditionalOk/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/TraditionalOk/gtk-3.0/gtk-widgets.css
@@ -2396,6 +2396,12 @@ treemenu menuitem {
     padding: 2px;
 }
 
+/* Decouple the font of context menus from their entry/textview */
+.context-menu {
+        font: initial;
+        text-shadow: none;
+}
+
 menu,
 .menu {
     font-weight: normal;


### PR DESCRIPTION
See https://github.com/mate-desktop/pluma/pull/582#issuecomment-710752054