### PR TITLE
Fix blackmate panel charpick and tasklist buttons

### DIFF
--- a/desktop-themes/BlackMATE/gtk-3.0/mate-applications.css
+++ b/desktop-themes/BlackMATE/gtk-3.0/mate-applications.css
@@ -347,12 +347,11 @@ PanelSeparator {
     text-shadow: none;
 }
 */
-/* FIXME, this does not work anymore with >= gtk+-3.20 */
-/* dictionary applet */
-GdictApplet .entry,
-GdictApplet .entry:focus {
+
+.mate-panel-menu-bar #PanelApplet  entry,
+.mate-panel-menu-bar #PanelApplet  entry:focus {
     border-style: none;
-    padding: 1px 4px 5px 4px;
+    padding: 1px 4px 1px 4px;
     box-shadow: inset  0px  1px shade (@theme_selected_bg_color, 1.3),
                 inset  1px  0px shade (@theme_selected_bg_color, 1.3),
                 inset -1px  0px shade (@theme_selected_bg_color, 1.3),

--- a/desktop-themes/BlackMATE/gtk-3.0/mate-applications.css
+++ b/desktop-themes/BlackMATE/gtk-3.0/mate-applications.css
@@ -473,13 +473,13 @@ dictionary */
 }
 
 /*Wncklist */
-.mate-panel-menu-bar #tasklist-button {
+.mate-panel-menu-bar #PanelApplet button.flat.toggle {
     transition: all 400ms ease-out;
     padding: 2px;
     border-radius: 3px;
     border-width: 1px;
     border-style: solid;
-	border-color:transparent;
+	border-color: shade(@button_border, 1.1);
     text-shadow: none;
     color: @theme_fg_color;
 	background-image: none;
@@ -493,10 +493,8 @@ dictionary */
                       to (shade(@button_gradient_color_b, 0.7)));
 */
 }
-.mate-panel-menu-bar #tasklist-button:checked:hover,
-.mate-panel-menu-bar #tasklist-button:checked,
-.mate-panel-menu-bar #tasklist-button:active:hover,
-.mate-panel-menu-bar #tasklist-button:active {
+.mate-panel-menu-bar #PanelApplet button.flat.toggle:checked,
+.mate-panel-menu-bar #PanelApplet button.flat.toggle:active {
     border-radius: 3px;
     color: @theme_fg_color;
     border-style: solid;
@@ -506,8 +504,7 @@ dictionary */
                                       shade(@button_gradient_color_a, 1.5));
 }
 
-/* FIXME, this does not work anymore with >= gtk+-3.20 */
-.mate-panel-menu-bar button .button:hover {
+.mate-panel-menu-bar #PanelApplet button.flat.toggle:hover{
     border-radius: 3px;
     border-image: none;
     border-style: solid;
@@ -555,12 +552,20 @@ dictionary */
                                       shade(@theme_selected_bg_color, 0.5));
 }
 
-#clock-applet-button,
+.mate-panel-menu-bar #PanelApplet #clock-applet-button,
 .mate-panel-menu-bar.menubar,
 MatePanelApplet > menubar {
     font-style: normal;
     font-weight: normal;
 }
+
+/*Keep tasklist/charpick/etc borders off of clock applet*/
+.mate-panel-menu-bar #PanelApplet button#clock-applet-button.flat.toggle {
+    border-style: none;
+	border-image: none;
+	border-color: transparent;
+}
+
 
 #clock-applet-button{
 	padding: 4px; /*any less and outlines touch text or get cut off */


### PR DESCRIPTION
Based on discussion of changes in yaru themes for charpick buttons in mate-panel, note that the tasklist also needed this. Also a fix for the dictionary applet, finishing and removing a FIXME dating back to GTK 3.20.

Note that charpick button behavior matches that in menta (selected buttons stay selected)