### PR TITLE
submarine: Specify foreground color in headerbar.

### DIFF
--- a/desktop-themes/Blue-Submarine/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/Blue-Submarine/gtk-3.0/gtk-widgets.css
@@ -5966,6 +5966,7 @@ headerbar,
                                       @wm_bg_a,
                                       @wm_bg_b);
     box-shadow: inset 0 -1px shade(@wm_bg_b, 0.95);
+    color: @theme_fg_dark_color;
 }
 
 headerbar,

--- a/desktop-themes/Green-Submarine/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/Green-Submarine/gtk-3.0/gtk-widgets.css
@@ -5965,6 +5965,7 @@ headerbar,
                                       @wm_bg_a,
                                       @wm_bg_b);
     box-shadow: inset 0 -1px shade(@wm_bg_b, 0.95);
+    color: @theme_fg_dark_color;
 }
 
 headerbar,


### PR DESCRIPTION
This fixes Firefox / Thunderbird's inactive tab colors when using CSD, probably others too.