### PR TITLE
Traditional themes: fix invisible text in error/warning entry fields

### DIFF
--- a/desktop-themes/TraditionalGreen/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/TraditionalGreen/gtk-3.0/gtk-widgets.css
@@ -3831,6 +3831,17 @@ entry.error:focus,
     border-width: 1px;
 }
 
+entry.info,
+entry.info:focus,
+entry.warning,
+entry.warning:focus,
+entry.question,
+entry.question:focus,
+entry.error,
+entry.error:focus {
+    background-image: none;
+}
+
 infobar,
 .info,
 .warning,

--- a/desktop-themes/TraditionalOk/gtk-3.0/gtk-widgets.css
+++ b/desktop-themes/TraditionalOk/gtk-3.0/gtk-widgets.css
@@ -3833,6 +3833,17 @@ entry.error:focus,
     border-width: 1px;
 }
 
+entry.info,
+entry.info:focus,
+entry.warning,
+entry.warning:focus,
+entry.question,
+entry.question:focus,
+entry.error,
+entry.error:focus {
+    background-image: none;
+}
+
 infobar,
 .info,
 .warning,


### PR DESCRIPTION
The entry widget uses a background-image gradient for an inner border effect, which renders on top of background-color. When GTK applies the .error class (e.g., search text not found), the text color changes to white but the light gradient remains, making text invisible. This clears the background-image for entry widgets in info/warning/question/error states so the state background color shows through.

Fixes #331

<img width="1734" height="1260" alt="Screenshot at 2026-05-15 09-04-24" src="https://github.com/user-attachments/assets/dfac4b59-1b0d-47c9-b697-9c4aa035850e" />
