### PR TITLE
build: add --enable-gtk2 configure flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,6 +16,13 @@ PKG_PROG_PKG_CONFIG([0.19])
 AM_GNU_GETTEXT_VERSION([0.19.8])
 AM_CONDITIONAL([USE_NLS], [test "x${USE_NLS}" = "xyes"])
 
+AC_ARG_ENABLE([gtk2],
+    [AS_HELP_STRING([--enable-gtk2],
+        [Enable GTK2 themes (default: yes)])],
+    [enable_gtk2=$enableval],
+    [enable_gtk2=yes])
+AM_CONDITIONAL([ENABLE_GTK2], [test "x$enable_gtk2" != "xno"])
+
 # Workaround to make aclocal get the right flags
 AC_SUBST(ACLOCAL_AMFLAGS, "\${ACLOCAL_FLAGS}")
 
@@ -368,4 +375,5 @@ Configure summary:
 
     Installation prefix ........: ${prefix}
     Native Language support ....: ${USE_NLS}
+    GTK2 themes ................: ${enable_gtk2}
 "

--- a/desktop-themes/BlackMATE/Makefile.am
+++ b/desktop-themes/BlackMATE/Makefile.am
@@ -12,6 +12,15 @@ else
 endif
 
 SUBDIRS =		\
+	gtk-3.0		\
+	metacity-1	\
+	cinnamon	\
+	unity		\
+	apps
+if ENABLE_GTK2
+SUBDIRS += gtk-2.0
+endif
+DIST_SUBDIRS =		\
 	gtk-2.0		\
 	gtk-3.0		\
 	metacity-1	\

--- a/desktop-themes/Blue-Submarine/Makefile.am
+++ b/desktop-themes/Blue-Submarine/Makefile.am
@@ -14,6 +14,14 @@ endif
 SUBDIRS =		\
 	cinnamon	\
 	emerald		\
+	gtk-3.0		\
+	metacity-1
+if ENABLE_GTK2
+SUBDIRS += gtk-2.0
+endif
+DIST_SUBDIRS =		\
+	cinnamon	\
+	emerald		\
 	gtk-2.0		\
 	gtk-3.0		\
 	metacity-1

--- a/desktop-themes/BlueMenta-dark/Makefile.am
+++ b/desktop-themes/BlueMenta-dark/Makefile.am
@@ -14,6 +14,16 @@ endif
 SUBDIRS = \
 	cinnamon \
 	emerald \
+	gtk-3.0 \
+	metacity-1 \
+	unity \
+	xfwm4
+if ENABLE_GTK2
+SUBDIRS += gtk-2.0
+endif
+DIST_SUBDIRS = \
+	cinnamon \
+	emerald \
 	gtk-2.0 \
 	gtk-3.0 \
 	metacity-1 \

--- a/desktop-themes/BlueMenta/Makefile.am
+++ b/desktop-themes/BlueMenta/Makefile.am
@@ -14,6 +14,16 @@ endif
 SUBDIRS = \
 	cinnamon \
 	emerald \
+	gtk-3.0 \
+	metacity-1 \
+	unity \
+	xfwm4
+if ENABLE_GTK2
+SUBDIRS += gtk-2.0
+endif
+DIST_SUBDIRS = \
+	cinnamon \
+	emerald \
 	gtk-2.0 \
 	gtk-3.0 \
 	metacity-1 \

--- a/desktop-themes/Green-Submarine/Makefile.am
+++ b/desktop-themes/Green-Submarine/Makefile.am
@@ -14,6 +14,14 @@ endif
 SUBDIRS =		\
 	cinnamon	\
 	emerald		\
+	gtk-3.0		\
+	metacity-1
+if ENABLE_GTK2
+SUBDIRS += gtk-2.0
+endif
+DIST_SUBDIRS =		\
+	cinnamon	\
+	emerald		\
 	gtk-2.0		\
 	gtk-3.0		\
 	metacity-1

--- a/desktop-themes/GreenLaguna/Makefile.am
+++ b/desktop-themes/GreenLaguna/Makefile.am
@@ -12,6 +12,13 @@ else
 endif
 
 SUBDIRS =		\
+	gtk-3.0		\
+	metacity-1	\
+	unity
+if ENABLE_GTK2
+SUBDIRS += gtk-2.0
+endif
+DIST_SUBDIRS =		\
 	gtk-2.0		\
 	gtk-3.0		\
 	metacity-1	\

--- a/desktop-themes/HighContrastInverse/Makefile.am
+++ b/desktop-themes/HighContrastInverse/Makefile.am
@@ -12,7 +12,13 @@ else
 endif
 
 SUBDIRS =      \
-	gtk-2.0	   \
+	metacity-1 \
+	pixmaps
+if ENABLE_GTK2
+SUBDIRS += gtk-2.0
+endif
+DIST_SUBDIRS = \
+	gtk-2.0    \
 	metacity-1 \
 	pixmaps
 

--- a/desktop-themes/Menta/Makefile.am
+++ b/desktop-themes/Menta/Makefile.am
@@ -14,6 +14,16 @@ endif
 SUBDIRS = \
 	cinnamon \
 	emerald \
+	gtk-3.0	\
+	metacity-1 \
+	unity \
+	xfwm4
+if ENABLE_GTK2
+SUBDIRS += gtk-2.0
+endif
+DIST_SUBDIRS = \
+	cinnamon \
+	emerald \
 	gtk-2.0	\
 	gtk-3.0	\
 	metacity-1 \

--- a/desktop-themes/TraditionalGreen/Makefile.am
+++ b/desktop-themes/TraditionalGreen/Makefile.am
@@ -12,6 +12,12 @@ else
 endif
 
 SUBDIRS =		\
+	gtk-3.0		\
+	metacity-1
+if ENABLE_GTK2
+SUBDIRS += gtk-2.0
+endif
+DIST_SUBDIRS =		\
 	gtk-2.0		\
 	gtk-3.0		\
 	metacity-1

--- a/desktop-themes/TraditionalOk/Makefile.am
+++ b/desktop-themes/TraditionalOk/Makefile.am
@@ -12,6 +12,14 @@ else
 endif
 
 SUBDIRS =		\
+	gtk-3.0		\
+	metacity-1	\
+	openbox-3	\
+	xfwm4
+if ENABLE_GTK2
+SUBDIRS += gtk-2.0
+endif
+DIST_SUBDIRS =		\
 	gtk-2.0		\
 	gtk-3.0		\
 	metacity-1	\

--- a/desktop-themes/YaruGreen/Makefile.am
+++ b/desktop-themes/YaruGreen/Makefile.am
@@ -12,6 +12,12 @@ else
 endif
 
 SUBDIRS =		\
+	gtk-3.0		\
+	metacity-1
+if ENABLE_GTK2
+SUBDIRS += gtk-2.0
+endif
+DIST_SUBDIRS =		\
 	gtk-2.0		\
 	gtk-3.0		\
 	metacity-1

--- a/desktop-themes/YaruOk/Makefile.am
+++ b/desktop-themes/YaruOk/Makefile.am
@@ -12,6 +12,14 @@ else
 endif
 
 SUBDIRS =		\
+	gtk-3.0		\
+	metacity-1	\
+	openbox-3	\
+	xfwm4
+if ENABLE_GTK2
+SUBDIRS += gtk-2.0
+endif
+DIST_SUBDIRS =		\
 	gtk-2.0		\
 	gtk-3.0		\
 	metacity-1	\


### PR DESCRIPTION
Add a configure flag to optionally skip installation of GTK2 theme files. Enabled by default for backward compatibility. Distros that have dropped GTK2 can pass --disable-gtk2 to avoid installing unused theme files.

Fixes #332